### PR TITLE
feat: editor diff and hide streaming

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -222,6 +222,7 @@ DEFAULT_SETTINGS = {
     "character_library_view": "grid",
     "character_library_sort": "time-added",
     "show_editor_diff": 1,
+    "hide_streaming_until_baked": 0,
 }
 
 SEED_PHRASE_BANK = [
@@ -344,7 +345,8 @@ async def init_db():
                 active_persona_id INTEGER REFERENCES user_personas(id) ON DELETE SET NULL,
                 character_library_view TEXT NOT NULL DEFAULT 'grid',
                 character_library_sort TEXT NOT NULL DEFAULT 'time-added',
-                show_editor_diff INTEGER NOT NULL DEFAULT 1
+                show_editor_diff INTEGER NOT NULL DEFAULT 1,
+                hide_streaming_until_baked INTEGER NOT NULL DEFAULT 0
             );
 
             CREATE TABLE IF NOT EXISTS mood_fragments (
@@ -522,6 +524,10 @@ async def init_db():
         if "show_editor_diff" not in existing_cols:
             await db.execute(
                 "ALTER TABLE settings ADD COLUMN show_editor_diff INTEGER NOT NULL DEFAULT 1"
+            )
+        if "hide_streaming_until_baked" not in existing_cols:
+            await db.execute(
+                "ALTER TABLE settings ADD COLUMN hide_streaming_until_baked INTEGER NOT NULL DEFAULT 0"
             )
         endpoint_cols = {
             row[1] for row in await db.execute_fetchall("PRAGMA table_info(endpoints)")
@@ -747,6 +753,7 @@ async def update_settings(data: dict) -> dict:
             "character_library_sort",
             "active_endpoint_id",
             "show_editor_diff",
+            "hide_streaming_until_baked",
         ]
         json_fields = {"enabled_tools", "reasoning_enabled_passes"}
         sets = []

--- a/backend/database.py
+++ b/backend/database.py
@@ -221,6 +221,7 @@ DEFAULT_SETTINGS = {
     "length_guard_max_paragraphs": 4,
     "character_library_view": "grid",
     "character_library_sort": "time-added",
+    "show_editor_diff": 1,
 }
 
 SEED_PHRASE_BANK = [
@@ -342,7 +343,8 @@ async def init_db():
                 reasoning_enabled_passes TEXT NOT NULL DEFAULT '{"director":true,"writer":false,"editor":false}',
                 active_persona_id INTEGER REFERENCES user_personas(id) ON DELETE SET NULL,
                 character_library_view TEXT NOT NULL DEFAULT 'grid',
-                character_library_sort TEXT NOT NULL DEFAULT 'time-added'
+                character_library_sort TEXT NOT NULL DEFAULT 'time-added',
+                show_editor_diff INTEGER NOT NULL DEFAULT 1
             );
 
             CREATE TABLE IF NOT EXISTS mood_fragments (
@@ -516,6 +518,10 @@ async def init_db():
         if "shared_system_prompt" not in existing_cols:
             await db.execute(
                 "ALTER TABLE settings ADD COLUMN shared_system_prompt TEXT NOT NULL DEFAULT ''"
+            )
+        if "show_editor_diff" not in existing_cols:
+            await db.execute(
+                "ALTER TABLE settings ADD COLUMN show_editor_diff INTEGER NOT NULL DEFAULT 1"
             )
         endpoint_cols = {
             row[1] for row in await db.execute_fetchall("PRAGMA table_info(endpoints)")
@@ -740,6 +746,7 @@ async def update_settings(data: dict) -> dict:
             "character_library_view",
             "character_library_sort",
             "active_endpoint_id",
+            "show_editor_diff",
         ]
         json_fields = {"enabled_tools", "reasoning_enabled_passes"}
         sets = []

--- a/backend/main.py
+++ b/backend/main.py
@@ -134,6 +134,7 @@ class SettingsUpdate(BaseModel):
     character_library_view: Optional[str] = None
     character_library_sort: Optional[str] = None
     active_endpoint_id: Optional[int] = None
+    show_editor_diff: Optional[bool] = None
 
 
 class EndpointCreate(BaseModel):

--- a/backend/main.py
+++ b/backend/main.py
@@ -135,6 +135,7 @@ class SettingsUpdate(BaseModel):
     character_library_sort: Optional[str] = None
     active_endpoint_id: Optional[int] = None
     show_editor_diff: Optional[bool] = None
+    hide_streaming_until_baked: Optional[bool] = None
 
 
 class EndpointCreate(BaseModel):

--- a/backend/migrations/0011_add_show_editor_diff.py
+++ b/backend/migrations/0011_add_show_editor_diff.py
@@ -1,0 +1,18 @@
+"""
+0011_add_show_editor_diff -- add show_editor_diff column to settings for
+databases created before this toggle existed. Default 1 preserves prior
+behavior (editor diff highlights visible).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(settings)").fetchall()}
+    if "show_editor_diff" not in cols:
+        conn.execute(
+            "ALTER TABLE settings ADD COLUMN show_editor_diff INTEGER NOT NULL DEFAULT 1"
+        )
+        print("[migrations] 0011: added show_editor_diff column to settings")

--- a/backend/migrations/0012_hide_streaming_until_baked.py
+++ b/backend/migrations/0012_hide_streaming_until_baked.py
@@ -1,0 +1,18 @@
+"""
+0012_hide_streaming_until_baked -- add hide_streaming_until_baked column to
+settings for databases created before this toggle existed. Default 0
+preserves prior behavior (streaming message visible live).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(settings)").fetchall()}
+    if "hide_streaming_until_baked" not in cols:
+        conn.execute(
+            "ALTER TABLE settings ADD COLUMN hide_streaming_until_baked INTEGER NOT NULL DEFAULT 0"
+        )
+        print("[migrations] 0012: added hide_streaming_until_baked column to settings")

--- a/backend/migrations/__init__.py
+++ b/backend/migrations/__init__.py
@@ -27,6 +27,7 @@ MIGRATIONS: list[str] = [
     "0008_multi_endpoints",
     "0009_shared_system_prompt",
     "0010_active_model_config_on_endpoints",
+    "0011_add_show_editor_diff",
 ]
 
 

--- a/backend/migrations/__init__.py
+++ b/backend/migrations/__init__.py
@@ -28,6 +28,7 @@ MIGRATIONS: list[str] = [
     "0009_shared_system_prompt",
     "0010_active_model_config_on_endpoints",
     "0011_add_show_editor_diff",
+    "0012_hide_streaming_until_baked",
 ]
 
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -16,6 +16,7 @@ import {
   toggleLengthGuard,
   saveLengthGuardConfig,
   toggleLengthGuardEnforce,
+  toggleShowEditorDiff,
   showPhraseBankModal,
   showAddPhraseGroupModal,
   showPersonaEditModal,
@@ -235,6 +236,7 @@ Object.assign(window, {
   toggleLengthGuard,
   saveLengthGuardConfig,
   toggleLengthGuardEnforce,
+  toggleShowEditorDiff,
   // phrase bank
   showPhraseBankModal,
   showAddPhraseGroupModal,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -17,6 +17,7 @@ import {
   saveLengthGuardConfig,
   toggleLengthGuardEnforce,
   toggleShowEditorDiff,
+  toggleHideUntilBaked,
   showPhraseBankModal,
   showAddPhraseGroupModal,
   showPersonaEditModal,
@@ -237,6 +238,7 @@ Object.assign(window, {
   saveLengthGuardConfig,
   toggleLengthGuardEnforce,
   toggleShowEditorDiff,
+  toggleHideUntilBaked,
   // phrase bank
   showPhraseBankModal,
   showAddPhraseGroupModal,

--- a/frontend/chat.js
+++ b/frontend/chat.js
@@ -119,15 +119,16 @@ function finalizeStreamingDiv(lastMsg) {
   div.setAttribute("data-msg-id", lastMsg.id);
   body.removeAttribute("id");
 
-  const bodyHtml = S.pendingRefineDiff
-    ? formatProseWithDiff(S.pendingRefineDiff.ops)
-    : formatProse(resolvePlaceholders(lastMsg.content));
+  const bodyHtml =
+    S.pendingRefineDiff && S.showEditorDiff
+      ? formatProseWithDiff(S.pendingRefineDiff.ops)
+      : formatProse(resolvePlaceholders(lastMsg.content));
   smoothUpdateBody(body, bodyHtml, () => scrollToBottom(true));
 
   const tb = div.querySelector(".msg-toolbar");
   if (tb) {
     const diffBtn =
-      S.pendingRefineDiff?.msgId && lastMsg.id === S.pendingRefineDiff.msgId
+      S.pendingRefineDiff?.msgId && lastMsg.id === S.pendingRefineDiff.msgId && S.showEditorDiff
         ? `<button onclick="clearRefineDiff()" title="Clear diff highlights" class="btn-clear-diff">✕ Diff</button>`
         : "";
     const editBtn = S.hasMultipleTabs
@@ -487,7 +488,7 @@ export function renderMessages() {
           ? `<button onclick="deleteMessage(${m.id})" title="Delete message, siblings, and all children" class="msg-btn-del">${ICON_DEL}</button>`
           : `<button disabled class="msg-btn-del">${ICON_DEL}</button>`;
         const diffBtn =
-          S.pendingRefineDiff?.msgId && m.id === S.pendingRefineDiff.msgId
+          S.pendingRefineDiff?.msgId && m.id === S.pendingRefineDiff.msgId && S.showEditorDiff
             ? `<button onclick="clearRefineDiff()" title="Clear diff highlights" class="btn-clear-diff">${ICON_CLEAR}</button>`
             : "";
         const toolbar = isEditing
@@ -506,7 +507,7 @@ export function renderMessages() {
           </div>
         </div>`
           : `<div class="msg-body">${
-              S.pendingRefineDiff?.msgId && m.id === S.pendingRefineDiff.msgId
+              S.pendingRefineDiff?.msgId && m.id === S.pendingRefineDiff.msgId && S.showEditorDiff
                 ? formatProseWithDiff(S.pendingRefineDiff.ops)
                 : formatProse(resolvePlaceholders(m.content))
             }</div>`;
@@ -833,7 +834,10 @@ async function processSSEStream(resp, container, msgDiv, signal) {
             rewrittenResponse = text;
             S.streamingContent = text;
             if (S.streamingBodyEl) {
-              const html = S.pendingRefineDiff ? formatProseWithDiff(S.pendingRefineDiff.ops) : formatProse(text);
+              const html =
+                S.pendingRefineDiff && S.showEditorDiff
+                  ? formatProseWithDiff(S.pendingRefineDiff.ops)
+                  : formatProse(text);
               smoothUpdateBody(S.streamingBodyEl, html, scrollToBottom);
             } else {
               scrollToBottom();

--- a/frontend/chat.js
+++ b/frontend/chat.js
@@ -522,7 +522,7 @@ export function renderMessages() {
   if (badgeEl) ct.appendChild(badgeEl);
   // Don't show streaming box when editing a message (looks ugly)
   // Also hide for a short time after cancelling edit during streaming
-  if (streamingEl && !S.editingMsgId && !S.hideStreamingBox) ct.appendChild(streamingEl);
+  if (streamingEl && !S.editingMsgId && !S.hideStreamingBox && !S.hideUntilBaked) ct.appendChild(streamingEl);
   // Restore scroll position synchronously so the browser never paints a jump.
   // Near-bottom → snap to bottom; otherwise preserve distance from bottom.
   if (distFromBottom <= 50) {
@@ -822,7 +822,7 @@ async function processSSEStream(resp, container, msgDiv, signal) {
           () => {
             if (firstToken) {
               firstToken = false;
-              if (!msgDiv.isConnected) container.appendChild(msgDiv);
+              if (!msgDiv.isConnected && !S.hideUntilBaked) container.appendChild(msgDiv);
               if (S.streamingBodyEl) S.streamingBodyEl.innerHTML = "";
             }
             fullResponse += data.replace(/\\n/g, "\n");
@@ -966,7 +966,7 @@ export async function continueFromUser() {
   renderMessages();
   const ct = $("chat-messages");
   const msgDiv = createStreamingDiv();
-  ct.appendChild(msgDiv);
+  if (!S.hideUntilBaked) ct.appendChild(msgDiv);
   scrollToBottom();
   S.abortController = new AbortController();
   try {
@@ -1068,7 +1068,7 @@ export async function regenerate(msgId) {
 
   const ct = $("chat-messages");
   const msgDiv = createStreamingDiv();
-  ct.appendChild(msgDiv);
+  if (!S.hideUntilBaked) ct.appendChild(msgDiv);
   scrollToBottom();
   S.abortController = new AbortController();
   try {

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -155,6 +155,12 @@ export function renderSettings() {
   }).join("");
   $("settings-form").innerHTML += `
     <div class="field" style="margin-top:16px;padding-top:16px;border-top:1px solid var(--accent-dim)">
+      <label class="lg-enforce-label" title="Hide the assistant's reply while the pipeline (director -> writer -> editor) runs. The phase indicator stays visible.">
+        <input type="checkbox" ${S.hideUntilBaked ? "checked" : ""} onchange="toggleHideUntilBaked(this.checked)">
+        Hide streaming message until baked
+      </label>
+    </div>
+    <div class="field" style="margin-top:16px;padding-top:16px;border-top:1px solid var(--accent-dim)">
       <button class="btn btn-danger" onclick="showResetConfirmModal()" style="width:100%;justify-content:center">Reset to Defaults</button>
     </div>
   `;
@@ -808,7 +814,7 @@ export async function toggleShowEditorDiff(on) {
 export async function toggleHideUntilBaked(on) {
   S.hideUntilBaked = on;
   renderMessages();
-  renderToolsPanel();
+  renderSettings();
   try {
     S.settings = await api.put("/settings", { hide_streaming_until_baked: on });
   } catch (e) {
@@ -844,6 +850,15 @@ export function renderToolsPanel() {
   $("tools-panel-btn").style.opacity = S.agentEnabled ? "1" : "0.5";
   const toolCards = TOOL_DEFS.map((t) => {
     const on = !!S.enabledTools[t.id];
+    const extras =
+      t.id === "editor_apply_patch" && on
+        ? `<div class="lg-config">
+             <label class="lg-enforce-label" title="Highlight edited sentences with green/red strikethrough when the editor pass rewrites the writer's output.">
+               <input type="checkbox" ${S.showEditorDiff ? "checked" : ""} onchange="toggleShowEditorDiff(this.checked)">
+               Show diff highlights
+             </label>
+           </div>`
+        : "";
     return `<div class="tool-card ${on ? "tool-on" : ""}">
       <div class="tool-card-header">
         <span class="tool-card-name">${t.name}</span>
@@ -853,6 +868,7 @@ export function renderToolsPanel() {
         </label>
       </div>
       <div class="tool-card-desc">${t.desc}</div>
+      ${extras}
     </div>`;
   }).join("");
 
@@ -890,21 +906,7 @@ export function renderToolsPanel() {
     ${lgConfig}
   </div>`;
 
-  const showEditorDiffCard = `<div class="tool-card">
-    <label class="lg-enforce-label" title="Highlight edited sentences with green/red strikethrough when the editor pass rewrites the writer's output.">
-      <input type="checkbox" ${S.showEditorDiff ? "checked" : ""} onchange="toggleShowEditorDiff(this.checked)">
-      Show editor diff highlights
-    </label>
-  </div>`;
-
-  const hideUntilBakedCard = `<div class="tool-card">
-    <label class="lg-enforce-label" title="Hide the assistant's reply while the pipeline (director -> writer -> editor) runs. The phase indicator stays visible.">
-      <input type="checkbox" ${S.hideUntilBaked ? "checked" : ""} onchange="toggleHideUntilBaked(this.checked)">
-      Hide streaming message until baked
-    </label>
-  </div>`;
-
-  $("tools-list").innerHTML = toolCards + lengthGuardCard + showEditorDiffCard + hideUntilBakedCard;
+  $("tools-list").innerHTML = toolCards + lengthGuardCard;
 }
 
 // ── Phrase Bank

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -83,6 +83,11 @@ export async function loadSettings() {
   if (typeof S.settings.show_editor_diff === "number") S.showEditorDiff = S.settings.show_editor_diff !== 0;
   else if (typeof S.settings.show_editor_diff === "boolean") S.showEditorDiff = S.settings.show_editor_diff;
 
+  if (typeof S.settings.hide_streaming_until_baked === "number")
+    S.hideUntilBaked = S.settings.hide_streaming_until_baked !== 0;
+  else if (typeof S.settings.hide_streaming_until_baked === "boolean")
+    S.hideUntilBaked = S.settings.hide_streaming_until_baked;
+
   // Expand Settings section if endpoint_url is empty
   const settingsSection = $("settings-section");
   if (settingsSection && (!S.settings.endpoint_url || S.settings.endpoint_url.trim() === "")) {
@@ -800,6 +805,17 @@ export async function toggleShowEditorDiff(on) {
   }
 }
 
+export async function toggleHideUntilBaked(on) {
+  S.hideUntilBaked = on;
+  renderMessages();
+  renderToolsPanel();
+  try {
+    S.settings = await api.put("/settings", { hide_streaming_until_baked: on });
+  } catch (e) {
+    toast("Failed to save hide-until-baked setting", true);
+  }
+}
+
 export async function saveLengthGuardConfig() {
   const words = parseInt($("lg-max-words").value, 10);
   const paras = parseInt($("lg-max-paragraphs").value, 10);
@@ -881,7 +897,14 @@ export function renderToolsPanel() {
     </label>
   </div>`;
 
-  $("tools-list").innerHTML = toolCards + lengthGuardCard + showEditorDiffCard;
+  const hideUntilBakedCard = `<div class="tool-card">
+    <label class="lg-enforce-label" title="Hide the assistant's reply while the pipeline (director -> writer -> editor) runs. The phase indicator stays visible.">
+      <input type="checkbox" ${S.hideUntilBaked ? "checked" : ""} onchange="toggleHideUntilBaked(this.checked)">
+      Hide streaming message until baked
+    </label>
+  </div>`;
+
+  $("tools-list").innerHTML = toolCards + lengthGuardCard + showEditorDiffCard + hideUntilBakedCard;
 }
 
 // ── Phrase Bank

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -3,6 +3,7 @@ import { $, esc, toast } from "./utils.js";
 import { api } from "./api.js";
 import { showModal, closeModal, showConfirmModal } from "./modal.js";
 import { validate } from "./validate.js";
+import { renderMessages } from "./chat.js";
 
 // ── Theme
 const THEMES = [
@@ -78,6 +79,9 @@ export async function loadSettings() {
   if (S.settings.length_guard_max_paragraphs) S.lengthGuardMaxParagraphs = S.settings.length_guard_max_paragraphs;
   if (S.settings.reasoning_enabled_passes)
     S.reasoningEnabled = { ...S.reasoningEnabled, ...S.settings.reasoning_enabled_passes };
+
+  if (typeof S.settings.show_editor_diff === "number") S.showEditorDiff = S.settings.show_editor_diff !== 0;
+  else if (typeof S.settings.show_editor_diff === "boolean") S.showEditorDiff = S.settings.show_editor_diff;
 
   // Expand Settings section if endpoint_url is empty
   const settingsSection = $("settings-section");
@@ -785,6 +789,17 @@ export async function toggleLengthGuardEnforce(on) {
   }
 }
 
+export async function toggleShowEditorDiff(on) {
+  S.showEditorDiff = on;
+  renderMessages();
+  renderToolsPanel();
+  try {
+    S.settings = await api.put("/settings", { show_editor_diff: on });
+  } catch (e) {
+    toast("Failed to save editor diff setting", true);
+  }
+}
+
 export async function saveLengthGuardConfig() {
   const words = parseInt($("lg-max-words").value, 10);
   const paras = parseInt($("lg-max-paragraphs").value, 10);
@@ -859,7 +874,14 @@ export function renderToolsPanel() {
     ${lgConfig}
   </div>`;
 
-  $("tools-list").innerHTML = toolCards + lengthGuardCard;
+  const showEditorDiffCard = `<div class="tool-card">
+    <label class="lg-enforce-label" title="Highlight edited sentences with green/red strikethrough when the editor pass rewrites the writer's output.">
+      <input type="checkbox" ${S.showEditorDiff ? "checked" : ""} onchange="toggleShowEditorDiff(this.checked)">
+      Show editor diff highlights
+    </label>
+  </div>`;
+
+  $("tools-list").innerHTML = toolCards + lengthGuardCard + showEditorDiffCard;
 }
 
 // ── Phrase Bank

--- a/frontend/state.js
+++ b/frontend/state.js
@@ -42,6 +42,7 @@ export const S = {
   reasoningOpen: true,
   reasoningEnabled: { director: true, writer: false, editor: false },
   pendingRefineDiff: null, // {original, ops} set on writer_rewrite, cleared on next stream
+  showEditorDiff: true, // when false, editor-pass diff highlights + "clear diff" button are suppressed
   autoscrollEnabled: true, // whether to auto-scroll chat to bottom during streaming
   _programmaticScroll: false, // true while scrollToBottom() is executing — suppresses scroll listener
   hasMultipleTabs: false, // true if multiple tabs of the app are open

--- a/frontend/state.js
+++ b/frontend/state.js
@@ -43,6 +43,7 @@ export const S = {
   reasoningEnabled: { director: true, writer: false, editor: false },
   pendingRefineDiff: null, // {original, ops} set on writer_rewrite, cleared on next stream
   showEditorDiff: true, // when false, editor-pass diff highlights + "clear diff" button are suppressed
+  hideUntilBaked: false, // when true, in-flight streaming message is kept detached from DOM until stream finalizes
   autoscrollEnabled: true, // whether to auto-scroll chat to bottom during streaming
   _programmaticScroll: false, // true while scrollToBottom() is executing — suppresses scroll listener
   hasMultipleTabs: false, // true if multiple tabs of the app are open

--- a/tests/integration/test_settings.py
+++ b/tests/integration/test_settings.py
@@ -72,3 +72,22 @@ async def test_show_editor_diff_default_and_roundtrip(client, db):
 
     resp = await client.put("/api/settings", json={"show_editor_diff": True})
     assert resp.json()["show_editor_diff"] == 1
+
+
+async def test_hide_streaming_until_baked_default_and_roundtrip(client, db):
+    resp = await client.get("/api/settings")
+    assert resp.status_code == 200
+    assert resp.json()["hide_streaming_until_baked"] == 0
+
+    resp = await client.put("/api/settings", json={"hide_streaming_until_baked": True})
+    assert resp.status_code == 200
+    assert resp.json()["hide_streaming_until_baked"] == 1
+
+    async with db.execute(
+        "SELECT hide_streaming_until_baked FROM settings WHERE id = 1"
+    ) as cur:
+        row = await cur.fetchone()
+    assert row["hide_streaming_until_baked"] == 1
+
+    resp = await client.put("/api/settings", json={"hide_streaming_until_baked": False})
+    assert resp.json()["hide_streaming_until_baked"] == 0

--- a/tests/integration/test_settings.py
+++ b/tests/integration/test_settings.py
@@ -55,3 +55,20 @@ async def test_update_enabled_tools_json_field(client, db):
     async with db.execute("SELECT enabled_tools FROM settings WHERE id = 1") as cur:
         row = await cur.fetchone()
     assert json.loads(row["enabled_tools"]) == tools
+
+
+async def test_show_editor_diff_default_and_roundtrip(client, db):
+    resp = await client.get("/api/settings")
+    assert resp.status_code == 200
+    assert resp.json()["show_editor_diff"] == 1
+
+    resp = await client.put("/api/settings", json={"show_editor_diff": False})
+    assert resp.status_code == 200
+    assert resp.json()["show_editor_diff"] == 0
+
+    async with db.execute("SELECT show_editor_diff FROM settings WHERE id = 1") as cur:
+        row = await cur.fetchone()
+    assert row["show_editor_diff"] == 0
+
+    resp = await client.put("/api/settings", json={"show_editor_diff": True})
+    assert resp.json()["show_editor_diff"] == 1


### PR DESCRIPTION
The three-pass pipeline is a lot of visual noise. Writer tokens appear live, then the editor pass paints strikethrough over whatever it rewrites. Great for seeing what the editor did, less great if you just want the finished scene. This PR introduces two toggles in the tools panel: one suppresses the editor diff overlay (default on, matches current behavior), one hides the streaming message entirely until the pipeline bakes (default off). The phase indicator stays visible either way, so you still see progress.