### PR TITLE
fix: introduce a basic per-endpoint per-model parameter translation mechanism

### DIFF
--- a/backend/endpoint_profiles.py
+++ b/backend/endpoint_profiles.py
@@ -1,0 +1,53 @@
+"""Endpoint-URL-matched param allowlists.
+
+Some OpenAI-compatible backends reject unknown body fields with HTTP 400
+(notably DeepSeek). Orb normally forwards user-configured sampling params
+like `min_p`, `top_k`, `repetition_penalty` which these backends don't
+understand. When an endpoint URL matches a known profile below, the
+LLMClient drops any body key not in `ALWAYS_ALLOWED | PROFILES[match]`.
+
+Unknown endpoints (e.g. local llama.cpp, vLLM) get no profile and pass
+through unchanged.
+"""
+
+from __future__ import annotations
+
+# Body keys always sent; never subject to allowlist filtering.
+ALWAYS_ALLOWED: frozenset[str] = frozenset(
+    {"model", "messages", "stream", "tools", "tool_choice"}
+)
+
+# URL-substring → set of extra body keys permitted (beyond ALWAYS_ALLOWED).
+PROFILES: dict[str, frozenset[str]] = {
+    # https://api-docs.deepseek.com/api/create-chat-completion
+    "api.deepseek.com": frozenset(
+        {
+            "temperature",
+            "top_p",
+            "max_tokens",
+            "presence_penalty",
+            "frequency_penalty",
+            "stop",
+            "response_format",
+            "logprobs",
+            "top_logprobs",
+            "stream_options",
+            "thinking",
+        }
+    ),
+}
+
+
+def allowlist_for(endpoint_url: str) -> frozenset[str] | None:
+    """Return the extra-keys allowlist for a matching profile, or None.
+
+    None means "no profile matched → allow all params through" (current
+    behavior for local/unknown backends).
+    """
+    if not endpoint_url:
+        return None
+    haystack = endpoint_url.lower()
+    for needle, allowed in PROFILES.items():
+        if needle in haystack:
+            return allowed
+    return None

--- a/backend/endpoint_profiles.py
+++ b/backend/endpoint_profiles.py
@@ -1,53 +1,141 @@
-"""Endpoint-URL-matched param allowlists.
+"""Endpoint/model-matched request translation profiles.
 
-Some OpenAI-compatible backends reject unknown body fields with HTTP 400
-(notably DeepSeek). Orb normally forwards user-configured sampling params
-like `min_p`, `top_k`, `repetition_penalty` which these backends don't
-understand. When an endpoint URL matches a known profile below, the
-LLMClient drops any body key not in `ALWAYS_ALLOWED | PROFILES[match]`.
+Some OpenAI-compatible backends reject unknown body fields or demand
+specific value shapes that don't match Orb's defaults. This module defines
+per-(endpoint_url, model) policies that mutate the request body before it
+leaves LLMClient.complete().
 
-Unknown endpoints (e.g. local llama.cpp, vLLM) get no profile and pass
-through unchanged.
+Two-level lookup:
+- Known endpoint + known model -> model-specific profile (replaces default).
+- Known endpoint + unknown/blank model -> endpoint default (None key).
+- Unknown endpoint -> None = pass-through (for local llama.cpp, vLLM, etc.).
+
+Adding a new quirk (extensibility gradient):
+  1. Flip an existing typed knob (allow_extra, allow_forced_tool_choice).
+  2. Attach a `custom=` callable to a profile for one-off logic.
+  3. Promote a recurring `custom=` pattern to a named dataclass field.
+  4. Subclass ModelProfile and override apply() for radically different APIs.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional
 
 # Body keys always sent; never subject to allowlist filtering.
 ALWAYS_ALLOWED: frozenset[str] = frozenset(
     {"model", "messages", "stream", "tools", "tool_choice"}
 )
 
-# URL-substring → set of extra body keys permitted (beyond ALWAYS_ALLOWED).
-PROFILES: dict[str, frozenset[str]] = {
-    # https://api-docs.deepseek.com/api/create-chat-completion
-    "api.deepseek.com": frozenset(
-        {
-            "temperature",
-            "top_p",
-            "max_tokens",
-            "presence_penalty",
-            "frequency_penalty",
-            "stop",
-            "response_format",
-            "logprobs",
-            "top_logprobs",
-            "stream_options",
-            "thinking",
-        }
-    ),
+# Mutates body in place. Returns a log line to surface the action, or None.
+Transform = Callable[[dict], Optional[str]]
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    """Per-(endpoint, model) request translation policy.
+
+    Typed knobs cover the common cases; `custom` is the escape hatch for
+    bespoke transforms that don't yet warrant a named field.
+    """
+
+    # Extra body keys allowed past ALWAYS_ALLOWED. Anything else is dropped.
+    allow_extra: frozenset[str]
+
+    # If False, coerce forced-function tool_choice dicts and "required" to
+    # "auto". True means the caller's value passes through unchanged.
+    allow_forced_tool_choice: bool = True
+
+    # Bespoke transforms applied after typed knobs, in order. Each callable
+    # mutates body in place and may return a log line (or None for silent).
+    custom: tuple[Transform, ...] = field(default_factory=tuple)
+
+    def apply(self, body: dict) -> list[str]:
+        """Mutate body in place. Return human-readable actions for logging."""
+        actions: list[str] = []
+
+        allowed = ALWAYS_ALLOWED | self.allow_extra
+        dropped = [k for k in body if k not in allowed]
+        for k in dropped:
+            body.pop(k)
+        if dropped:
+            actions.append(f"dropped={dropped}")
+
+        if not self.allow_forced_tool_choice:
+            tc = body.get("tool_choice")
+            if isinstance(tc, dict) or tc == "required":
+                body["tool_choice"] = "auto"
+                actions.append(f"tool_choice {tc!r} -> 'auto'")
+
+        for fn in self.custom:
+            log = fn(body)
+            if log:
+                actions.append(log)
+
+        return actions
+
+
+# https://api-docs.deepseek.com/api/create-chat-completion
+_DEEPSEEK_DEFAULT_EXTRA: frozenset[str] = frozenset(
+    {
+        "temperature",
+        "top_p",
+        "max_tokens",
+        "presence_penalty",
+        "frequency_penalty",
+        "stop",
+        "response_format",
+        "logprobs",
+        "top_logprobs",
+        "stream_options",
+        "thinking",
+    }
+)
+
+# deepseek-reasoner rejects logprobs/top_logprobs with HTTP 400. Other
+# "unsupported" params (temperature/top_p/presence_penalty/frequency_penalty)
+# are silently ignored per DeepSeek docs, so keeping them in is harmless.
+_DEEPSEEK_REASONER_EXTRA: frozenset[str] = _DEEPSEEK_DEFAULT_EXTRA - {
+    "logprobs",
+    "top_logprobs",
 }
 
 
-def allowlist_for(endpoint_url: str) -> frozenset[str] | None:
-    """Return the extra-keys allowlist for a matching profile, or None.
+# Outer key: URL-substring (case-insensitive match; first insertion wins, so
+# order matters if adding more specific URL prefixes like "api.deepseek.com/beta"
+# -- the more specific one must come first).
+# Inner None key: endpoint default profile. Inner str keys: exact-match
+# per-model overrides (replace, not merge).
+PROFILES: dict[str, dict[Optional[str], ModelProfile]] = {
+    "api.deepseek.com": {
+        None: ModelProfile(
+            allow_extra=_DEEPSEEK_DEFAULT_EXTRA,
+            allow_forced_tool_choice=True,
+        ),
+        # deepseek-reasoner rejects forced-function tool_choice and "required".
+        # Coerce to "auto" and let graceful skip paths in Director/Editor handle
+        # any skipped tool calls.
+        "deepseek-reasoner": ModelProfile(
+            allow_extra=_DEEPSEEK_REASONER_EXTRA,
+            allow_forced_tool_choice=False,
+        ),
+    },
+}
 
-    None means "no profile matched → allow all params through" (current
-    behavior for local/unknown backends).
+
+def profile_for(endpoint_url: str, model: str = "") -> Optional[ModelProfile]:
+    """Resolve (endpoint_url, model) to a ModelProfile, or None for pass-through.
+
+    A blank `model` falls through to the endpoint default. An unmatched URL
+    returns None -- LLMClient then sends the body unchanged (current behavior
+    for local / unknown backends).
     """
     if not endpoint_url:
         return None
     haystack = endpoint_url.lower()
-    for needle, allowed in PROFILES.items():
+    for needle, models in PROFILES.items():
         if needle in haystack:
-            return allowed
+            if model and model in models:
+                return models[model]
+            return models.get(None)
     return None

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -5,7 +5,7 @@ import json
 import logging
 from typing import AsyncIterator
 
-from .endpoint_profiles import ALWAYS_ALLOWED
+from .endpoint_profiles import ModelProfile
 
 logger = logging.getLogger(__name__)
 
@@ -36,12 +36,12 @@ class LLMClient:
         base_url: str,
         api_key: str = "",
         timeout: float = 120.0,
-        param_allowlist: frozenset[str] | set[str] | None = None,
+        profile: ModelProfile | None = None,
     ):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.timeout = timeout
-        self.param_allowlist = param_allowlist
+        self.profile = profile
         self._abort: asyncio.Event = asyncio.Event()
 
     def abort(self) -> None:
@@ -82,13 +82,9 @@ class LLMClient:
         if tool_choice:
             body["tool_choice"] = tool_choice
 
-        if self.param_allowlist is not None:
-            allowed = ALWAYS_ALLOWED | self.param_allowlist
-            dropped = [k for k in body if k not in allowed]
-            for k in dropped:
-                body.pop(k)
-            if dropped:
-                logger.info("LLM param allowlist dropped: %s", dropped)
+        if self.profile is not None:
+            for action in self.profile.apply(body):
+                logger.info("LLM profile: %s", action)
 
         logger.info(
             "LLM complete: model=%s, tools=%s, tool_choice=%s",

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -5,6 +5,8 @@ import json
 import logging
 from typing import AsyncIterator
 
+from .endpoint_profiles import ALWAYS_ALLOWED
+
 logger = logging.getLogger(__name__)
 
 
@@ -29,10 +31,17 @@ def reasoning_cfg(on: bool) -> dict:
 
 
 class LLMClient:
-    def __init__(self, base_url: str, api_key: str = "", timeout: float = 120.0):
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str = "",
+        timeout: float = 120.0,
+        param_allowlist: frozenset[str] | set[str] | None = None,
+    ):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.timeout = timeout
+        self.param_allowlist = param_allowlist
         self._abort: asyncio.Event = asyncio.Event()
 
     def abort(self) -> None:
@@ -73,6 +82,14 @@ class LLMClient:
         if tool_choice:
             body["tool_choice"] = tool_choice
 
+        if self.param_allowlist is not None:
+            allowed = ALWAYS_ALLOWED | self.param_allowlist
+            dropped = [k for k in body if k not in allowed]
+            for k in dropped:
+                body.pop(k)
+            if dropped:
+                logger.info("LLM param allowlist dropped: %s", dropped)
+
         logger.info(
             "LLM complete: model=%s, tools=%s, tool_choice=%s",
             model,
@@ -90,7 +107,22 @@ class LLMClient:
             async with client.stream(
                 "POST", self._url(), json=body, headers=self._headers()
             ) as resp:
-                resp.raise_for_status()
+                if resp.status_code >= 400:
+                    # Streaming response: body isn't eagerly read, so
+                    # raise_for_status() would surface only the status line.
+                    # Read the body so upstream error detail lands in logs.
+                    try:
+                        err_bytes = await resp.aread()
+                        err_text = err_bytes.decode("utf-8", errors="replace")
+                    except Exception as read_err:
+                        err_text = f"<failed to read response body: {read_err!r}>"
+                    logger.error(
+                        "LLM HTTP %d from %s: %s",
+                        resp.status_code,
+                        self._url(),
+                        err_text,
+                    )
+                    resp.raise_for_status()
                 # Race each line read against the abort signal so that client.abort()
                 # breaks out of this loop immediately, letting the async-with block
                 # exit *normally* and cleanly close the TCP connection to the LLM

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -11,7 +11,7 @@ from typing import AsyncIterator, List, Optional
 
 from . import database as db
 from .llm_client import LLMClient
-from .endpoint_profiles import allowlist_for
+from .endpoint_profiles import profile_for
 from .tool_defs import TOOLS, POST_WRITER_TOOLS
 from .prompt_builder import build_prefix, compute_style_injection_block
 from .kv_tracker import _KVCacheTracker
@@ -280,7 +280,10 @@ async def _load_pipeline_context(conversation_id: str) -> dict | None:
     client = LLMClient(
         settings["endpoint_url"],
         api_key=settings.get("api_key", ""),
-        param_allowlist=allowlist_for(settings["endpoint_url"]),
+        profile=profile_for(
+            settings["endpoint_url"],
+            settings.get("model_name", ""),
+        ),
     )
 
     system_prompt, char_persona, mes_example = await db.resolve_char_context(

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -11,6 +11,7 @@ from typing import AsyncIterator, List, Optional
 
 from . import database as db
 from .llm_client import LLMClient
+from .endpoint_profiles import allowlist_for
 from .tool_defs import TOOLS, POST_WRITER_TOOLS
 from .prompt_builder import build_prefix, compute_style_injection_block
 from .kv_tracker import _KVCacheTracker
@@ -276,7 +277,11 @@ async def _load_pipeline_context(conversation_id: str) -> dict | None:
     director_fragments = await db.get_director_fragments()
     director_fragments = [df for df in director_fragments if df.get("enabled", True)]
     phrase_bank = await db.get_phrase_bank()
-    client = LLMClient(settings["endpoint_url"], api_key=settings.get("api_key", ""))
+    client = LLMClient(
+        settings["endpoint_url"],
+        api_key=settings.get("api_key", ""),
+        param_allowlist=allowlist_for(settings["endpoint_url"]),
+    )
 
     system_prompt, char_persona, mes_example = await db.resolve_char_context(
         conv, settings


### PR DESCRIPTION
This PR fixes a bug where the writer pass fails with HTTP 400 against DeepSeek (https://github.com/OrbFrontend/Orb/issues/6), because Orb forwards sampling params (`min_p`, `top_k`, `repetition_penalty`) and reasoning hints that DeepSeek's API does not accept. A new `backend/endpoint_profiles.py` holds a per-endpoint allowlist of body fields, and `LLMClient` drops anything not on the list before POST. Unknown endpoints are unaffected. HTTP error response bodies are now logged, so future 400s show the upstream reason instead of just the status code.

This is reported by the original issue creator to fix the bug.