### PR TITLE
ci: add Lefthook pre-commit hooks for auto-formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .venv
 backend/data
 __pycache__
+node_modules/
+package-lock.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,15 @@ Make sure the feature or fix works first.
 
 Start the backend with `./run_unix.sh` (or `run_windows.bat` on Windows). Python 3.9+ required.
 
+### Optional: Auto-formatting on commit
+
+Run `npm install` to set up git hooks via Lefthook. This auto-formats staged files before each commit:
+
+- **Python** — Black (formatting) + Flake8 (linting)
+- **JavaScript** — Biome (formatting)
+
+No more CI failures from formatting issues. Requires Node.js.
+
 ## 2. Run the checks
 
 Everything lives in `scripts/`. Run them before you push:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,32 @@
+# Lefthook configuration for Orb
+# Docs: https://github.com/evilmartians/lefthook/blob/master/docs/configuration.md
+
+pre-commit:
+  parallel: true
+  commands:
+    format-python:
+      glob: "*.py"
+      run: python3 -m black --quiet {staged_files}
+      stage_fixed: true
+
+    format-js:
+      glob: "*.{js,jsx,ts,tsx}"
+      path_filter: "^frontend/"
+      run: npx biome format --write {staged_files}
+      stage_fixed: true
+
+    lint-python:
+      glob: "*.py"
+      run: python3 -m flake8 {staged_files}
+
+commit-msg:
+  commands:
+    conventional:
+      run: |
+        # Optional: enforce conventional commit prefixes
+        # Uncomment to enable:
+        # head -1 "$LEFTHOOK_GIT_PARAMS" | grep -qE "^(feat|fix|refactor|style|docs|test|chore|ci|perf|build|revert)(\(.+\))?: .+" || {
+        #   echo "Commit message must follow conventional format: type(scope): message"
+        #   exit 1
+        # }
+        exit 0

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "orb",
+  "private": true,
+  "devDependencies": {
+    "@biomejs/biome": "^2.0.0",
+    "@evilmartians/lefthook": "^1.11.0"
+  },
+  "scripts": {
+    "prepare": "lefthook install",
+    "format:frontend": "biome format frontend/ --write",
+    "format:backend": "python3 -m black backend/ tests/",
+    "lint": "python3 -m flake8 backend/ tests/ && biome check frontend/",
+    "test": "python3 -m pytest tests/"
+  }
+}


### PR DESCRIPTION
## Why

CI catches formatting/lint issues, but contributors only find out after pushing. This adds local pre-commit hooks so formatting is auto-fixed before the commit even happens.

## What

Adds [Lefthook](https://github.com/evilmartians/lefthook) — a fast, language-agnostic git hooks manager. Config in one file (`lefthook.yml`), installs automatically via `npm install`.

### Pre-commit hooks

| Language | Tool | Action |
|----------|------|--------|
| Python (`.py`) | Black | Auto-format staged files |
| Python (`.py`) | Flake8 | Lint check (blocks commit on errors) |
| JavaScript (frontend/) | Biome | Auto-format staged files |

Hooks run in parallel and only on staged files that match — fast.

### Setup

```bash
npm install
```

That's it. The `prepare` script in `package.json` runs `lefthook install` automatically.

### No Node.js?

This is fully optional. Contributors without Node.js skip `npm install` and run the existing `scripts/format_backend.sh` / `scripts/format_frontend.sh` manually. CI still catches everything.

## Changes

| File | Change |
|------|--------|
| `package.json` | New — Lefthook + Biome as dev dependencies, `prepare` script |
| `lefthook.yml` | New — hook config: Black + Flake8 + Biome on pre-commit |
| `.gitignore` | Added `node_modules/`, `package-lock.json` |
| `CONTRIBUTING.md` | Added "Auto-formatting on commit" section |

## Bonus

There's a commented-out conventional commit validator in `lefthook.yml`. Uncomment it to enforce `type(scope): message` format on commit messages.