### PR TITLE
feat: add Night City theme

### DIFF
--- a/frontend/themes/night_city.css
+++ b/frontend/themes/night_city.css
@@ -1,0 +1,22 @@
+:root {
+  --bg-deep:#04050c;--bg-primary:#080a16;--bg-surface:#0c0f1e;--bg-elevated:#11142a;
+  --bg-hover:#181c36;--border:#1a1e40;--border-light:#242856;
+  --text-primary:#dce4f0;--text-secondary:#6070a0;--text-muted:#3e4a6e;
+  --accent:#00d4ee;--accent-dim:#006878;--accent-glow:rgba(0,212,238,0.13);
+  --red:#ff1a5e;
+  --font-prose:'Lora',Georgia,'Palatino Linotype',Palatino,serif;--font-ui:'SF Mono','Fira Code','Cascadia Code',Consolas,monospace;
+  --font-mono:'SF Mono','Fira Code','Cascadia Code',Consolas,monospace;--radius:3px;
+  --font-prose-size:16px;
+  --sidebar-width:300px;--inspector-width:340px;--tools-width:260px;
+}
+
+/* Scrollbars */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border-light); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--accent-dim); }
+* { scrollbar-width: thin; scrollbar-color: var(--border-light) transparent; }
+
+/* Kill default textarea chrome */
+textarea { appearance: none; -webkit-appearance: none; }
+textarea::-webkit-resizer { background: transparent; }


### PR DESCRIPTION
## Night City Theme

Cyberpunk-inspired dark theme with neon cyan accents against deep navy-blue backgrounds.

### Palette
| Token | Value | Usage |
|-------|-------|-------|
| `--bg-deep` | `#04050c` | Body background — near-black with cold blue undertone |
| `--bg-primary` | `#080a16` | Sidebar, panels |
| `--bg-surface` | `#0c0f1e` | Cards, elevated surfaces |
| `--bg-elevated` | `#11142a` | Hover states, inputs |
| `--accent` | `#00d4ee` | Electric cyan — buttons, focus rings, active elements |
| `--accent-dim` | `#006878` | Dimmed accent — borders, secondary highlights |
| `--text-primary` | `#dce4f0` | Cool steel-white |
| `--text-secondary` | `#6070a0` | Muted blue-gray |
| `--red` | `#ff1a5e` | Hot magenta-red for errors |

### Design choices
- **Monospace UI font** — SF Mono / Fira Code / Cascadia Code / Consolas. Netrunner terminal feel.
- **Lora serif prose font** — keeps RP text warm against the cold UI shell.
- **3px border radius** — sharp, functional, no decorative rounding.
- **Custom dark scrollbars** — themed thumb/track matching the palette (WebKit + Firefox).
- **Stripped native textarea chrome** — removes the default 3D bevel/white highlight on resize grip.

### Screenshot
<img width="1802" height="1071" alt="screenshot" src="https://github.com/user-attachments/assets/c6f6e5e2-6dd6-4a4c-bd2e-e57ea46f2f97" />

### Files
- `frontend/themes/night_city.css` — single CSS file, auto-discovered by `GET /api/themes`