### PR TITLE
feat(tts): cache eviction strategy

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import asyncio
 import hashlib
 import json
 import uuid
@@ -111,8 +112,11 @@ from .tts.cache import (
     cache_media_type,
     cache_meta_path,
     cache_path,
+    cache_stats,
     invalidate_cache_for_card,
+    invalidate_cache_for_conversation,
     metadata_headers,
+    run_eviction_cycle,
     synthesize_and_cache,
 )
 
@@ -124,12 +128,32 @@ FRONTEND_DIR = os.path.join(
 )
 
 
+_TTS_EVICT_INTERVAL = 30 * 60  # 30 minutes
+
+
+async def _tts_eviction_loop() -> None:
+    """Background task: periodically evict stale / oversized TTS cache entries."""
+    # Run once at startup, then every N minutes.
+    while True:
+        try:
+            run_eviction_cycle()
+        except Exception:
+            logger.warning("TTS cache eviction cycle failed", exc_info=True)
+        await asyncio.sleep(_TTS_EVICT_INTERVAL)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await init_db()
     run_pending(DB_PATH)
     logger.info("Database initialized")
+    task = asyncio.create_task(_tts_eviction_loop())
     yield
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
 
 
 app = FastAPI(title="Orb", lifespan=lifespan)
@@ -919,6 +943,7 @@ async def api_create_conversation(data: ConversationCreate):
 async def api_delete_conversation(cid: str):
     if not await delete_conversation(cid):
         raise HTTPException(status_code=404, detail="Conversation not found")
+    invalidate_cache_for_conversation(cid)
     return {"ok": True}
 
 
@@ -1712,6 +1737,18 @@ async def serve_frontend():
 async def api_tts_backends():
     """List available TTS backends."""
     return list_backends()
+
+
+@app.get("/api/tts/cache/stats")
+async def api_tts_cache_stats():
+    """Return TTS cache usage statistics."""
+    return cache_stats()
+
+
+@app.post("/api/tts/cache/evict")
+async def api_tts_cache_evict():
+    """Manually trigger a cache eviction cycle (TTL + LRU)."""
+    return run_eviction_cycle()
 
 
 @app.get("/api/tts/voices")

--- a/backend/main.py
+++ b/backend/main.py
@@ -94,7 +94,6 @@ from .database import (
     get_voice_profile,
     upsert_voice_profile,
 )
-import asyncio
 from .orchestrator import (
     handle_turn,
     handle_regenerate,

--- a/backend/tts/cache.py
+++ b/backend/tts/cache.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import shutil
+import time
 import urllib.parse
 from typing import TYPE_CHECKING
 
@@ -84,6 +86,144 @@ def invalidate_cache_for_card(conv_ids: list[str]) -> None:
         _cache_dir = os.path.join(TTS_CACHE_DIR, cid)
         if os.path.isdir(_cache_dir):
             shutil.rmtree(_cache_dir)
+
+
+# ---------------------------------------------------------------------------
+# Cache eviction
+# ---------------------------------------------------------------------------
+
+logger = logging.getLogger(__name__)
+
+# Defaults — override per-installation if needed.
+DEFAULT_MAX_CACHE_BYTES = 500 * 1024 * 1024  # 500 MB
+DEFAULT_TTL_SECONDS = 7 * 24 * 3600          # 7 days
+
+
+def cache_stats() -> dict:
+    """Return total file count and bytes used by the TTS cache."""
+    total_bytes = 0
+    total_files = 0
+    if not os.path.isdir(TTS_CACHE_DIR):
+        return {"files": 0, "bytes": 0, "mb": 0.0}
+    for dirpath, _, filenames in os.walk(TTS_CACHE_DIR):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            try:
+                total_bytes += os.path.getsize(fp)
+                total_files += 1
+            except OSError:
+                pass
+    return {
+        "files": total_files,
+        "bytes": total_bytes,
+        "mb": round(total_bytes / (1024 * 1024), 2),
+    }
+
+
+def evict_expired(ttl_seconds: int = DEFAULT_TTL_SECONDS) -> int:
+    """Remove cache entries older than *ttl_seconds*. Returns count deleted."""
+    if not os.path.isdir(TTS_CACHE_DIR):
+        return 0
+    cutoff = time.time() - ttl_seconds
+    removed = 0
+    for dirpath, _, filenames in os.walk(TTS_CACHE_DIR):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            try:
+                if os.path.getmtime(fp) < cutoff:
+                    os.remove(fp)
+                    removed += 1
+            except OSError:
+                pass
+    _prune_empty_dirs()
+    if removed:
+        logger.info("TTS cache TTL eviction: removed %d files (ttl=%ds)", removed, ttl_seconds)
+    return removed
+
+
+def evict_lru(max_bytes: int = DEFAULT_MAX_CACHE_BYTES) -> int:
+    """Delete oldest files until total cache is under *max_bytes*.
+
+    Returns count of deleted files.
+    """
+    if not os.path.isdir(TTS_CACHE_DIR):
+        return 0
+    entries: list[tuple[str, float, int]] = []  # (path, mtime, size)
+    total = 0
+    for dirpath, _, filenames in os.walk(TTS_CACHE_DIR):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            try:
+                st = os.stat(fp)
+                entries.append((fp, st.st_mtime, st.st_size))
+                total += st.st_size
+            except OSError:
+                pass
+    if total <= max_bytes:
+        return 0
+    # Oldest first
+    entries.sort(key=lambda e: e[1])
+    removed = 0
+    for fp, _, sz in entries:
+        try:
+            os.remove(fp)
+        except OSError:
+            continue
+        total -= sz
+        removed += 1
+        if total <= max_bytes:
+            break
+    _prune_empty_dirs()
+    if removed:
+        logger.info(
+            "TTS cache LRU eviction: removed %d files (%.1f MB → %.1f MB budget)",
+            removed,
+            (total + sum(e[2] for e in entries[:removed])) / (1024 * 1024),
+            max_bytes / (1024 * 1024),
+        )
+    return removed
+
+
+def invalidate_cache_for_conversation(cid: str) -> bool:
+    """Remove cached TTS audio for a single conversation. Returns True if existed."""
+    _cache_dir = os.path.join(TTS_CACHE_DIR, cid)
+    if os.path.isdir(_cache_dir):
+        shutil.rmtree(_cache_dir)
+        return True
+    return False
+
+
+def run_eviction_cycle(
+    max_bytes: int = DEFAULT_MAX_CACHE_BYTES,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+) -> dict:
+    """Run a full eviction cycle: TTL purge first, then LRU if still over budget.
+
+    Returns a summary dict.
+    """
+    ttl_removed = evict_expired(ttl_seconds)
+    lru_removed = evict_lru(max_bytes)
+    stats = cache_stats()
+    return {
+        "ttl_removed": ttl_removed,
+        "lru_removed": lru_removed,
+        "stats": stats,
+    }
+
+
+def _prune_empty_dirs() -> None:
+    """Remove leaf directories under TTS_CACHE_DIR that have no files."""
+    if not os.path.isdir(TTS_CACHE_DIR):
+        return
+    for dirpath, dirnames, filenames in os.walk(TTS_CACHE_DIR, topdown=False):
+        # Only prune sub-directories, not TTS_CACHE_DIR itself
+        if dirpath == TTS_CACHE_DIR:
+            continue
+        if not dirnames and not filenames:
+            try:
+                os.rmdir(dirpath)
+            except OSError:
+                pass
 
 
 async def synthesize_and_cache(

--- a/backend/tts/cache.py
+++ b/backend/tts/cache.py
@@ -96,7 +96,7 @@ logger = logging.getLogger(__name__)
 
 # Defaults — override per-installation if needed.
 DEFAULT_MAX_CACHE_BYTES = 500 * 1024 * 1024  # 500 MB
-DEFAULT_TTL_SECONDS = 7 * 24 * 3600          # 7 days
+DEFAULT_TTL_SECONDS = 7 * 24 * 3600  # 7 days
 
 
 def cache_stats() -> dict:
@@ -137,7 +137,9 @@ def evict_expired(ttl_seconds: int = DEFAULT_TTL_SECONDS) -> int:
                 pass
     _prune_empty_dirs()
     if removed:
-        logger.info("TTS cache TTL eviction: removed %d files (ttl=%ds)", removed, ttl_seconds)
+        logger.info(
+            "TTS cache TTL eviction: removed %d files (ttl=%ds)", removed, ttl_seconds
+        )
     return removed
 
 

--- a/tests/unit/test_tts_cache_eviction.py
+++ b/tests/unit/test_tts_cache_eviction.py
@@ -1,0 +1,214 @@
+"""
+Unit tests for TTS cache eviction functions.
+
+Tests cache_stats, evict_expired, evict_lru, invalidate_cache_for_conversation,
+run_eviction_cycle, and _prune_empty_dirs using tmp_path fixtures.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from backend.tts.cache import (
+    DEFAULT_MAX_CACHE_BYTES,
+    DEFAULT_TTL_SECONDS,
+    _prune_empty_dirs,
+    cache_stats,
+    evict_expired,
+    evict_lru,
+    invalidate_cache_for_conversation,
+    run_eviction_cycle,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache_dir(tmp_path, monkeypatch):
+    """Point TTS_CACHE_DIR at a temp directory for every test."""
+    cache_root = tmp_path / "tts_cache"
+    cache_root.mkdir()
+    monkeypatch.setattr("backend.tts.cache.TTS_CACHE_DIR", str(cache_root))
+    return cache_root
+
+
+def _write_file(cache_root, cid, filename, content=b"audio", age_seconds=0):
+    """Helper: create a cache file under a conversation dir."""
+    conv_dir = cache_root / cid
+    conv_dir.mkdir(exist_ok=True)
+    fp = conv_dir / filename
+    fp.write_bytes(content)
+    if age_seconds:
+        mtime = time.time() - age_seconds
+        os.utime(str(fp), (mtime, mtime))
+    return fp
+
+
+# ---------------------------------------------------------------------------
+# cache_stats
+# ---------------------------------------------------------------------------
+
+
+class TestCacheStats:
+    def test_empty_cache(self, _isolate_cache_dir):
+        result = cache_stats()
+        assert result == {"files": 0, "bytes": 0, "mb": 0.0}
+
+    def test_counts_files_and_bytes(self, _isolate_cache_dir):
+        _write_file(_isolate_cache_dir, "conv1", "a.wav", b"x" * 100)
+        _write_file(_isolate_cache_dir, "conv1", "b.wav", b"x" * 200)
+        _write_file(_isolate_cache_dir, "conv2", "c.wav", b"x" * 300)
+
+        result = cache_stats()
+        assert result["files"] == 3
+        assert result["bytes"] == 600
+        assert result["mb"] == round(600 / (1024 * 1024), 2)
+
+    def test_missing_cache_dir(self, _isolate_cache_dir, monkeypatch):
+        monkeypatch.setattr("backend.tts.cache.TTS_CACHE_DIR", "/nonexistent/path")
+        result = cache_stats()
+        assert result == {"files": 0, "bytes": 0, "mb": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# evict_expired
+# ---------------------------------------------------------------------------
+
+
+class TestEvictExpired:
+    def test_removes_old_files(self, _isolate_cache_dir):
+        _write_file(
+            _isolate_cache_dir, "conv1", "old.wav", age_seconds=DEFAULT_TTL_SECONDS + 10
+        )
+        _write_file(_isolate_cache_dir, "conv1", "new.wav", age_seconds=100)
+
+        removed = evict_expired()
+        assert removed == 1
+
+        conv_dir = _isolate_cache_dir / "conv1"
+        assert not (conv_dir / "old.wav").exists()
+        assert (conv_dir / "new.wav").exists()
+
+    def test_nothing_to_remove(self, _isolate_cache_dir):
+        _write_file(_isolate_cache_dir, "conv1", "a.wav", age_seconds=10)
+        removed = evict_expired()
+        assert removed == 0
+
+    def test_custom_ttl(self, _isolate_cache_dir):
+        _write_file(_isolate_cache_dir, "conv1", "mid.wav", age_seconds=500)
+        removed = evict_expired(ttl_seconds=100)
+        assert removed == 1
+
+    def test_empty_cache_dir(self, _isolate_cache_dir):
+        removed = evict_expired()
+        assert removed == 0
+
+
+# ---------------------------------------------------------------------------
+# evict_lru
+# ---------------------------------------------------------------------------
+
+
+class TestEvictLru:
+    def test_removes_oldest_until_under_budget(self, _isolate_cache_dir):
+        # 3 files of 100 bytes each, budget = 150 bytes
+        _write_file(
+            _isolate_cache_dir, "conv1", "oldest.wav", b"x" * 100, age_seconds=300
+        )
+        _write_file(_isolate_cache_dir, "conv1", "mid.wav", b"x" * 100, age_seconds=200)
+        _write_file(
+            _isolate_cache_dir, "conv1", "newest.wav", b"x" * 100, age_seconds=10
+        )
+
+        removed = evict_lru(max_bytes=150)
+        assert removed == 2  # oldest + mid removed
+        assert (_isolate_cache_dir / "conv1" / "newest.wav").exists()
+
+    def test_under_budget_no_removal(self, _isolate_cache_dir):
+        _write_file(_isolate_cache_dir, "conv1", "a.wav", b"x" * 10)
+        removed = evict_lru(max_bytes=DEFAULT_MAX_CACHE_BYTES)
+        assert removed == 0
+
+    def test_empty_cache(self, _isolate_cache_dir):
+        removed = evict_lru()
+        assert removed == 0
+
+
+# ---------------------------------------------------------------------------
+# invalidate_cache_for_conversation
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidateCacheForConversation:
+    def test_removes_existing_conversation(self, _isolate_cache_dir):
+        _write_file(_isolate_cache_dir, "conv1", "a.wav")
+        _write_file(_isolate_cache_dir, "conv2", "b.wav")
+
+        result = invalidate_cache_for_conversation("conv1")
+        assert result is True
+        assert not (_isolate_cache_dir / "conv1").exists()
+        assert (_isolate_cache_dir / "conv2").exists()
+
+    def test_nonexistent_conversation(self, _isolate_cache_dir):
+        result = invalidate_cache_for_conversation("nope")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# run_eviction_cycle
+# ---------------------------------------------------------------------------
+
+
+class TestRunEvictionCycle:
+    def test_returns_summary(self, _isolate_cache_dir):
+        _write_file(_isolate_cache_dir, "conv1", "a.wav", b"x" * 50)
+
+        result = run_eviction_cycle()
+        assert "ttl_removed" in result
+        assert "lru_removed" in result
+        assert "stats" in result
+        assert result["stats"]["files"] == 1
+
+    def test_ttl_then_lru(self, _isolate_cache_dir):
+        # Old file (evicted by TTL)
+        _write_file(
+            _isolate_cache_dir,
+            "conv1",
+            "old.wav",
+            b"x" * 100,
+            age_seconds=DEFAULT_TTL_SECONDS + 10,
+        )
+        # New file within budget (kept)
+        _write_file(_isolate_cache_dir, "conv1", "new.wav", b"x" * 50, age_seconds=10)
+
+        result = run_eviction_cycle(max_bytes=DEFAULT_MAX_CACHE_BYTES)
+        assert result["ttl_removed"] == 1
+        assert result["lru_removed"] == 0
+        assert result["stats"]["files"] == 1
+
+
+# ---------------------------------------------------------------------------
+# _prune_empty_dirs
+# ---------------------------------------------------------------------------
+
+
+class TestPruneEmptyDirs:
+    def test_removes_empty_leaf_dirs(self, _isolate_cache_dir):
+        (_isolate_cache_dir / "empty_conv").mkdir()
+        _prune_empty_dirs()
+        assert not (_isolate_cache_dir / "empty_conv").exists()
+
+    def test_keeps_dirs_with_files(self, _isolate_cache_dir):
+        _write_file(_isolate_cache_dir, "conv1", "a.wav")
+        _prune_empty_dirs()
+        assert (_isolate_cache_dir / "conv1").exists()
+
+    def test_does_not_remove_cache_root(self, _isolate_cache_dir):
+        _prune_empty_dirs()
+        assert _isolate_cache_dir.exists()


### PR DESCRIPTION
## Problem

The TTS audio cache (`backend/data/tts_cache/`) grows unbounded — every synthesized message writes an audio file (~50–500 KB each) and nothing ever removes them. Deleting a conversation leaves its cache directory behind forever.

## Changes

### `backend/tts/cache.py` — eviction functions
- **`cache_stats()`** — returns `{files, bytes, mb}` for the entire cache
- **`evict_expired(ttl_seconds=604800)`** — deletes files older than 7 days
- **`evict_lru(max_bytes=524288000)`** — deletes oldest files until under 500 MB
- **`invalidate_cache_for_conversation(cid)`** — wipes a single conversation cache dir
- **`run_eviction_cycle()`** — runs TTL purge then LRU trim, returns summary
- **`_prune_empty_dirs()`** — cleans orphaned empty directories after eviction

### `backend/main.py` — wiring
- **Conversation delete hook**: `api_delete_conversation` now calls `invalidate_cache_for_conversation(cid)` — no more orphaned cache
- **Background eviction task**: `_tts_eviction_loop` runs `run_eviction_cycle()` every 30 min via `asyncio.create_task`, properly cancelled on shutdown
- **New endpoints**:
  - `GET /api/tts/cache/stats` — cache size/file count
  - `POST /api/tts/cache/evict` — manual eviction trigger

### Defaults (no config needed)
| Parameter | Default |
|---|---|
| Max cache size | 500 MB |
| TTL | 7 days |
| Sweep interval | 30 minutes |

## Test Plan
- [x] All 299 existing tests pass
- [x] Manual: `GET /api/tts/cache/stats` returns correct stats
- [x] Manual: `POST /api/tts/cache/evict` triggers eviction and returns summary
- [x] Manual: delete a conversation, verify its cache dir is removed