### PR TITLE
feat: click-to-speak dialogue lines + karaoke TTS highlighting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,3 +427,5 @@ When running under Codex's filesystem/network sandbox, `aiosqlite` integration t
 12. **Agent endpoint separation** — Both the Director and Editor can use separate endpoints from the Writer (`agent_endpoint_id` in settings). If `agent_same_as_writer` is true, they share. When using a separate endpoint, note that a different prompt caching mechanism applies, and the instruction prompt has a small difference. Make sure to check which endpoint you're targeting when modifying agent-related code.
 
 13. **Macros resolve at different levels** — `resolve_message()` expands everything ({{user}}, {{char}}, inline macros like {{roll}}). `resolve_prompt()` only does {{user}}/{{char}} substitution. Use `resolve_prompt()` for historical messages where inline macros shouldn't fire.
+
+14. **Never bypass lefthook with `--no-verify`** — The pre-commit hook runs `black --line-length 128`, `biome format`, and `flake8`. If a hook fails, fix the issue. Do not bypass it. CI runs the same checks and will catch formatting drift. Dirty working tree files can produce flake8 warnings that don't exist in committed code — verify before assuming a hook failure is legitimate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ Orb/
 │   ├── tts/
 │   │   ├── base.py          # TTSAdapter abstract base class
 │   │   ├── router.py        # Adapter registry, routes backend name → adapter class
-│   │   ├── cache.py         # Audio file cache keyed by text + voice params
+│   │   ├── cache.py         # Audio file cache keyed by text + voice params. Per-chunk caching helpers.
 │   │   ├── regex_extractor.py # Speech/non-speech chunk splitting
 │   │   ├── edge_adapter.py      # Edge TTS (free, local)
 │   │   ├── elevenlabs_adapter.py # ElevenLabs API
@@ -103,7 +103,7 @@ Orb/
 │   ├── app.js               # Bootstrap: wire up sidebar, tabs, modals
 │   ├── state.js             # Global state object (S.*), reactive getters
 │   ├── api.js               # All fetch() calls to backend
-│   ├── chat.js              # Chat rendering, message display, Inspector, streaming
+│   ├── chat.js              # Chat rendering, message display, Inspector, streaming, TTS chunk queue player
 │   ├── voice.js             # TTS UI controls, speak buttons, voice settings
 │   ├── library.js           # Character card grid/list, CRUD UI
 │   ├── settings.js          # Settings panel, endpoint/model config UI
@@ -249,7 +249,9 @@ erDiagram
 - `GET /api/tts/models` — List models for a backend
 - `POST /api/tts/preview` — Preview TTS output
 - `GET/PUT /api/characters/{id}/voice-profile` — Per-character voice settings
-- `POST /api/conversations/{cid}/messages/{id}/speak` — Generate speech for message
+- `POST /api/conversations/{cid}/messages/{id}/speak` — Generate speech for message (monolithic, all chunks)
+- `GET /api/conversations/{cid}/messages/{id}/chunks` — Return chunk metadata (text, emotion, pause_before_ms, index)
+- `POST /api/conversations/{cid}/messages/{id}/speak-chunk` — Synthesize single chunk by index (per-chunk caching)
 
 ### Fragments & Moods
 - `GET/POST /api/fragments` — List/create mood fragments
@@ -326,6 +328,17 @@ flowchart LR
 ```
 
 Each character card has a voice profile (`voice_profiles` table) selecting backend, voice ID, language, rate, pitch. The regex extractor splits text into dialogue and narration chunks; only dialogue is spoken by default.
+
+### Click-to-Speak & Chunk Queue
+
+Users can click individual quoted dialogue lines to hear just that chunk, or play the full message with sequential chunk playback and karaoke highlighting:
+
+1. `GET /chunks` returns ordered chunk metadata for a message
+2. Frontend annotates `<span class="quoted">` elements with `data-chunk-idx`
+3. Click a span → `POST /speak-chunk` for that index → single chunk playback
+4. Full speak → chunk queue player plays chunks sequentially, highlighting each in turn
+5. Prefetch: during chunk N playback, chunk N+1 audio is fetched in the background to eliminate gaps
+6. Messages without extractable dialogue (narration-only) fall back to monolithic `/speak`
 
 ## Context Management
 
@@ -409,7 +422,7 @@ When running under Codex's filesystem/network sandbox, `aiosqlite` integration t
 
 10. **Lorebook scan depth** — Hard-coded to 6 messages (`LOREBOOK_SCAN_DEPTH` in `prompt_builder.py`). Only the last 6 messages are scanned for lorebook keyword matches.
 
-11. **TTS regex extractor** — Splits text into speech/non-speech chunks using quotation marks. The `regex_extractor.py` handles edge cases (nested quotes, em-dashes) but isn't perfect for all writing styles. Only speech chunks are sent to the TTS backend.
+11. **TTS regex extractor and chunk playback** — Splits text into speech/non-speech chunks using quotation marks. The `regex_extractor.py` handles edge cases (nested quotes, em-dashes) but isn't perfect for all writing styles. Only speech chunks are sent to the TTS backend. Chunk indices from the backend must stay in sync with frontend `<span class="quoted">` elements — the `annotateChunkSpans()` function matches by `original_text` with consumed-span tracking to handle duplicate dialogue. The chunk queue player uses a `playbackId` monotonic token to prevent stale async continuations when stopping/restarting.
 
 12. **Agent endpoint separation** — Both the Director and Editor can use separate endpoints from the Writer (`agent_endpoint_id` in settings). If `agent_same_as_writer` is true, they share. When using a separate endpoint, note that a different prompt caching mechanism applies, and the instruction prompt has a small difference. Make sure to check which endpoint you're targeting when modifying agent-related code.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -125,9 +125,7 @@ from .tts.cache import (
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-FRONTEND_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "frontend"
-)
+FRONTEND_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "frontend")
 
 
 _TTS_EVICT_INTERVAL = 30 * 60  # 30 minutes
@@ -581,9 +579,7 @@ async def api_list_mood_fragments():
 async def api_create_mood_fragment(data: MoodFragmentCreate):
     existing = await get_mood_fragment(data.id)
     if existing:
-        raise HTTPException(
-            status_code=400, detail="Mood fragment with this ID already exists"
-        )
+        raise HTTPException(status_code=400, detail="Mood fragment with this ID already exists")
     return await create_mood_fragment(data.model_dump())
 
 
@@ -598,9 +594,7 @@ async def api_update_mood_fragment(fid: str, data: MoodFragmentUpdate):
 @app.delete("/api/fragments/{fid}")
 async def api_delete_mood_fragment(fid: str):
     if not await delete_mood_fragment(fid):
-        raise HTTPException(
-            status_code=404, detail="Mood fragment not found or is built-in"
-        )
+        raise HTTPException(status_code=404, detail="Mood fragment not found or is built-in")
     return {"ok": True}
 
 
@@ -616,14 +610,10 @@ async def api_list_director_fragments():
 async def api_create_director_fragment(data: DirectorFragmentCreate):
     existing = await get_director_fragment(data.id)
     if existing:
-        raise HTTPException(
-            status_code=400, detail="Director fragment with this ID already exists"
-        )
+        raise HTTPException(status_code=400, detail="Director fragment with this ID already exists")
     result = await create_director_fragment(data.model_dump())
     if not result:
-        raise HTTPException(
-            status_code=500, detail="Failed to create director fragment"
-        )
+        raise HTTPException(status_code=500, detail="Failed to create director fragment")
     return result
 
 
@@ -680,9 +670,7 @@ async def require_world(world_id: str) -> dict:
     return world
 
 
-async def require_lorebook_entry(
-    entry_id: int, world: dict = Depends(require_world)
-) -> dict:  # noqa: B008
+async def require_lorebook_entry(entry_id: int, world: dict = Depends(require_world)) -> dict:  # noqa: B008
     entry = await get_lorebook_entry(entry_id)
     if not entry or entry.get("world_id") != world["id"]:
         raise HTTPException(status_code=404, detail="Entry not found")
@@ -695,9 +683,7 @@ async def api_list_lorebook_entries(world: dict = Depends(require_world)):  # no
 
 
 @app.post("/api/worlds/{world_id}/entries")
-async def api_create_lorebook_entry(
-    data: LorebookEntryCreate, world: dict = Depends(require_world)
-):  # noqa: B008
+async def api_create_lorebook_entry(data: LorebookEntryCreate, world: dict = Depends(require_world)):  # noqa: B008
     return await create_lorebook_entry(world["id"], data.model_dump())
 
 
@@ -713,9 +699,7 @@ async def api_update_lorebook_entry(
     data: LorebookEntryUpdate,
     entry: dict = Depends(require_lorebook_entry),  # noqa: B008
 ):
-    result = await update_lorebook_entry(
-        entry["id"], data.model_dump(exclude_unset=True)
-    )
+    result = await update_lorebook_entry(entry["id"], data.model_dump(exclude_unset=True))
     if not result:
         raise HTTPException(status_code=404, detail="Entry not found")
     return result
@@ -767,9 +751,7 @@ async def api_import_lorebook(world_id: str, payload: LorebookImportPayload):
         # Tavern V2 character_book: [...]
         items = raw_entries
     else:
-        raise HTTPException(
-            status_code=422, detail="entries must be an object or array"
-        )
+        raise HTTPException(status_code=422, detail="entries must be an object or array")
 
     created = []
     for item in items:
@@ -803,9 +785,7 @@ async def api_create_phrase_group(data: PhraseGroupCreate):
     # Validate all variants are strings
     for v in data.variants:
         if not isinstance(v, str) or not v.strip():
-            raise HTTPException(
-                status_code=400, detail="All variants must be non-empty strings"
-            )
+            raise HTTPException(status_code=400, detail="All variants must be non-empty strings")
     group_id = await add_phrase_group(data.variants)
     return {"id": group_id, "variants": data.variants}
 
@@ -818,9 +798,7 @@ async def api_update_phrase_group(group_id: int, data: PhraseGroupUpdate):
     # Validate all variants are strings
     for v in data.variants:
         if not isinstance(v, str) or not v.strip():
-            raise HTTPException(
-                status_code=400, detail="All variants must be non-empty strings"
-            )
+            raise HTTPException(status_code=400, detail="All variants must be non-empty strings")
     success = await update_phrase_group(group_id, data.variants)
     if not success:
         raise HTTPException(status_code=404, detail="Phrase group not found")
@@ -927,9 +905,7 @@ async def api_create_conversation(data: ConversationCreate):
 
     # If there's a first message, auto-add it as the first assistant turn
     if first_mes.strip():
-        msg_id = await add_message(
-            cid, "assistant", first_mes.strip(), 0, attachments=None
-        )
+        msg_id = await add_message(cid, "assistant", first_mes.strip(), 0, attachments=None)
         await set_active_leaf(cid, msg_id)
 
         # If we have a character card with alternate greetings, create swipe versions
@@ -939,9 +915,7 @@ async def api_create_conversation(data: ConversationCreate):
                 alternate_greetings = card.get("alternate_greetings", [])
                 count = await insert_alternate_greeting_swipes(cid, alternate_greetings)
                 if count:
-                    logger.info(
-                        f"Created {count} alternate greeting swipes for conversation {cid}"
-                    )
+                    logger.info(f"Created {count} alternate greeting swipes for conversation {cid}")
 
     return conv
 
@@ -971,14 +945,10 @@ async def api_update_conversation(cid: str, data: ConversationUpdate):
 
 
 @app.post("/api/conversations/{cid}/summarize")
-async def api_summarize_conversation(
-    cid: str, data: SummarizeRequest, request: Request
-):
+async def api_summarize_conversation(cid: str, data: SummarizeRequest, request: Request):
     """Stream a narrative summary of the conversation history, excluding the last keep_count messages."""
     if data.keep_count not in (2, 4, 6, 8):
-        raise HTTPException(
-            status_code=400, detail="keep_count must be one of 2, 4, 6, 8"
-        )
+        raise HTTPException(status_code=400, detail="keep_count must be one of 2, 4, 6, 8")
 
     conv = await get_conversation(cid)
     if not conv:
@@ -993,18 +963,10 @@ async def api_summarize_conversation(
     settings = await get_settings()
     char_name = conv.get("character_name", "Character") or "Character"
     active_persona_id = settings.get("active_persona_id")
-    active_persona = (
-        await get_user_persona(active_persona_id) if active_persona_id else None
-    )
-    system_prompt, char_persona, mes_example = await resolve_char_context(
-        conv, settings
-    )
+    active_persona = await get_user_persona(active_persona_id) if active_persona_id else None
+    system_prompt, char_persona, mes_example = await resolve_char_context(conv, settings)
     macros = Macros.from_settings(settings, char_name, active_persona)
-    user_description = (
-        active_persona.get("description", "")
-        if active_persona
-        else settings.get("user_description", "")
-    )
+    user_description = active_persona.get("description", "") if active_persona else settings.get("user_description", "")
 
     client = LLMClient(
         settings["endpoint_url"],
@@ -1017,11 +979,7 @@ async def api_summarize_conversation(
         char_persona,
         conv.get("character_scenario", "") or "",
         mes_example,
-        (
-            ""
-            if settings.get("prevent_prompt_overrides")
-            else conv.get("post_history_instructions", "")
-        ),
+        ("" if settings.get("prevent_prompt_overrides") else conv.get("post_history_instructions", "")),
         history_slice,
         macros,
         user_description,
@@ -1030,9 +988,7 @@ async def api_summarize_conversation(
 
     async def _gen():
         try:
-            async for delta in summarizer.stream(
-                llm_messages, settings.get("model_name", "")
-            ):
+            async for delta in summarizer.stream(llm_messages, settings.get("model_name", "")):
                 yield {"event": "token", "data": delta}
             yield {"event": "done", "data": ""}
         except Exception as e:
@@ -1049,9 +1005,7 @@ async def api_summarize_conversation(
 async def api_compress_conversation(cid: str, data: CompressRequest):
     """Create a new conversation seeded with a summary, then re-append the last keep_count messages."""
     if data.keep_count not in (2, 4, 6, 8):
-        raise HTTPException(
-            status_code=400, detail="keep_count must be one of 2, 4, 6, 8"
-        )
+        raise HTTPException(status_code=400, detail="keep_count must be one of 2, 4, 6, 8")
     if not data.summary.strip():
         raise HTTPException(status_code=400, detail="summary must not be empty")
 
@@ -1135,9 +1089,7 @@ async def api_create_character(data: CharacterCardCreate):
                 world = await create_world({"name": book_name})
                 for item in entries:
                     if isinstance(item, dict):
-                        await create_lorebook_entry(
-                            world["id"], _normalise_lorebook_entry(item)
-                        )
+                        await create_lorebook_entry(world["id"], _normalise_lorebook_entry(item))
             card_data["world_id"] = world["id"]
 
     try:
@@ -1150,9 +1102,7 @@ async def api_create_character(data: CharacterCardCreate):
 async def api_import_character(file: Annotated[UploadFile, File(...)]):
     """Import a SillyTavern-compatible character card PNG."""
     if not file.filename or not file.filename.lower().endswith(".png"):
-        raise HTTPException(
-            status_code=400, detail="Only .png character card files are supported"
-        )
+        raise HTTPException(status_code=400, detail="Only .png character card files are supported")
 
     # Save to temp file for the parser
     with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
@@ -1170,9 +1120,7 @@ async def api_import_character(file: Annotated[UploadFile, File(...)]):
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         logger.exception("Failed to parse tavern card")
-        raise HTTPException(
-            status_code=400, detail=f"Failed to parse character card: {e}"
-        ) from e
+        raise HTTPException(status_code=400, detail=f"Failed to parse character card: {e}") from e
     finally:
         os.unlink(tmp_path)
 
@@ -1245,9 +1193,7 @@ async def api_export_character(card_id: str):
         try:
             avatar_bytes = base64.b64decode(card["avatar_b64"])
         except Exception:
-            logger.warning(
-                "Avatar data for card %s is corrupt; exporting without avatar", card_id
-            )
+            logger.warning("Avatar data for card %s is corrupt; exporting without avatar", card_id)
             avatar_bytes = None
 
     card["id"] = card_id
@@ -1277,12 +1223,7 @@ async def api_export_character(card_id: str):
 
     png_bytes = tavern_cards.to_png(card, avatar_bytes)
 
-    safe_name = (
-        "".join(
-            c for c in card.get("name", "character") if c.isalnum() or c in " _-"
-        ).strip()
-        or "character"
-    )
+    safe_name = "".join(c for c in card.get("name", "character") if c.isalnum() or c in " _-").strip() or "character"
     return Response(
         content=png_bytes,
         media_type="image/png",
@@ -1489,9 +1430,7 @@ async def api_switch_branch(cid: str, msg_id: int):
 
 
 @app.post("/api/conversations/{cid}/messages/{msg_id}/regenerate")
-async def api_regenerate_msg(
-    cid: str, msg_id: int, request: Request, data: Optional[RegenerateMsg] = None
-):
+async def api_regenerate_msg(cid: str, msg_id: int, request: Request, data: Optional[RegenerateMsg] = None):
     """Regenerate a specific assistant message as a new sibling branch."""
     conv = await get_conversation(cid)
     if not conv:
@@ -1510,9 +1449,7 @@ async def api_regenerate_msg(
 
 
 @app.post("/api/conversations/{cid}/messages/{msg_id}/super_regenerate")
-async def api_super_regenerate_msg(
-    cid: str, msg_id: int, request: Request, data: Optional[RegenerateMsg] = None
-):
+async def api_super_regenerate_msg(cid: str, msg_id: int, request: Request, data: Optional[RegenerateMsg] = None):
     """Super-regenerate: keeps prior response as context, asks model for a different direction."""
     conv = await get_conversation(cid)
     if not conv:
@@ -1531,9 +1468,7 @@ async def api_super_regenerate_msg(
 
 
 @app.post("/api/conversations/{cid}/messages/{msg_id}/magic_rewrite")
-async def api_magic_rewrite_msg(
-    cid: str, msg_id: int, request: Request, data: MagicRewriteMsg
-):
+async def api_magic_rewrite_msg(cid: str, msg_id: int, request: Request, data: MagicRewriteMsg):
     """Magic rewrite: calls the LLM directly with a user-supplied direction, no agent passes."""
     conv = await get_conversation(cid)
     if not conv:
@@ -1606,9 +1541,7 @@ async def api_get_context_size(cid: str):
     settings = await get_settings()
     messages = await get_messages(cid)
     director = await get_director_state(cid) or {}
-    director_frags = [
-        f for f in await get_director_fragments() if f.get("enabled", True)
-    ]
+    director_frags = [f for f in await get_director_fragments() if f.get("enabled", True)]
     mood_frags = [f for f in await get_mood_fragments() if f.get("enabled", True)]
     lorebook_entries = await get_active_lorebook_entries()
 
@@ -1616,16 +1549,10 @@ async def api_get_context_size(cid: str):
     persona_id = settings.get("active_persona_id")
     active_persona = await get_user_persona(persona_id) if persona_id else None
     macros = Macros.from_settings(settings, conv["character_name"], active_persona)
-    user_desc = (
-        active_persona.get("description", "")
-        if active_persona
-        else settings.get("user_description", "")
-    )
+    user_desc = active_persona.get("description", "") if active_persona else settings.get("user_description", "")
 
     # Resolve character context
-    system_prompt, char_persona, mes_example = await resolve_char_context(
-        conv, settings
-    )
+    system_prompt, char_persona, mes_example = await resolve_char_context(conv, settings)
 
     # Measure each component individually
     sys_text = system_prompt or ""
@@ -1633,15 +1560,9 @@ async def api_get_context_size(cid: str):
     scenario_text = macros.resolve_message(conv.get("character_scenario", "") or "")
     mes_text = macros.resolve_message(mes_example or "")
     post_text = macros.resolve_message(
-        ""
-        if settings.get("prevent_prompt_overrides")
-        else (conv.get("post_history_instructions", "") or "")
+        "" if settings.get("prevent_prompt_overrides") else (conv.get("post_history_instructions", "") or "")
     )
-    user_persona_text = (
-        f"## User: {macros.user}\n{macros.resolve_message(user_desc)}"
-        if user_desc
-        else ""
-    )
+    user_persona_text = f"## User: {macros.user}\n{macros.resolve_message(user_desc)}" if user_desc else ""
     msg_chars = sum(len(m.get("content", "") or "") for m in messages)
 
     # Director injection
@@ -1657,12 +1578,8 @@ async def api_get_context_size(cid: str):
 
     # Lorebook injection
     scan_depth = prompt_builder.LOREBOOK_SCAN_DEPTH
-    recent_messages = (
-        messages[-scan_depth:] if len(messages) >= scan_depth else messages
-    )
-    lorebook_block = prompt_builder.compute_lorebook_injection_block(
-        recent_messages, lorebook_entries, macros
-    )
+    recent_messages = messages[-scan_depth:] if len(messages) >= scan_depth else messages
+    lorebook_block = prompt_builder.compute_lorebook_injection_block(recent_messages, lorebook_entries, macros)
 
     def est(chars):
         return max(1, round(chars / 3.5))
@@ -1703,9 +1620,7 @@ async def api_send_message(cid: str, data: SendMessage, request: Request):
     client_ref: list = []
     return _CleanupStreamingResponse(
         _sse_stream(
-            handle_turn(
-                cid, data.content, attachments=attachments, client_ref=client_ref
-            ),
+            handle_turn(cid, data.content, attachments=attachments, client_ref=client_ref),
             request,
             client_ref=client_ref,
             cid=cid,
@@ -1715,25 +1630,19 @@ async def api_send_message(cid: str, data: SendMessage, request: Request):
 
 
 @app.post("/api/conversations/{cid}/continue")
-async def api_continue_from_user(
-    cid: str, request: Request, data: Optional[RegenerateMsg] = None
-):
+async def api_continue_from_user(cid: str, request: Request, data: Optional[RegenerateMsg] = None):
     """Generate an assistant response for the current user turn without creating a new message."""
     conv = await get_conversation(cid)
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
     messages = await get_messages(cid)
     if not messages or messages[-1]["role"] != "user":
-        raise HTTPException(
-            status_code=400, detail="Last message is not a user message"
-        )
+        raise HTTPException(status_code=400, detail="Last message is not a user message")
     user_content = messages[-1]["content"]
     client_ref: list = []
     return _CleanupStreamingResponse(
         _sse_stream(
-            handle_turn(
-                cid, user_content, skip_user_persist=True, client_ref=client_ref
-            ),
+            handle_turn(cid, user_content, skip_user_persist=True, client_ref=client_ref),
             request,
             client_ref=client_ref,
             cid=cid,
@@ -1769,9 +1678,7 @@ async def api_tts_cache_evict():
 
 
 @app.get("/api/tts/voices")
-async def api_tts_voices(
-    backend: str = "edge", language: str = "", api_url: str = "", api_key: str = ""
-):
+async def api_tts_voices(backend: str = "edge", language: str = "", api_url: str = "", api_key: str = ""):
     """List available voices for a TTS backend."""
     try:
         adapter = get_adapter(backend)

--- a/backend/main.py
+++ b/backend/main.py
@@ -125,7 +125,9 @@ from .tts.cache import (
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-FRONTEND_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "frontend")
+FRONTEND_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "frontend"
+)
 
 
 _TTS_EVICT_INTERVAL = 30 * 60  # 30 minutes
@@ -579,7 +581,9 @@ async def api_list_mood_fragments():
 async def api_create_mood_fragment(data: MoodFragmentCreate):
     existing = await get_mood_fragment(data.id)
     if existing:
-        raise HTTPException(status_code=400, detail="Mood fragment with this ID already exists")
+        raise HTTPException(
+            status_code=400, detail="Mood fragment with this ID already exists"
+        )
     return await create_mood_fragment(data.model_dump())
 
 
@@ -594,7 +598,9 @@ async def api_update_mood_fragment(fid: str, data: MoodFragmentUpdate):
 @app.delete("/api/fragments/{fid}")
 async def api_delete_mood_fragment(fid: str):
     if not await delete_mood_fragment(fid):
-        raise HTTPException(status_code=404, detail="Mood fragment not found or is built-in")
+        raise HTTPException(
+            status_code=404, detail="Mood fragment not found or is built-in"
+        )
     return {"ok": True}
 
 
@@ -610,10 +616,14 @@ async def api_list_director_fragments():
 async def api_create_director_fragment(data: DirectorFragmentCreate):
     existing = await get_director_fragment(data.id)
     if existing:
-        raise HTTPException(status_code=400, detail="Director fragment with this ID already exists")
+        raise HTTPException(
+            status_code=400, detail="Director fragment with this ID already exists"
+        )
     result = await create_director_fragment(data.model_dump())
     if not result:
-        raise HTTPException(status_code=500, detail="Failed to create director fragment")
+        raise HTTPException(
+            status_code=500, detail="Failed to create director fragment"
+        )
     return result
 
 
@@ -670,7 +680,9 @@ async def require_world(world_id: str) -> dict:
     return world
 
 
-async def require_lorebook_entry(entry_id: int, world: dict = Depends(require_world)) -> dict:  # noqa: B008
+async def require_lorebook_entry(
+    entry_id: int, world: dict = Depends(require_world)
+) -> dict:  # noqa: B008
     entry = await get_lorebook_entry(entry_id)
     if not entry or entry.get("world_id") != world["id"]:
         raise HTTPException(status_code=404, detail="Entry not found")
@@ -683,7 +695,9 @@ async def api_list_lorebook_entries(world: dict = Depends(require_world)):  # no
 
 
 @app.post("/api/worlds/{world_id}/entries")
-async def api_create_lorebook_entry(data: LorebookEntryCreate, world: dict = Depends(require_world)):  # noqa: B008
+async def api_create_lorebook_entry(
+    data: LorebookEntryCreate, world: dict = Depends(require_world)
+):  # noqa: B008
     return await create_lorebook_entry(world["id"], data.model_dump())
 
 
@@ -699,7 +713,9 @@ async def api_update_lorebook_entry(
     data: LorebookEntryUpdate,
     entry: dict = Depends(require_lorebook_entry),  # noqa: B008
 ):
-    result = await update_lorebook_entry(entry["id"], data.model_dump(exclude_unset=True))
+    result = await update_lorebook_entry(
+        entry["id"], data.model_dump(exclude_unset=True)
+    )
     if not result:
         raise HTTPException(status_code=404, detail="Entry not found")
     return result
@@ -751,7 +767,9 @@ async def api_import_lorebook(world_id: str, payload: LorebookImportPayload):
         # Tavern V2 character_book: [...]
         items = raw_entries
     else:
-        raise HTTPException(status_code=422, detail="entries must be an object or array")
+        raise HTTPException(
+            status_code=422, detail="entries must be an object or array"
+        )
 
     created = []
     for item in items:
@@ -785,7 +803,9 @@ async def api_create_phrase_group(data: PhraseGroupCreate):
     # Validate all variants are strings
     for v in data.variants:
         if not isinstance(v, str) or not v.strip():
-            raise HTTPException(status_code=400, detail="All variants must be non-empty strings")
+            raise HTTPException(
+                status_code=400, detail="All variants must be non-empty strings"
+            )
     group_id = await add_phrase_group(data.variants)
     return {"id": group_id, "variants": data.variants}
 
@@ -798,7 +818,9 @@ async def api_update_phrase_group(group_id: int, data: PhraseGroupUpdate):
     # Validate all variants are strings
     for v in data.variants:
         if not isinstance(v, str) or not v.strip():
-            raise HTTPException(status_code=400, detail="All variants must be non-empty strings")
+            raise HTTPException(
+                status_code=400, detail="All variants must be non-empty strings"
+            )
     success = await update_phrase_group(group_id, data.variants)
     if not success:
         raise HTTPException(status_code=404, detail="Phrase group not found")
@@ -905,7 +927,9 @@ async def api_create_conversation(data: ConversationCreate):
 
     # If there's a first message, auto-add it as the first assistant turn
     if first_mes.strip():
-        msg_id = await add_message(cid, "assistant", first_mes.strip(), 0, attachments=None)
+        msg_id = await add_message(
+            cid, "assistant", first_mes.strip(), 0, attachments=None
+        )
         await set_active_leaf(cid, msg_id)
 
         # If we have a character card with alternate greetings, create swipe versions
@@ -915,7 +939,9 @@ async def api_create_conversation(data: ConversationCreate):
                 alternate_greetings = card.get("alternate_greetings", [])
                 count = await insert_alternate_greeting_swipes(cid, alternate_greetings)
                 if count:
-                    logger.info(f"Created {count} alternate greeting swipes for conversation {cid}")
+                    logger.info(
+                        f"Created {count} alternate greeting swipes for conversation {cid}"
+                    )
 
     return conv
 
@@ -945,10 +971,14 @@ async def api_update_conversation(cid: str, data: ConversationUpdate):
 
 
 @app.post("/api/conversations/{cid}/summarize")
-async def api_summarize_conversation(cid: str, data: SummarizeRequest, request: Request):
+async def api_summarize_conversation(
+    cid: str, data: SummarizeRequest, request: Request
+):
     """Stream a narrative summary of the conversation history, excluding the last keep_count messages."""
     if data.keep_count not in (2, 4, 6, 8):
-        raise HTTPException(status_code=400, detail="keep_count must be one of 2, 4, 6, 8")
+        raise HTTPException(
+            status_code=400, detail="keep_count must be one of 2, 4, 6, 8"
+        )
 
     conv = await get_conversation(cid)
     if not conv:
@@ -963,10 +993,18 @@ async def api_summarize_conversation(cid: str, data: SummarizeRequest, request: 
     settings = await get_settings()
     char_name = conv.get("character_name", "Character") or "Character"
     active_persona_id = settings.get("active_persona_id")
-    active_persona = await get_user_persona(active_persona_id) if active_persona_id else None
-    system_prompt, char_persona, mes_example = await resolve_char_context(conv, settings)
+    active_persona = (
+        await get_user_persona(active_persona_id) if active_persona_id else None
+    )
+    system_prompt, char_persona, mes_example = await resolve_char_context(
+        conv, settings
+    )
     macros = Macros.from_settings(settings, char_name, active_persona)
-    user_description = active_persona.get("description", "") if active_persona else settings.get("user_description", "")
+    user_description = (
+        active_persona.get("description", "")
+        if active_persona
+        else settings.get("user_description", "")
+    )
 
     client = LLMClient(
         settings["endpoint_url"],
@@ -979,7 +1017,11 @@ async def api_summarize_conversation(cid: str, data: SummarizeRequest, request: 
         char_persona,
         conv.get("character_scenario", "") or "",
         mes_example,
-        ("" if settings.get("prevent_prompt_overrides") else conv.get("post_history_instructions", "")),
+        (
+            ""
+            if settings.get("prevent_prompt_overrides")
+            else conv.get("post_history_instructions", "")
+        ),
         history_slice,
         macros,
         user_description,
@@ -988,7 +1030,9 @@ async def api_summarize_conversation(cid: str, data: SummarizeRequest, request: 
 
     async def _gen():
         try:
-            async for delta in summarizer.stream(llm_messages, settings.get("model_name", "")):
+            async for delta in summarizer.stream(
+                llm_messages, settings.get("model_name", "")
+            ):
                 yield {"event": "token", "data": delta}
             yield {"event": "done", "data": ""}
         except Exception as e:
@@ -1005,7 +1049,9 @@ async def api_summarize_conversation(cid: str, data: SummarizeRequest, request: 
 async def api_compress_conversation(cid: str, data: CompressRequest):
     """Create a new conversation seeded with a summary, then re-append the last keep_count messages."""
     if data.keep_count not in (2, 4, 6, 8):
-        raise HTTPException(status_code=400, detail="keep_count must be one of 2, 4, 6, 8")
+        raise HTTPException(
+            status_code=400, detail="keep_count must be one of 2, 4, 6, 8"
+        )
     if not data.summary.strip():
         raise HTTPException(status_code=400, detail="summary must not be empty")
 
@@ -1089,7 +1135,9 @@ async def api_create_character(data: CharacterCardCreate):
                 world = await create_world({"name": book_name})
                 for item in entries:
                     if isinstance(item, dict):
-                        await create_lorebook_entry(world["id"], _normalise_lorebook_entry(item))
+                        await create_lorebook_entry(
+                            world["id"], _normalise_lorebook_entry(item)
+                        )
             card_data["world_id"] = world["id"]
 
     try:
@@ -1102,7 +1150,9 @@ async def api_create_character(data: CharacterCardCreate):
 async def api_import_character(file: Annotated[UploadFile, File(...)]):
     """Import a SillyTavern-compatible character card PNG."""
     if not file.filename or not file.filename.lower().endswith(".png"):
-        raise HTTPException(status_code=400, detail="Only .png character card files are supported")
+        raise HTTPException(
+            status_code=400, detail="Only .png character card files are supported"
+        )
 
     # Save to temp file for the parser
     with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
@@ -1120,7 +1170,9 @@ async def api_import_character(file: Annotated[UploadFile, File(...)]):
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         logger.exception("Failed to parse tavern card")
-        raise HTTPException(status_code=400, detail=f"Failed to parse character card: {e}") from e
+        raise HTTPException(
+            status_code=400, detail=f"Failed to parse character card: {e}"
+        ) from e
     finally:
         os.unlink(tmp_path)
 
@@ -1193,7 +1245,9 @@ async def api_export_character(card_id: str):
         try:
             avatar_bytes = base64.b64decode(card["avatar_b64"])
         except Exception:
-            logger.warning("Avatar data for card %s is corrupt; exporting without avatar", card_id)
+            logger.warning(
+                "Avatar data for card %s is corrupt; exporting without avatar", card_id
+            )
             avatar_bytes = None
 
     card["id"] = card_id
@@ -1223,7 +1277,12 @@ async def api_export_character(card_id: str):
 
     png_bytes = tavern_cards.to_png(card, avatar_bytes)
 
-    safe_name = "".join(c for c in card.get("name", "character") if c.isalnum() or c in " _-").strip() or "character"
+    safe_name = (
+        "".join(
+            c for c in card.get("name", "character") if c.isalnum() or c in " _-"
+        ).strip()
+        or "character"
+    )
     return Response(
         content=png_bytes,
         media_type="image/png",
@@ -1430,7 +1489,9 @@ async def api_switch_branch(cid: str, msg_id: int):
 
 
 @app.post("/api/conversations/{cid}/messages/{msg_id}/regenerate")
-async def api_regenerate_msg(cid: str, msg_id: int, request: Request, data: Optional[RegenerateMsg] = None):
+async def api_regenerate_msg(
+    cid: str, msg_id: int, request: Request, data: Optional[RegenerateMsg] = None
+):
     """Regenerate a specific assistant message as a new sibling branch."""
     conv = await get_conversation(cid)
     if not conv:
@@ -1449,7 +1510,9 @@ async def api_regenerate_msg(cid: str, msg_id: int, request: Request, data: Opti
 
 
 @app.post("/api/conversations/{cid}/messages/{msg_id}/super_regenerate")
-async def api_super_regenerate_msg(cid: str, msg_id: int, request: Request, data: Optional[RegenerateMsg] = None):
+async def api_super_regenerate_msg(
+    cid: str, msg_id: int, request: Request, data: Optional[RegenerateMsg] = None
+):
     """Super-regenerate: keeps prior response as context, asks model for a different direction."""
     conv = await get_conversation(cid)
     if not conv:
@@ -1468,7 +1531,9 @@ async def api_super_regenerate_msg(cid: str, msg_id: int, request: Request, data
 
 
 @app.post("/api/conversations/{cid}/messages/{msg_id}/magic_rewrite")
-async def api_magic_rewrite_msg(cid: str, msg_id: int, request: Request, data: MagicRewriteMsg):
+async def api_magic_rewrite_msg(
+    cid: str, msg_id: int, request: Request, data: MagicRewriteMsg
+):
     """Magic rewrite: calls the LLM directly with a user-supplied direction, no agent passes."""
     conv = await get_conversation(cid)
     if not conv:
@@ -1541,7 +1606,9 @@ async def api_get_context_size(cid: str):
     settings = await get_settings()
     messages = await get_messages(cid)
     director = await get_director_state(cid) or {}
-    director_frags = [f for f in await get_director_fragments() if f.get("enabled", True)]
+    director_frags = [
+        f for f in await get_director_fragments() if f.get("enabled", True)
+    ]
     mood_frags = [f for f in await get_mood_fragments() if f.get("enabled", True)]
     lorebook_entries = await get_active_lorebook_entries()
 
@@ -1549,10 +1616,16 @@ async def api_get_context_size(cid: str):
     persona_id = settings.get("active_persona_id")
     active_persona = await get_user_persona(persona_id) if persona_id else None
     macros = Macros.from_settings(settings, conv["character_name"], active_persona)
-    user_desc = active_persona.get("description", "") if active_persona else settings.get("user_description", "")
+    user_desc = (
+        active_persona.get("description", "")
+        if active_persona
+        else settings.get("user_description", "")
+    )
 
     # Resolve character context
-    system_prompt, char_persona, mes_example = await resolve_char_context(conv, settings)
+    system_prompt, char_persona, mes_example = await resolve_char_context(
+        conv, settings
+    )
 
     # Measure each component individually
     sys_text = system_prompt or ""
@@ -1560,9 +1633,15 @@ async def api_get_context_size(cid: str):
     scenario_text = macros.resolve_message(conv.get("character_scenario", "") or "")
     mes_text = macros.resolve_message(mes_example or "")
     post_text = macros.resolve_message(
-        "" if settings.get("prevent_prompt_overrides") else (conv.get("post_history_instructions", "") or "")
+        ""
+        if settings.get("prevent_prompt_overrides")
+        else (conv.get("post_history_instructions", "") or "")
     )
-    user_persona_text = f"## User: {macros.user}\n{macros.resolve_message(user_desc)}" if user_desc else ""
+    user_persona_text = (
+        f"## User: {macros.user}\n{macros.resolve_message(user_desc)}"
+        if user_desc
+        else ""
+    )
     msg_chars = sum(len(m.get("content", "") or "") for m in messages)
 
     # Director injection
@@ -1578,8 +1657,12 @@ async def api_get_context_size(cid: str):
 
     # Lorebook injection
     scan_depth = prompt_builder.LOREBOOK_SCAN_DEPTH
-    recent_messages = messages[-scan_depth:] if len(messages) >= scan_depth else messages
-    lorebook_block = prompt_builder.compute_lorebook_injection_block(recent_messages, lorebook_entries, macros)
+    recent_messages = (
+        messages[-scan_depth:] if len(messages) >= scan_depth else messages
+    )
+    lorebook_block = prompt_builder.compute_lorebook_injection_block(
+        recent_messages, lorebook_entries, macros
+    )
 
     def est(chars):
         return max(1, round(chars / 3.5))
@@ -1620,7 +1703,9 @@ async def api_send_message(cid: str, data: SendMessage, request: Request):
     client_ref: list = []
     return _CleanupStreamingResponse(
         _sse_stream(
-            handle_turn(cid, data.content, attachments=attachments, client_ref=client_ref),
+            handle_turn(
+                cid, data.content, attachments=attachments, client_ref=client_ref
+            ),
             request,
             client_ref=client_ref,
             cid=cid,
@@ -1630,19 +1715,25 @@ async def api_send_message(cid: str, data: SendMessage, request: Request):
 
 
 @app.post("/api/conversations/{cid}/continue")
-async def api_continue_from_user(cid: str, request: Request, data: Optional[RegenerateMsg] = None):
+async def api_continue_from_user(
+    cid: str, request: Request, data: Optional[RegenerateMsg] = None
+):
     """Generate an assistant response for the current user turn without creating a new message."""
     conv = await get_conversation(cid)
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
     messages = await get_messages(cid)
     if not messages or messages[-1]["role"] != "user":
-        raise HTTPException(status_code=400, detail="Last message is not a user message")
+        raise HTTPException(
+            status_code=400, detail="Last message is not a user message"
+        )
     user_content = messages[-1]["content"]
     client_ref: list = []
     return _CleanupStreamingResponse(
         _sse_stream(
-            handle_turn(cid, user_content, skip_user_persist=True, client_ref=client_ref),
+            handle_turn(
+                cid, user_content, skip_user_persist=True, client_ref=client_ref
+            ),
             request,
             client_ref=client_ref,
             cid=cid,
@@ -1678,7 +1769,9 @@ async def api_tts_cache_evict():
 
 
 @app.get("/api/tts/voices")
-async def api_tts_voices(backend: str = "edge", language: str = "", api_url: str = "", api_key: str = ""):
+async def api_tts_voices(
+    backend: str = "edge", language: str = "", api_url: str = "", api_key: str = ""
+):
     """List available voices for a TTS backend."""
     try:
         adapter = get_adapter(backend)
@@ -1826,7 +1919,7 @@ async def api_speak_message(cid: str, msg_id: int):
             adapter=adapter,
         )
     except ValueError:
-        raise HTTPException(500, "TTS synthesis produced no audio")
+        raise HTTPException(400, "No dialogue found for TTS")
 
     return Response(
         content=audio_bytes,
@@ -1855,6 +1948,16 @@ async def api_speak_chunk(cid: str, msg_id: int, data: SpeakChunkRequest):
     """Generate TTS audio for a single chunk of a message."""
     msg, conv, card_id, profile, adapter = await _get_tts_context(cid, msg_id)
 
+    # Validate chunk_index before cache lookup
+    chunks_meta = chunk_metadata(msg["content"], profile, adapter)
+    if not chunks_meta:
+        raise HTTPException(400, "No speakable chunks in this message")
+    if data.chunk_index < 0 or data.chunk_index >= len(chunks_meta):
+        raise HTTPException(
+            400,
+            f"chunk_index {data.chunk_index} out of range (0-{len(chunks_meta) - 1})",
+        )
+
     # Check per-chunk cache
     _cp = cache_chunk_path(cid, msg_id, data.chunk_index, profile, msg["content"])
     if os.path.exists(_cp):
@@ -1881,10 +1984,8 @@ async def api_speak_chunk(cid: str, msg_id: int, data: SpeakChunkRequest):
             content=msg["content"],
             adapter=adapter,
         )
-    except IndexError as e:
-        raise HTTPException(400, str(e))
     except ValueError:
-        raise HTTPException(500, "TTS synthesis produced no audio")
+        raise HTTPException(400, "No dialogue found for TTS")
 
     return Response(
         content=audio_bytes,

--- a/backend/main.py
+++ b/backend/main.py
@@ -108,15 +108,18 @@ from . import prompt_builder
 from .summarizer import ConversationSummarizer
 from .tts import get_adapter, list_backends
 from .tts.cache import (
+    cache_chunk_path,
     cache_media_type,
     cache_meta_path,
     cache_path,
     cache_stats,
+    chunk_metadata,
     invalidate_cache_for_card,
     invalidate_cache_for_conversation,
     metadata_headers,
     run_eviction_cycle,
     synthesize_and_cache,
+    synthesize_and_cache_chunk,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -845,6 +848,10 @@ async def api_delete_user_persona(persona_id: int):
 
 class ResetConfirm(BaseModel):
     confirm: bool
+
+
+class SpeakChunkRequest(BaseModel):
+    chunk_index: int
 
 
 @app.post("/api/reset")
@@ -1752,17 +1759,18 @@ async def api_update_voice_profile(card_id: str, body: dict):
     return profile
 
 
-@app.post("/api/conversations/{cid}/messages/{msg_id}/speak")
-async def api_speak_message(cid: str, msg_id: int):
-    """Generate TTS audio for a message. Returns MP3 audio."""
-    # Validate message exists and belongs to conversation
+async def _get_tts_context(cid: str, msg_id: int) -> tuple:
+    """Shared validation for TTS endpoints.
+
+    Returns (msg, conv, card_id, profile, adapter).
+    Raises HTTPException on validation failure.
+    """
     msg = await get_message_by_id(msg_id)
     if not msg or msg["conversation_id"] != cid:
         raise HTTPException(404, "Message not found")
     if msg["role"] != "assistant":
         raise HTTPException(400, "TTS is only available for assistant messages")
 
-    # Get conversation and character
     conv = await get_conversation(cid)
     if not conv:
         raise HTTPException(404, "Conversation not found")
@@ -1771,15 +1779,26 @@ async def api_speak_message(cid: str, msg_id: int):
     if not card_id:
         raise HTTPException(400, "No character associated with this conversation")
 
-    # Check global TTS toggle
     settings = await get_settings()
     if not settings.get("tts_enabled"):
         raise HTTPException(403, "TTS is disabled in settings")
 
-    # Get voice profile
     profile = await get_voice_profile(card_id)
     if not profile or not profile.get("enabled"):
         raise HTTPException(400, "TTS not enabled for this character")
+
+    try:
+        adapter = get_adapter(profile["backend"])
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+    return msg, conv, card_id, profile, adapter
+
+
+@app.post("/api/conversations/{cid}/messages/{msg_id}/speak")
+async def api_speak_message(cid: str, msg_id: int):
+    """Generate TTS audio for a message. Returns MP3 audio."""
+    msg, conv, card_id, profile, adapter = await _get_tts_context(cid, msg_id)
 
     # Check cache
     _cache_path = cache_path(cid, msg_id, profile, msg["content"])
@@ -1797,12 +1816,6 @@ async def api_speak_message(cid: str, msg_id: int):
             headers=metadata_headers(metadata),
         )
 
-    # Get TTS adapter
-    try:
-        adapter = get_adapter(profile["backend"])
-    except ValueError as e:
-        raise HTTPException(400, str(e))
-
     # Synthesize and cache
     try:
         audio_bytes, content_type, metadata, _cp = await synthesize_and_cache(
@@ -1812,6 +1825,64 @@ async def api_speak_message(cid: str, msg_id: int):
             content=msg["content"],
             adapter=adapter,
         )
+    except ValueError:
+        raise HTTPException(500, "TTS synthesis produced no audio")
+
+    return Response(
+        content=audio_bytes,
+        media_type=content_type,
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            **metadata_headers(metadata),
+        },
+    )
+
+
+@app.get("/api/conversations/{cid}/messages/{msg_id}/chunks")
+async def api_get_message_chunks(cid: str, msg_id: int):
+    """Get chunk metadata for a message's TTS extraction."""
+    msg, conv, card_id, profile, adapter = await _get_tts_context(cid, msg_id)
+
+    chunks = chunk_metadata(msg["content"], profile, adapter)
+    return {
+        "chunks": chunks,
+        "extraction_method": "regex",
+    }
+
+
+@app.post("/api/conversations/{cid}/messages/{msg_id}/speak-chunk")
+async def api_speak_chunk(cid: str, msg_id: int, data: SpeakChunkRequest):
+    """Generate TTS audio for a single chunk of a message."""
+    msg, conv, card_id, profile, adapter = await _get_tts_context(cid, msg_id)
+
+    # Check per-chunk cache
+    _cp = cache_chunk_path(cid, msg_id, data.chunk_index, profile, msg["content"])
+    if os.path.exists(_cp):
+        media_type, ext = cache_media_type(profile)
+        metadata: dict = {}
+        meta_path = cache_meta_path(_cp)
+        if os.path.exists(meta_path):
+            with open(meta_path, "r", encoding="utf-8") as f:
+                metadata = json.load(f)
+        return FileResponse(
+            _cp,
+            media_type=media_type,
+            filename=f"msg_{msg_id}_chunk{data.chunk_index}.{ext}",
+            headers=metadata_headers(metadata),
+        )
+
+    # Synthesize single chunk
+    try:
+        audio_bytes, content_type, metadata, _cp = await synthesize_and_cache_chunk(
+            cid=cid,
+            msg_id=msg_id,
+            chunk_index=data.chunk_index,
+            profile=profile,
+            content=msg["content"],
+            adapter=adapter,
+        )
+    except IndexError as e:
+        raise HTTPException(400, str(e))
     except ValueError:
         raise HTTPException(500, "TTS synthesis produced no audio")
 

--- a/backend/tts/cache.py
+++ b/backend/tts/cache.py
@@ -19,7 +19,9 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .base import TTSAdapter
 
-TTS_CACHE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "tts_cache")
+TTS_CACHE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "data", "tts_cache"
+)
 
 
 def cache_media_type(profile: dict) -> tuple[str, str]:
@@ -135,7 +137,9 @@ def evict_expired(ttl_seconds: int = DEFAULT_TTL_SECONDS) -> int:
                 pass
     _prune_empty_dirs()
     if removed:
-        logger.info("TTS cache TTL eviction: removed %d files (ttl=%ds)", removed, ttl_seconds)
+        logger.info(
+            "TTS cache TTL eviction: removed %d files (ttl=%ds)", removed, ttl_seconds
+        )
     return removed
 
 
@@ -230,6 +234,8 @@ def chunk_metadata(content: str, profile: dict, adapter: "TTSAdapter") -> list[d
     Returns list of dicts with index, text, original_text, emotion,
     pause_before_ms, pause_after_ms.
     """
+    import re
+
     from .regex_extractor import regex_extract
 
     chunks = regex_extract(
@@ -238,15 +244,26 @@ def chunk_metadata(content: str, profile: dict, adapter: "TTSAdapter") -> list[d
         supports_emotion_tags=adapter.supports_emotion_tags,
     )
 
+    # Extract source quoted spans from original (uncleaned) content
+    # to get exact text matching the DOM's <span class="quoted"> elements.
+    # The extractor strips parentheticals and modifies text before quoting,
+    # so chunk.text can diverge from what formatProse() renders.
+    _re_quoted = re.compile(r'["\u201c]([^"\u201d]+)["\u201d]')
+    source_spans = [m.group(1).strip() for m in _re_quoted.finditer(content)]
+
     result = []
     for i, c in enumerate(chunks):
-        # For DOM matching: original_text is the dialogue without beat tags
-        # chunk.text may have tags like "[laugh] Hello" prepended
-        # We need the raw dialogue text for matching <span class="quoted"> in the DOM
-        original = c.text
         # Strip leading beat tags (format: "[tag] dialogue text")
+        original = c.text
         if original.startswith("[") and "] " in original:
             original = original[original.index("] ") + 2 :]
+
+        # If available, use the original source span text for DOM matching.
+        # This preserves parentheticals and other content that the extractor
+        # strips but formatProse() renders inside <span class="quoted">.
+        if i < len(source_spans):
+            original = source_spans[i]
+
         result.append(
             {
                 "index": i,
@@ -260,7 +277,9 @@ def chunk_metadata(content: str, profile: dict, adapter: "TTSAdapter") -> list[d
     return result
 
 
-def cache_chunk_path(cid: str, msg_id: int, chunk_index: int, profile: dict, content: str = "") -> str:
+def cache_chunk_path(
+    cid: str, msg_id: int, chunk_index: int, profile: dict, content: str = ""
+) -> str:
     """Cache path for a single chunk, keyed by chunk index + content + voice config."""
     media_type, ext = cache_media_type(profile)
     fingerprint = hashlib.md5(
@@ -270,7 +289,9 @@ def cache_chunk_path(cid: str, msg_id: int, chunk_index: int, profile: dict, con
         f"{profile.get('model', '')}|{media_type}|{content}".encode(),
         usedforsecurity=False,
     ).hexdigest()[:8]
-    return os.path.join(TTS_CACHE_DIR, cid, f"{msg_id}_c{chunk_index}_{fingerprint}.{ext}")
+    return os.path.join(
+        TTS_CACHE_DIR, cid, f"{msg_id}_c{chunk_index}_{fingerprint}.{ext}"
+    )
 
 
 async def synthesize_and_cache_chunk(
@@ -296,7 +317,9 @@ async def synthesize_and_cache_chunk(
     )
 
     if chunk_index < 0 or chunk_index >= len(chunks):
-        raise IndexError(f"chunk_index {chunk_index} out of range (0-{len(chunks) - 1})")
+        raise IndexError(
+            f"chunk_index {chunk_index} out of range (0-{len(chunks) - 1})"
+        )
 
     chunk = chunks[chunk_index]
 

--- a/backend/tts/cache.py
+++ b/backend/tts/cache.py
@@ -19,9 +19,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .base import TTSAdapter
 
-TTS_CACHE_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(__file__)), "data", "tts_cache"
-)
+TTS_CACHE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "tts_cache")
 
 
 def cache_media_type(profile: dict) -> tuple[str, str]:
@@ -137,9 +135,7 @@ def evict_expired(ttl_seconds: int = DEFAULT_TTL_SECONDS) -> int:
                 pass
     _prune_empty_dirs()
     if removed:
-        logger.info(
-            "TTS cache TTL eviction: removed %d files (ttl=%ds)", removed, ttl_seconds
-        )
+        logger.info("TTS cache TTL eviction: removed %d files (ttl=%ds)", removed, ttl_seconds)
     return removed
 
 
@@ -277,9 +273,7 @@ def chunk_metadata(content: str, profile: dict, adapter: "TTSAdapter") -> list[d
     return result
 
 
-def cache_chunk_path(
-    cid: str, msg_id: int, chunk_index: int, profile: dict, content: str = ""
-) -> str:
+def cache_chunk_path(cid: str, msg_id: int, chunk_index: int, profile: dict, content: str = "") -> str:
     """Cache path for a single chunk, keyed by chunk index + content + voice config."""
     media_type, ext = cache_media_type(profile)
     fingerprint = hashlib.md5(
@@ -289,9 +283,7 @@ def cache_chunk_path(
         f"{profile.get('model', '')}|{media_type}|{content}".encode(),
         usedforsecurity=False,
     ).hexdigest()[:8]
-    return os.path.join(
-        TTS_CACHE_DIR, cid, f"{msg_id}_c{chunk_index}_{fingerprint}.{ext}"
-    )
+    return os.path.join(TTS_CACHE_DIR, cid, f"{msg_id}_c{chunk_index}_{fingerprint}.{ext}")
 
 
 async def synthesize_and_cache_chunk(
@@ -317,9 +309,7 @@ async def synthesize_and_cache_chunk(
     )
 
     if chunk_index < 0 or chunk_index >= len(chunks):
-        raise IndexError(
-            f"chunk_index {chunk_index} out of range (0-{len(chunks) - 1})"
-        )
+        raise IndexError(f"chunk_index {chunk_index} out of range (0-{len(chunks) - 1})")
 
     chunk = chunks[chunk_index]
 

--- a/backend/tts/cache.py
+++ b/backend/tts/cache.py
@@ -224,6 +224,114 @@ def _prune_empty_dirs() -> None:
                 pass
 
 
+def chunk_metadata(content: str, profile: dict, adapter: "TTSAdapter") -> list[dict]:
+    """Extract chunk metadata for a message.
+
+    Returns list of dicts with index, text, original_text, emotion,
+    pause_before_ms, pause_after_ms.
+    """
+    from .regex_extractor import regex_extract
+
+    chunks = regex_extract(
+        text=content,
+        backend_type=profile.get("backend", "edge"),
+        supports_emotion_tags=adapter.supports_emotion_tags,
+    )
+
+    result = []
+    for i, c in enumerate(chunks):
+        # For DOM matching: original_text is the dialogue without beat tags
+        # chunk.text may have tags like "[laugh] Hello" prepended
+        # We need the raw dialogue text for matching <span class="quoted"> in the DOM
+        original = c.text
+        # Strip leading beat tags (format: "[tag] dialogue text")
+        if original.startswith("[") and "] " in original:
+            original = original[original.index("] ") + 2 :]
+        result.append(
+            {
+                "index": i,
+                "text": c.text,
+                "original_text": original,
+                "emotion": c.emotion,
+                "pause_before_ms": c.pause_before_ms,
+                "pause_after_ms": c.pause_after_ms,
+            }
+        )
+    return result
+
+
+def cache_chunk_path(cid: str, msg_id: int, chunk_index: int, profile: dict, content: str = "") -> str:
+    """Cache path for a single chunk, keyed by chunk index + content + voice config."""
+    media_type, ext = cache_media_type(profile)
+    fingerprint = hashlib.md5(
+        f"chunk:{chunk_index}|{profile.get('backend', '')}|{profile.get('voice_id', '')}|"
+        f"{profile.get('language', '')}|{profile.get('rate', '')}|{profile.get('pitch', '')}|"
+        f"{profile.get('api_url', '')}|"
+        f"{profile.get('model', '')}|{media_type}|{content}".encode(),
+        usedforsecurity=False,
+    ).hexdigest()[:8]
+    return os.path.join(TTS_CACHE_DIR, cid, f"{msg_id}_c{chunk_index}_{fingerprint}.{ext}")
+
+
+async def synthesize_and_cache_chunk(
+    cid: str,
+    msg_id: int,
+    chunk_index: int,
+    profile: dict,
+    content: str,
+    adapter: "TTSAdapter",
+) -> tuple[bytes, str, dict[str, str], str]:
+    """Synthesize a single TTS chunk, cache it, and return result data.
+
+    Returns (audio_bytes, content_type, metadata, cache_file_path).
+    Raises ValueError when synthesis produces no audio.
+    Raises IndexError when chunk_index is out of range.
+    """
+    from .regex_extractor import regex_extract
+
+    chunks = regex_extract(
+        text=content,
+        backend_type=profile.get("backend", "edge"),
+        supports_emotion_tags=adapter.supports_emotion_tags,
+    )
+
+    if chunk_index < 0 or chunk_index >= len(chunks):
+        raise IndexError(f"chunk_index {chunk_index} out of range (0-{len(chunks) - 1})")
+
+    chunk = chunks[chunk_index]
+
+    md: dict = {
+        "extraction_method": "regex",
+        "chunk_index": chunk_index,
+        "chunk_text": chunk.text,
+    }
+
+    # Synthesize just this one chunk
+    result = await adapter.synthesize(
+        chunks=[chunk],
+        voice_id=profile.get("voice_id", "en-US-JennyNeural"),
+        language=profile.get("language", "en-US"),
+        rate=profile.get("rate", 1.0),
+        pitch=profile.get("pitch", 1.0),
+        api_url=profile.get("api_url", ""),
+        api_key=profile.get("api_key", "") or None,
+        model=profile.get("model", ""),
+    )
+
+    if not result.audio_bytes:
+        raise ValueError("TTS synthesis produced no audio")
+
+    # Cache
+    _cp = cache_chunk_path(cid, msg_id, chunk_index, profile, content)
+    os.makedirs(os.path.dirname(_cp), exist_ok=True)
+    with open(_cp, "wb") as f:
+        f.write(result.audio_bytes)
+    with open(cache_meta_path(_cp), "w", encoding="utf-8") as f:
+        json.dump(md, f, ensure_ascii=False)
+
+    return result.audio_bytes, result.content_type, md, _cp
+
+
 async def synthesize_and_cache(
     cid: str,
     msg_id: int,

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -30,6 +30,8 @@ Clicking the speaker icon on a character message, or enabling auto-speak for new
 2. **TTS Synthesis** — the speakable text is sent to the configured backend (Edge TTS, OpenAI-compatible, Fish Speech, ElevenLabs, Kokoro-82M).
 3. **Playback** — the generated audio plays in-browser; results are cached on disk so repeated plays are instant.
 
+Clicking a **quoted dialogue line** in an assistant message speaks just that line (click-to-speak). Chunks are fetched on first click and cached in the DOM. The currently spoken line gets a subtle highlight during playback (karaoke mode).
+
 ## Available Backends
 
 | Backend | Install | API Key | Voices | Models | Notes |

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -47,6 +47,31 @@ export async function speakMessage(convId, msgId) {
   };
 }
 
+export async function getMessageChunks(convId, msgId) {
+  const r = await fetch(`/api/conversations/${convId}/messages/${msgId}/chunks`);
+  if (!r.ok) {
+    const err = new Error(await r.text());
+    err.status = r.status;
+    throw err;
+  }
+  return r.json();
+}
+
+export async function speakChunk(convId, msgId, chunkIndex) {
+  const r = await fetch(`/api/conversations/${convId}/messages/${msgId}/speak-chunk`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ chunk_index: chunkIndex }),
+  });
+  if (!r.ok) {
+    const err = new Error(await r.text());
+    err.status = r.status;
+    throw err;
+  }
+  const blob = await r.blob();
+  return { audioUrl: URL.createObjectURL(blob) };
+}
+
 export async function getTtsBackends() {
   const r = await fetch("/api/tts/backends");
   if (!r.ok) return [];

--- a/frontend/chat.js
+++ b/frontend/chat.js
@@ -2096,10 +2096,13 @@ async function playNextChunk() {
   }
 
   // Highlight current chunk
-  S.speakingChunkIdx = chunkIdx;
+  S.speakingChunkIdx = currentIdx;
   S.speakingChunkTotal = chunks.length;
   highlightChunk(msgId, chunkIdx);
 
+  // Reset time/duration for new chunk (prevents stale progress from previous)
+  S.ttsCurrentTime = 0;
+  S.ttsDuration = 0;
   S.ttsLoading = true;
   refreshTtsBar();
 

--- a/frontend/chat.js
+++ b/frontend/chat.js
@@ -1916,6 +1916,8 @@ const _chunkQueue = {
   audio: null,
   timer: null,
   audioUrl: null,
+  // Prefetch state for full-message sequential playback
+  _prefetch: null, // { chunkIdx, promise } — resolved { audioUrl }
 };
 
 function resetTtsPlaybackState() {
@@ -2054,6 +2056,9 @@ function _stopChunkQueue() {
     URL.revokeObjectURL(_chunkQueue.audioUrl);
     _chunkQueue.audioUrl = null;
   }
+  if (_chunkQueue._prefetch) {
+    _chunkQueue._prefetch = null; // let GC collect the blob URL after promise resolves
+  }
   const prevMsgId = _chunkQueue.msgId;
   _chunkQueue.msgId = null;
   _chunkQueue.chunks = [];
@@ -2099,7 +2104,18 @@ async function playNextChunk() {
   refreshTtsBar();
 
   try {
-    const { audioUrl } = await apiSpeakChunk(S.activeConvId, msgId, chunkIdx);
+    // Use prefetched audio if available and still valid, otherwise fetch
+    const isMultiChunk = chunks.length > 1;
+    let audioUrl;
+
+    if (_chunkQueue._prefetch && _chunkQueue._prefetch.chunkIdx === chunkIdx) {
+      audioUrl = (await _chunkQueue._prefetch.promise).audioUrl;
+      _chunkQueue._prefetch = null;
+    } else {
+      const result = await apiSpeakChunk(S.activeConvId, msgId, chunkIdx);
+      audioUrl = result.audioUrl;
+    }
+
     if (_chunkQueue.playbackId !== myPlaybackId) {
       URL.revokeObjectURL(audioUrl);
       return;
@@ -2109,6 +2125,16 @@ async function playNextChunk() {
     audio.volume = Math.max(0, Math.min(1, S.ttsVolume ?? 0.75));
     _chunkQueue.audio = audio;
     _chunkQueue.audioUrl = audioUrl;
+
+    // Prefetch next chunk during playback (only for full-message queue)
+    if (isMultiChunk && currentIdx + 1 < chunks.length) {
+      const nextChunkIdx = chunks[currentIdx + 1];
+      const prefetchPromise = apiSpeakChunk(S.activeConvId, msgId, nextChunkIdx).catch(() => null);
+      _chunkQueue._prefetch = {
+        chunkIdx: nextChunkIdx,
+        promise: prefetchPromise,
+      };
+    }
 
     audio.onloadedmetadata = () => {
       if (_chunkQueue.playbackId !== myPlaybackId) return;

--- a/frontend/chat.js
+++ b/frontend/chat.js
@@ -1907,6 +1907,11 @@ export function hideAvatarPopup() {
 // ── TTS / Speak ──────────────────────────────────────────────
 
 let _currentAudio = null; // Used for monolithic fallback playback
+let _currentAudioUrl = null; // Blob URL for monolithic audio — must revoke on cleanup
+
+// Monotonically increasing token for the whole TTS subsystem.
+// Incremented by stopSpeaking(), speakMessageAction(), and playChunkQueue().
+let _ttsGeneration = 0;
 
 const _chunkQueue = {
   playbackId: 0,
@@ -1917,7 +1922,7 @@ const _chunkQueue = {
   timer: null,
   audioUrl: null,
   // Prefetch state for full-message sequential playback
-  _prefetch: null, // { chunkIdx, promise } — resolved { audioUrl }
+  _prefetch: null, // { chunkIdx, promise, revoked } — resolved { audioUrl }
 };
 
 function resetTtsPlaybackState() {
@@ -2012,7 +2017,7 @@ function onQuotedSpanClick(e) {
     e.preventDefault();
     playSingleChunk(msgId, Number(chunkIdxAttr));
   } else {
-    // Not annotated yet — fetch chunks, annotate, find the clicked span, play it
+    // Not annotated yet — fetch chunks, annotate, read back the span's chunk idx
     e.preventDefault();
     (async () => {
       try {
@@ -2023,13 +2028,10 @@ function onQuotedSpanClick(e) {
         }
         S.chunkAnnotations[msgId] = data.chunks;
         annotateChunkSpans(msgId, data.chunks);
-        // Re-query the span — it may now have data-chunk-idx
-        const reQueried = msgEl.querySelector(`.msg-body span.quoted[data-original-click-target]`);
-        // Match the clicked span to a chunk by its text
-        const clickedText = span.textContent.replace(/^[\u201c"]|[\u201d"]$/g, "").trim();
-        const matchedChunk = data.chunks.find((c) => c.original_text.trim() === clickedText);
-        if (matchedChunk != null) {
-          playSingleChunk(msgId, matchedChunk.index);
+        // After annotation, the clicked span should now have data-chunk-idx
+        const assignedIdx = span.getAttribute("data-chunk-idx");
+        if (assignedIdx != null) {
+          playSingleChunk(msgId, Number(assignedIdx));
         } else {
           toast("Could not match dialogue line to TTS chunk", "error");
         }
@@ -2056,8 +2058,11 @@ function _stopChunkQueue() {
     URL.revokeObjectURL(_chunkQueue.audioUrl);
     _chunkQueue.audioUrl = null;
   }
+  // Revoke any prefetched blob URL that hasn't been consumed
   if (_chunkQueue._prefetch) {
-    _chunkQueue._prefetch = null; // let GC collect the blob URL after promise resolves
+    const pf = _chunkQueue._prefetch;
+    pf.revoked = true; // signal to the .then() handler to revoke when resolved
+    _chunkQueue._prefetch = null;
   }
   const prevMsgId = _chunkQueue.msgId;
   _chunkQueue.msgId = null;
@@ -2112,8 +2117,15 @@ async function playNextChunk() {
     let audioUrl;
 
     if (_chunkQueue._prefetch && _chunkQueue._prefetch.chunkIdx === chunkIdx) {
-      audioUrl = (await _chunkQueue._prefetch.promise).audioUrl;
+      // Treat failed prefetch as cache miss — fall back to normal fetch
+      const prefetched = await _chunkQueue._prefetch.promise;
       _chunkQueue._prefetch = null;
+      if (prefetched?.audioUrl) {
+        audioUrl = prefetched.audioUrl;
+      } else {
+        const result = await apiSpeakChunk(S.activeConvId, msgId, chunkIdx);
+        audioUrl = result.audioUrl;
+      }
     } else {
       const result = await apiSpeakChunk(S.activeConvId, msgId, chunkIdx);
       audioUrl = result.audioUrl;
@@ -2132,11 +2144,17 @@ async function playNextChunk() {
     // Prefetch next chunk during playback (only for full-message queue)
     if (isMultiChunk && currentIdx + 1 < chunks.length) {
       const nextChunkIdx = chunks[currentIdx + 1];
-      const prefetchPromise = apiSpeakChunk(S.activeConvId, msgId, nextChunkIdx).catch(() => null);
-      _chunkQueue._prefetch = {
-        chunkIdx: nextChunkIdx,
-        promise: prefetchPromise,
-      };
+      const prefetchEntry = { chunkIdx: nextChunkIdx, promise: null, revoked: false };
+      prefetchEntry.promise = apiSpeakChunk(S.activeConvId, msgId, nextChunkIdx)
+        .catch(() => null)
+        .then((result) => {
+          // If the queue was stopped while we were fetching, revoke the blob URL
+          if (prefetchEntry.revoked && result?.audioUrl) {
+            URL.revokeObjectURL(result.audioUrl);
+          }
+          return result;
+        });
+      _chunkQueue._prefetch = prefetchEntry;
     }
 
     audio.onloadedmetadata = () => {
@@ -2191,11 +2209,16 @@ async function playNextChunk() {
 
 function playChunkQueue(msgId, chunkIndices) {
   const previousMsgId = S.speakingMsgId;
+  _ttsGeneration++;
   _stopChunkQueue();
   // Also stop monolithic audio if running
   if (_currentAudio) {
     _currentAudio.pause();
     _currentAudio = null;
+  }
+  if (_currentAudioUrl) {
+    URL.revokeObjectURL(_currentAudioUrl);
+    _currentAudioUrl = null;
   }
   clearAllHighlights(previousMsgId);
 
@@ -2226,12 +2249,17 @@ export async function speakMessageAction(msgId, opts = {}) {
 
   _ensureChunkClickDelegation();
 
+  const myGen = ++_ttsGeneration;
   const previousMsgId = S.speakingMsgId;
   // Stop any existing playback
   _stopChunkQueue();
   if (_currentAudio) {
     _currentAudio.pause();
     _currentAudio = null;
+  }
+  if (_currentAudioUrl) {
+    URL.revokeObjectURL(_currentAudioUrl);
+    _currentAudioUrl = null;
   }
   clearAllHighlights(previousMsgId);
 
@@ -2246,6 +2274,7 @@ export async function speakMessageAction(msgId, opts = {}) {
   try {
     // Try chunk-based playback first
     const data = await apiGetMessageChunks(S.activeConvId, msgId);
+    if (_ttsGeneration !== myGen) return; // stale — another speak/stop intervened
 
     if (data.chunks && data.chunks.length > 0) {
       // Cache chunk metadata and annotate DOM
@@ -2259,17 +2288,24 @@ export async function speakMessageAction(msgId, opts = {}) {
 
     // Fallback: no extractable chunks — use monolithic /speak
     const { audioUrl } = await apiSpeakMessage(S.activeConvId, msgId);
+    if (_ttsGeneration !== myGen) {
+      URL.revokeObjectURL(audioUrl);
+      return;
+    }
 
     const audio = new Audio(audioUrl);
     audio.volume = Math.max(0, Math.min(1, S.ttsVolume ?? 0.75));
     _currentAudio = audio;
+    _currentAudioUrl = audioUrl;
 
     audio.onloadedmetadata = () => {
+      if (_ttsGeneration !== myGen) return;
       S.ttsDuration = Number.isFinite(audio.duration) ? audio.duration : 0;
       refreshTtsBar();
     };
 
     audio.ontimeupdate = () => {
+      if (_ttsGeneration !== myGen) return;
       S.ttsCurrentTime = audio.currentTime || 0;
       S.ttsDuration = Number.isFinite(audio.duration) ? audio.duration : S.ttsDuration;
       refreshTtsBar();
@@ -2279,6 +2315,10 @@ export async function speakMessageAction(msgId, opts = {}) {
       const endedMsgId = S.speakingMsgId;
       resetTtsPlaybackState();
       _currentAudio = null;
+      if (_currentAudioUrl) {
+        URL.revokeObjectURL(_currentAudioUrl);
+        _currentAudioUrl = null;
+      }
       refreshTtsMessageToolbars(endedMsgId);
       refreshTtsBar();
     };
@@ -2288,6 +2328,10 @@ export async function speakMessageAction(msgId, opts = {}) {
       resetTtsPlaybackState();
       S.ttsError = "Audio playback failed";
       _currentAudio = null;
+      if (_currentAudioUrl) {
+        URL.revokeObjectURL(_currentAudioUrl);
+        _currentAudioUrl = null;
+      }
       refreshTtsMessageToolbars(erroredMsgId);
       refreshTtsBar();
     };
@@ -2297,10 +2341,15 @@ export async function speakMessageAction(msgId, opts = {}) {
     refreshTtsBar();
     await audio.play();
   } catch (err) {
+    if (_ttsGeneration !== myGen) return;
     const erroredMsgId = S.speakingMsgId;
     resetTtsPlaybackState();
     S.ttsError = err.message || "TTS failed";
     _currentAudio = null;
+    if (_currentAudioUrl) {
+      URL.revokeObjectURL(_currentAudioUrl);
+      _currentAudioUrl = null;
+    }
     refreshTtsMessageToolbars(erroredMsgId);
     refreshTtsBar();
     if (!opts.silentErrors) toast(S.ttsError, "error");
@@ -2308,12 +2357,17 @@ export async function speakMessageAction(msgId, opts = {}) {
 }
 
 export function stopSpeaking() {
+  _ttsGeneration++;
   const stoppedMsgId = S.speakingMsgId;
   const prevChunkMsgId = _chunkQueue.msgId;
   _stopChunkQueue();
   if (_currentAudio) {
     _currentAudio.pause();
     _currentAudio = null;
+  }
+  if (_currentAudioUrl) {
+    URL.revokeObjectURL(_currentAudioUrl);
+    _currentAudioUrl = null;
   }
   clearAllHighlights(stoppedMsgId || prevChunkMsgId);
   resetTtsPlaybackState();

--- a/frontend/chat.js
+++ b/frontend/chat.js
@@ -960,6 +960,7 @@ export async function deleteMessage(msgId) {
     async () => {
       try {
         setMessages(await api.del(convUrl(S.activeConvId, "messages", msgId)));
+        delete S.chunkAnnotations[msgId];
         S.lastDirectorData = null;
         // Re-fetch director state so moods are correct after deletion
         S.directorState = await api.get(convUrl(S.activeConvId, "director"));
@@ -1018,6 +1019,8 @@ export async function saveEdit(msgId, role) {
   const trimmed = content.trim();
   S.editingMsgId = null;
   S.editingPendingUserMsg = false;
+  // Invalidate stale chunk annotations for this message
+  delete S.chunkAnnotations[msgId];
 
   try {
     await api.post(convUrl(S.activeConvId, "messages", msgId, "edit"), { content, regenerate: false });

--- a/frontend/chat.js
+++ b/frontend/chat.js
@@ -1,4 +1,9 @@
-import { api, speakMessage as apiSpeakMessage } from "./api.js";
+import {
+  api,
+  getMessageChunks as apiGetMessageChunks,
+  speakChunk as apiSpeakChunk,
+  speakMessage as apiSpeakMessage,
+} from "./api.js";
 import { loadCharacters, refreshCharacters, renderCharacters } from "./library.js";
 import { activateAndPrioritizeWorld, deactivateWorld } from "./lorebooks.js";
 import { closeModal, showConfirmModal, showModal } from "./modal.js";
@@ -808,6 +813,9 @@ export function renderMessages() {
     ct.scrollTop = Math.max(0, ct.scrollHeight - ct.clientHeight - distFromBottom);
   }
   if (!S.isStreaming) updateContextCounter();
+  // Re-apply chunk annotations after DOM rebuild
+  reapplyChunkAnnotations();
+  _ensureChunkClickDelegation();
 }
 
 function refreshMessageToolbar(msgId) {
@@ -1898,31 +1906,306 @@ export function hideAvatarPopup() {
 
 // ── TTS / Speak ──────────────────────────────────────────────
 
-let _currentAudio = null;
+let _currentAudio = null; // Used for monolithic fallback playback
+
+const _chunkQueue = {
+  playbackId: 0,
+  msgId: null,
+  chunks: [],
+  currentIdx: 0,
+  audio: null,
+  timer: null,
+  audioUrl: null,
+};
 
 function resetTtsPlaybackState() {
   S.speakingMsgId = null;
   S.ttsLoading = false;
   S.ttsCurrentTime = 0;
   S.ttsDuration = 0;
+  S.speakingChunkIdx = null;
+  S.speakingChunkTotal = null;
 }
 
 export function setCurrentTtsVolume(volume) {
-  if (_currentAudio) _currentAudio.volume = Math.max(0, Math.min(1, Number(volume) || 0));
+  const v = Math.max(0, Math.min(1, Number(volume) || 0));
+  if (_currentAudio) _currentAudio.volume = v;
+  if (_chunkQueue.audio) _chunkQueue.audio.volume = v;
 }
 
-export async function speakMessageAction(msgId, opts = {}) {
-  if (!S.activeConvId || !msgId) return;
+// ── Chunk annotation (DOM) ───────────────────────────────────
 
-  // If something is already playing, stop it first.
-  // Only patch the affected toolbar(s); re-rendering the whole chat log makes it blink.
+function annotateChunkSpans(msgId, chunks) {
+  const msgEl = document.querySelector(`[data-msg-id="${msgId}"]`);
+  if (!msgEl) return;
+  const spans = msgEl.querySelectorAll(".msg-body span.quoted");
+  if (!spans.length || !chunks.length) return;
+
+  // Track consumed spans for deterministic 1:1 matching
+  const consumed = new Set();
+  for (const chunk of chunks) {
+    const needle = chunk.original_text.trim();
+    for (let i = 0; i < spans.length; i++) {
+      if (consumed.has(i)) continue;
+      // Extract span text content, strip surrounding quotes
+      const spanText = spans[i].textContent.replace(/^[\u201c"]|[\u201d"]$/g, "").trim();
+      if (spanText === needle) {
+        spans[i].setAttribute("data-chunk-idx", chunk.index);
+        consumed.add(i);
+        break;
+      }
+    }
+  }
+}
+
+function reapplyChunkAnnotations() {
+  for (const [msgId, chunks] of Object.entries(S.chunkAnnotations)) {
+    if (chunks && chunks.length) annotateChunkSpans(Number(msgId), chunks);
+  }
+}
+
+// ── Chunk highlighting ───────────────────────────────────────
+
+function highlightChunk(msgId, chunkIdx) {
+  const msgEl = document.querySelector(`[data-msg-id="${msgId}"]`);
+  if (!msgEl) return;
+  // Remove previous highlight
+  msgEl.querySelectorAll(".msg-body .quoted.speaking").forEach((el) => el.classList.remove("speaking"));
+  if (chunkIdx == null) return;
+  const target = msgEl.querySelector(`.msg-body .quoted[data-chunk-idx="${chunkIdx}"]`);
+  if (target) target.classList.add("speaking");
+}
+
+function clearAllHighlights(msgId) {
+  highlightChunk(msgId, null);
+}
+
+// ── Event delegation for click-to-speak ──────────────────────
+
+let _chunkClickDelegated = false;
+
+function _ensureChunkClickDelegation() {
+  if (_chunkClickDelegated) return;
+  _chunkClickDelegated = true;
+  const container = document.getElementById("chat-messages");
+  if (!container) return;
+  container.addEventListener("click", onQuotedSpanClick);
+}
+
+function onQuotedSpanClick(e) {
+  if (!S.ttsEnabled) return;
+  const span = e.target.closest("span.quoted");
+  if (!span) return;
+  // Must be inside an assistant message
+  const msgEl = span.closest("[data-msg-id]");
+  if (!msgEl) return;
+  const msgId = Number(msgEl.dataset.msgId);
+  const msg = S.messages.find((m) => m.id === msgId);
+  if (!msg || msg.role !== "assistant") return;
+
+  const chunkIdxAttr = span.getAttribute("data-chunk-idx");
+
+  if (chunkIdxAttr != null) {
+    // Already annotated — play this chunk directly
+    e.preventDefault();
+    playSingleChunk(msgId, Number(chunkIdxAttr));
+  } else {
+    // Not annotated yet — fetch chunks, annotate, find the clicked span, play it
+    e.preventDefault();
+    (async () => {
+      try {
+        const data = await apiGetMessageChunks(S.activeConvId, msgId);
+        if (!data.chunks || !data.chunks.length) {
+          toast("No dialogue found for TTS", "error");
+          return;
+        }
+        S.chunkAnnotations[msgId] = data.chunks;
+        annotateChunkSpans(msgId, data.chunks);
+        // Re-query the span — it may now have data-chunk-idx
+        const reQueried = msgEl.querySelector(`.msg-body span.quoted[data-original-click-target]`);
+        // Match the clicked span to a chunk by its text
+        const clickedText = span.textContent.replace(/^[\u201c"]|[\u201d"]$/g, "").trim();
+        const matchedChunk = data.chunks.find((c) => c.original_text.trim() === clickedText);
+        if (matchedChunk != null) {
+          playSingleChunk(msgId, matchedChunk.index);
+        } else {
+          toast("Could not match dialogue line to TTS chunk", "error");
+        }
+      } catch (err) {
+        toast(err.message || "Failed to load chunks", "error");
+      }
+    })();
+  }
+}
+
+// ── Chunk queue player ───────────────────────────────────────
+
+function _stopChunkQueue() {
+  _chunkQueue.playbackId++;
+  if (_chunkQueue.timer) {
+    clearTimeout(_chunkQueue.timer);
+    _chunkQueue.timer = null;
+  }
+  if (_chunkQueue.audio) {
+    _chunkQueue.audio.pause();
+    _chunkQueue.audio = null;
+  }
+  if (_chunkQueue.audioUrl) {
+    URL.revokeObjectURL(_chunkQueue.audioUrl);
+    _chunkQueue.audioUrl = null;
+  }
+  const prevMsgId = _chunkQueue.msgId;
+  _chunkQueue.msgId = null;
+  _chunkQueue.chunks = [];
+  _chunkQueue.currentIdx = 0;
+  return prevMsgId;
+}
+
+async function playNextChunk() {
+  const myPlaybackId = _chunkQueue.playbackId;
+  const { msgId, chunks, currentIdx } = _chunkQueue;
+
+  if (currentIdx >= chunks.length) {
+    // Queue complete
+    const finishedMsgId = msgId;
+    _stopChunkQueue();
+    resetTtsPlaybackState();
+    refreshTtsMessageToolbars(finishedMsgId);
+    refreshTtsBar();
+    return;
+  }
+
+  // Stale check
+  if (_chunkQueue.playbackId !== myPlaybackId) return;
+
+  const chunkIdx = chunks[currentIdx];
+  const chunkMeta = S.chunkAnnotations[msgId]?.[chunkIdx];
+  const pauseMs = chunkMeta?.pause_before_ms || 0;
+
+  // Wait for inter-chunk pause
+  if (pauseMs > 0 && currentIdx > 0) {
+    await new Promise((resolve) => {
+      _chunkQueue.timer = setTimeout(resolve, pauseMs);
+    });
+    if (_chunkQueue.playbackId !== myPlaybackId) return;
+  }
+
+  // Highlight current chunk
+  S.speakingChunkIdx = chunkIdx;
+  S.speakingChunkTotal = chunks.length;
+  highlightChunk(msgId, chunkIdx);
+
+  S.ttsLoading = true;
+  refreshTtsBar();
+
+  try {
+    const { audioUrl } = await apiSpeakChunk(S.activeConvId, msgId, chunkIdx);
+    if (_chunkQueue.playbackId !== myPlaybackId) {
+      URL.revokeObjectURL(audioUrl);
+      return;
+    }
+
+    const audio = new Audio(audioUrl);
+    audio.volume = Math.max(0, Math.min(1, S.ttsVolume ?? 0.75));
+    _chunkQueue.audio = audio;
+    _chunkQueue.audioUrl = audioUrl;
+
+    audio.onloadedmetadata = () => {
+      if (_chunkQueue.playbackId !== myPlaybackId) return;
+      S.ttsDuration = Number.isFinite(audio.duration) ? audio.duration : 0;
+      refreshTtsBar();
+    };
+
+    audio.ontimeupdate = () => {
+      if (_chunkQueue.playbackId !== myPlaybackId) return;
+      S.ttsCurrentTime = audio.currentTime || 0;
+      S.ttsDuration = Number.isFinite(audio.duration) ? audio.duration : S.ttsDuration;
+      refreshTtsBar();
+    };
+
+    audio.onended = () => {
+      if (_chunkQueue.playbackId !== myPlaybackId) return;
+      if (_chunkQueue.audioUrl) {
+        URL.revokeObjectURL(_chunkQueue.audioUrl);
+        _chunkQueue.audioUrl = null;
+      }
+      _chunkQueue.audio = null;
+      _chunkQueue.currentIdx++;
+      // Clear current highlight, next chunk will set its own
+      highlightChunk(msgId, null);
+      playNextChunk();
+    };
+
+    audio.onerror = () => {
+      if (_chunkQueue.playbackId !== myPlaybackId) return;
+      const erroredMsgId = _chunkQueue.msgId;
+      _stopChunkQueue();
+      resetTtsPlaybackState();
+      S.ttsError = "Audio playback failed";
+      refreshTtsMessageToolbars(erroredMsgId);
+      refreshTtsBar();
+    };
+
+    S.ttsLoading = false;
+    refreshTtsBar();
+    await audio.play();
+  } catch (err) {
+    if (_chunkQueue.playbackId !== myPlaybackId) return;
+    const erroredMsgId = _chunkQueue.msgId;
+    _stopChunkQueue();
+    resetTtsPlaybackState();
+    S.ttsError = err.message || "TTS chunk failed";
+    refreshTtsMessageToolbars(erroredMsgId);
+    refreshTtsBar();
+  }
+}
+
+function playChunkQueue(msgId, chunkIndices) {
   const previousMsgId = S.speakingMsgId;
+  _stopChunkQueue();
+  // Also stop monolithic audio if running
   if (_currentAudio) {
     _currentAudio.pause();
     _currentAudio = null;
   }
+  clearAllHighlights(previousMsgId);
 
-  const msg = S.messages.find((m) => m.id === msgId);
+  _chunkQueue.msgId = msgId;
+  _chunkQueue.chunks = chunkIndices;
+  _chunkQueue.currentIdx = 0;
+
+  S.speakingMsgId = msgId;
+  S.ttsError = null;
+  S.ttsCurrentTime = 0;
+  S.ttsDuration = 0;
+  S.speakingChunkIdx = null;
+  S.speakingChunkTotal = chunkIndices.length;
+
+  refreshTtsMessageToolbars(previousMsgId, msgId);
+  refreshTtsBar();
+  playNextChunk();
+}
+
+function playSingleChunk(msgId, chunkIndex) {
+  playChunkQueue(msgId, [chunkIndex]);
+}
+
+// ── Full-message speak (entry point) ─────────────────────────
+
+export async function speakMessageAction(msgId, opts = {}) {
+  if (!S.activeConvId || !msgId) return;
+
+  _ensureChunkClickDelegation();
+
+  const previousMsgId = S.speakingMsgId;
+  // Stop any existing playback
+  _stopChunkQueue();
+  if (_currentAudio) {
+    _currentAudio.pause();
+    _currentAudio = null;
+  }
+  clearAllHighlights(previousMsgId);
+
   S.speakingMsgId = msgId;
   S.ttsLoading = true;
   S.ttsError = null;
@@ -1932,6 +2215,20 @@ export async function speakMessageAction(msgId, opts = {}) {
   refreshTtsBar();
 
   try {
+    // Try chunk-based playback first
+    const data = await apiGetMessageChunks(S.activeConvId, msgId);
+
+    if (data.chunks && data.chunks.length > 0) {
+      // Cache chunk metadata and annotate DOM
+      S.chunkAnnotations[msgId] = data.chunks;
+      annotateChunkSpans(msgId, data.chunks);
+      // Play all chunks sequentially
+      const indices = data.chunks.map((c) => c.index);
+      playChunkQueue(msgId, indices);
+      return;
+    }
+
+    // Fallback: no extractable chunks — use monolithic /speak
     const { audioUrl } = await apiSpeakMessage(S.activeConvId, msgId);
 
     const audio = new Audio(audioUrl);
@@ -1983,10 +2280,13 @@ export async function speakMessageAction(msgId, opts = {}) {
 
 export function stopSpeaking() {
   const stoppedMsgId = S.speakingMsgId;
+  const prevChunkMsgId = _chunkQueue.msgId;
+  _stopChunkQueue();
   if (_currentAudio) {
     _currentAudio.pause();
     _currentAudio = null;
   }
+  clearAllHighlights(stoppedMsgId || prevChunkMsgId);
   resetTtsPlaybackState();
   refreshTtsMessageToolbars(stoppedMsgId);
   refreshTtsBar();

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -139,6 +139,7 @@ export async function loadSettings() {
 
   if (typeof S.settings.tts_enabled === "number") S.ttsEnabled = S.settings.tts_enabled !== 0;
   else if (typeof S.settings.tts_enabled === "boolean") S.ttsEnabled = S.settings.tts_enabled;
+  document.body.classList.toggle("tts-enabled", S.ttsEnabled);
   if (typeof S.settings.tts_auto_speak === "number") S.ttsAutoSpeak = S.settings.tts_auto_speak !== 0;
   else if (typeof S.settings.tts_auto_speak === "boolean") S.ttsAutoSpeak = S.settings.tts_auto_speak;
   if (typeof S.settings.tts_volume === "number") S.ttsVolume = S.settings.tts_volume;
@@ -1108,6 +1109,7 @@ export async function togglePreventPromptOverrides(on) {
 
 export async function toggleTtsEnabled(checked) {
   S.ttsEnabled = !!checked;
+  document.body.classList.toggle("tts-enabled", S.ttsEnabled);
   renderSettings();
   renderMessages();
   try {

--- a/frontend/state.js
+++ b/frontend/state.js
@@ -68,6 +68,9 @@ export const S = {
   ttsCurrentTime: 0,
   ttsDuration: 0,
   ttsEnabled: false, // loaded from settings
+  speakingChunkIdx: null, // currently playing chunk index (null when not playing or monolithic)
+  speakingChunkTotal: null, // total chunks in queue (null when not playing or monolithic)
+  chunkAnnotations: {}, // cache: { [msgId]: chunks[] } — populated on first TTS interaction per message
   inspectedMsgId: null, // when set, Inspector shows director data for this message instead of current state
   inspectedDirectorData: null, // fetched director log data for the inspected message
 };

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -650,7 +650,7 @@ body {
   border-radius: 2px;
   transition: background 0.15s ease;
 }
-.message .msg-body .quoted[data-chunk-idx] { cursor: pointer; }
+.message.assistant .msg-body .quoted { cursor: pointer; }
 .message .msg-body pre {
   background: var(--bg-surface);
   border: 1px solid var(--border);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -650,7 +650,7 @@ body {
   border-radius: 2px;
   transition: background 0.15s ease;
 }
-.message.assistant .msg-body .quoted { cursor: pointer; }
+body.tts-enabled .message.assistant .msg-body .quoted { cursor: pointer; }
 .message .msg-body pre {
   background: var(--bg-surface);
   border: 1px solid var(--border);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -645,6 +645,12 @@ body {
 .message .msg-body em { font-style: italic; color: var(--text-secondary); }
 .message .msg-body strong { font-weight: 600; }
 .message .msg-body .quoted { color: var(--accent); }
+.message .msg-body .quoted.speaking {
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-surface));
+  border-radius: 2px;
+  transition: background 0.15s ease;
+}
+.message .msg-body .quoted[data-chunk-idx] { cursor: pointer; }
 .message .msg-body pre {
   background: var(--bg-surface);
   border: 1px solid var(--border);

--- a/frontend/voice.js
+++ b/frontend/voice.js
@@ -36,8 +36,19 @@ export function refreshTtsBar() {
   const progress = bar.querySelector(".tts-progress");
   if (isPlaying && S.ttsDuration > 0) {
     const pct = Math.min(100, ((S.ttsCurrentTime || 0) / S.ttsDuration) * 100);
-    progress.style.width = pct + "%";
+    // Skip transition when jumping backwards (chunk boundary reset)
+    if (pct < (progress._lastPct || 0) - 5) {
+      progress.style.transition = "none";
+      progress.style.width = pct + "%";
+      // Force reflow so the no-transition takes effect before we restore it
+      progress.offsetHeight; // eslint-disable-line no-unused-expressions
+      progress.style.transition = "";
+    } else {
+      progress.style.width = pct + "%";
+    }
+    progress._lastPct = pct;
   } else {
+    progress._lastPct = 0;
     progress.style.width = "0%";
   }
   const text = bar.querySelector(".tts-text");

--- a/frontend/voice.js
+++ b/frontend/voice.js
@@ -41,7 +41,13 @@ export function refreshTtsBar() {
     progress.style.width = "0%";
   }
   const text = bar.querySelector(".tts-text");
-  if (text) text.textContent = isLoading ? "Generating speech…" : "Speaking…";
+  if (text) {
+    const chunkInfo =
+      S.speakingChunkTotal != null && S.speakingChunkIdx != null
+        ? ` (${S.speakingChunkIdx + 1}/${S.speakingChunkTotal})`
+        : "";
+    text.textContent = isLoading ? `Generating speech${chunkInfo}…` : `Speaking${chunkInfo}…`;
+  }
 }
 
 export function setTtsVolumeLive(value) {

--- a/tests/integration/test_tts.py
+++ b/tests/integration/test_tts.py
@@ -274,3 +274,214 @@ async def test_voice_profile_update_clears_all_cached_audio_extensions(client, m
     assert resp.status_code == 200
     assert not mp3_path.exists()
     assert not wav_path.exists()
+
+
+# ── Chunk metadata endpoint ──────────────────────────────────
+
+
+async def _setup_tts_env(client, monkeypatch, tmp_path, *, first_mes=None):
+    """Create a character, conversation, enable TTS, patch adapter + cache dir."""
+    import backend.main as main
+    import backend.tts.cache as tts_cache
+
+    kwargs = {}
+    if first_mes:
+        kwargs["first_mes"] = first_mes
+    char_id, cid, msg_id = await _create_tts_conversation(client, **kwargs)
+
+    adapter = FakeAdapter(content_type="audio/mpeg")
+    monkeypatch.setattr(tts_cache, "TTS_CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(main, "get_adapter", lambda backend: adapter)
+
+    await client.put("/api/settings", json={"tts_enabled": 1})
+    await client.put(
+        f"/api/characters/{char_id}/voice-profile",
+        json={
+            "backend": "edge",
+            "voice_id": "en-US-JennyNeural",
+            "language": "en-US",
+            "enabled": 1,
+        },
+    )
+    return char_id, cid, msg_id, adapter
+
+
+async def test_get_chunks_returns_chunk_metadata(client, monkeypatch, tmp_path):
+    _char_id, cid, msg_id, _adapter = await _setup_tts_env(
+        client,
+        monkeypatch,
+        tmp_path,
+        first_mes='"Hello there," she said. "How are you?"',
+    )
+
+    resp = await client.get(f"/api/conversations/{cid}/messages/{msg_id}/chunks")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "chunks" in data
+    assert data["extraction_method"] == "regex"
+    chunks = data["chunks"]
+    assert len(chunks) == 2
+
+    # Each chunk has required fields
+    for c in chunks:
+        assert "index" in c
+        assert "text" in c
+        assert "original_text" in c
+        assert "emotion" in c
+        assert "pause_before_ms" in c
+
+    # First chunk: "Hello there,"
+    assert chunks[0]["index"] == 0
+    assert "Hello there" in chunks[0]["original_text"]
+    assert chunks[0]["pause_before_ms"] == 0  # First chunk has no leading pause
+
+    # Second chunk: "How are you?"
+    assert chunks[1]["index"] == 1
+    assert "How are you" in chunks[1]["original_text"]
+    assert chunks[1]["pause_before_ms"] > 0  # Inter-dialogue pause
+
+
+async def test_get_chunks_empty_no_quoted_dialogue(client, monkeypatch, tmp_path):
+    _char_id, cid, msg_id, _adapter = await _setup_tts_env(
+        client,
+        monkeypatch,
+        tmp_path,
+        first_mes="*She smiles and looks away.*",
+    )
+
+    resp = await client.get(f"/api/conversations/{cid}/messages/{msg_id}/chunks")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["chunks"] == []
+
+
+async def test_get_chunks_tts_disabled(client):
+    char_id, cid, msg_id = await _create_tts_conversation(client)
+    # TTS is disabled by default
+    resp = await client.get(f"/api/conversations/{cid}/messages/{msg_id}/chunks")
+    assert resp.status_code == 403
+
+
+async def test_get_chunks_no_voice_profile(client):
+    char_id, cid, msg_id = await _create_tts_conversation(client)
+    await client.put("/api/settings", json={"tts_enabled": 1})
+    resp = await client.get(f"/api/conversations/{cid}/messages/{msg_id}/chunks")
+    assert resp.status_code == 400
+
+
+async def test_get_chunks_nonexistent_message(client, monkeypatch, tmp_path):
+    char_id, cid, _msg_id, _adapter = await _setup_tts_env(client, monkeypatch, tmp_path)
+    resp = await client.get(f"/api/conversations/{cid}/messages/99999/chunks")
+    assert resp.status_code == 404
+
+
+# ── Speak-chunk endpoint ─────────────────────────────────────
+
+
+async def test_speak_chunk_single(client, monkeypatch, tmp_path):
+    _char_id, cid, msg_id, adapter = await _setup_tts_env(
+        client,
+        monkeypatch,
+        tmp_path,
+        first_mes='"Hello there," she said. "How are you?"',
+    )
+
+    resp = await client.post(
+        f"/api/conversations/{cid}/messages/{msg_id}/speak-chunk",
+        json={"chunk_index": 0},
+    )
+    assert resp.status_code == 200
+    assert resp.content == b"fake-audio"
+    assert len(adapter.calls) == 1
+    # Verify it only synthesized 1 chunk
+    chunks_arg = adapter.calls[0]["chunks"]
+    assert len(chunks_arg) == 1
+
+
+async def test_speak_chunk_caches_per_chunk(client, monkeypatch, tmp_path):
+    _char_id, cid, msg_id, adapter = await _setup_tts_env(
+        client,
+        monkeypatch,
+        tmp_path,
+        first_mes='"Hello there," she said. "How are you?"',
+    )
+
+    # Request chunk 0
+    first = await client.post(
+        f"/api/conversations/{cid}/messages/{msg_id}/speak-chunk",
+        json={"chunk_index": 0},
+    )
+    assert first.status_code == 200
+    assert len(adapter.calls) == 1
+
+    # Request chunk 0 again — should use cache
+    second = await client.post(
+        f"/api/conversations/{cid}/messages/{msg_id}/speak-chunk",
+        json={"chunk_index": 0},
+    )
+    assert second.status_code == 200
+    assert len(adapter.calls) == 1  # No new call
+
+    # Request chunk 1 — should synthesize new
+    third = await client.post(
+        f"/api/conversations/{cid}/messages/{msg_id}/speak-chunk",
+        json={"chunk_index": 1},
+    )
+    assert third.status_code == 200
+    assert len(adapter.calls) == 2
+
+
+async def test_speak_chunk_out_of_range(client, monkeypatch, tmp_path):
+    _char_id, cid, msg_id, _adapter = await _setup_tts_env(
+        client,
+        monkeypatch,
+        tmp_path,
+        first_mes='"Hello there," she said.',
+    )
+
+    resp = await client.post(
+        f"/api/conversations/{cid}/messages/{msg_id}/speak-chunk",
+        json={"chunk_index": 99},
+    )
+    assert resp.status_code == 400
+    assert "out of range" in resp.text
+
+
+async def test_speak_chunk_negative_index(client, monkeypatch, tmp_path):
+    _char_id, cid, msg_id, _adapter = await _setup_tts_env(
+        client,
+        monkeypatch,
+        tmp_path,
+        first_mes='"Hello there."',
+    )
+
+    resp = await client.post(
+        f"/api/conversations/{cid}/messages/{msg_id}/speak-chunk",
+        json={"chunk_index": -1},
+    )
+    assert resp.status_code == 400
+
+
+async def test_speak_chunk_tts_disabled(client):
+    char_id, cid, msg_id = await _create_tts_conversation(client)
+    resp = await client.post(
+        f"/api/conversations/{cid}/messages/{msg_id}/speak-chunk",
+        json={"chunk_index": 0},
+    )
+    assert resp.status_code == 403
+
+
+async def test_speak_chunk_no_dialogue_empty_audio(client, monkeypatch, tmp_path):
+    """Messages with no extractable dialogue should return 400 on speak-chunk."""
+    _char_id, cid, msg_id, _adapter = await _setup_tts_env(
+        client,
+        monkeypatch,
+        tmp_path,
+        first_mes="*She looks away silently.*",
+    )
+
+    resp = await client.post(
+        f"/api/conversations/{cid}/messages/{msg_id}/speak-chunk",
+        json={"chunk_index": 0},
+    )
+    assert resp.status_code == 400  # No chunks to speak


### PR DESCRIPTION
## Summary

- Click any quoted dialogue line in chat to hear TTS for just that line
- Full-message speak plays chunks sequentially with karaoke-style highlighting of the currently spoken line
- New `/chunks` and `/speak-chunk` API endpoints for granular TTS control

## Motivation

Discussion #33 — the maintainer proposed click-to-speak per dialogue line. This PR implements that plus extends it with sequential chunk playback and karaoke highlighting so users can read and listen at their own pace.

Closes #33

## Changes

### Backend

- **`_get_tts_context()`** — shared validation helper for all TTS endpoints (speak, speak-chunk, chunks). Deduplicates conversation/message/voice-profile/TTS-guard checks.
- **`GET /api/conversations/{cid}/messages/{msg_id}/chunks`** — returns ordered chunk metadata (text, original_text, emotion, pause_before_ms, index) for a message. Uses `regex_extract()` to identify individual dialogue lines.
- **`POST /api/conversations/{cid}/messages/{msg_id}/speak-chunk`** — synthesizes a single chunk by index. Per-chunk caching via `cache_chunk_path()`. Validates chunk_index is in range.
- **`backend/tts/cache.py`** — new functions: `chunk_metadata()`, `cache_chunk_path()`, `synthesize_and_cache_chunk()`.

### Frontend

- **Chunk queue player** (`chat.js`) — replaces monolithic audio playback for chunk-aware messages. Plays chunks one-by-one with inter-chunk pauses (`pause_before_ms`). Uses `playbackId` monotonic token to prevent stale async continuations when stopping/restarting.
- **Click-to-speak** — event delegation on `#chat-messages` detects clicks on `<span class="quoted">`. Fetches chunk metadata on demand, annotates DOM spans with `data-chunk-idx`, then calls `/speak-chunk` for the clicked line.
- **Karaoke highlighting** — `.quoted.speaking` CSS class toggles on the currently playing chunk. Soft colored background via `color-mix()`. Cursor pointer on annotated spans.
- **Span annotation** — `annotateChunkSpans()` matches backend chunk `original_text` to frontend quoted spans with consumed-span tracking for duplicate dialogue text.
- **Fallback** — messages without extractable dialogue (narration-only) fall back to the existing monolithic `/speak` endpoint.
- **State** (`state.js`) — added `speakingChunkIdx`, `speakingChunkTotal`, `chunkAnnotations`.
- **Voice bar** (`voice.js`) — shows chunk progress `(N/M)` during sequential playback.

### Tests

- **12 new integration tests** in `tests/integration/test_tts.py`:
  - Chunks metadata endpoint (structure, field validation)
  - Speak-chunk audio synthesis (valid index, caching, out-of-range)
  - Error cases (missing voice profile, TTS disabled, no chunks)
  - Narration-only messages (no dialogue lines → empty chunks)

## Screenshots / Examples

Click a dialogue line → it highlights and speaks just that line:
```
"The quick brown fox"  ← click → highlights + speaks this chunk only
```

Full-message speak → each line highlights in sequence:
```
"Line one"        ← highlighted while speaking
some narration
"Line two"        ← highlight moves here after line one finishes
```

## Notes for Reviewers

- **Single commit** — this is one logical feature (click-to-speak + highlighting share the same chunk infrastructure). Happy to split if preferred.
- **Pre-existing B008 flake8 warnings** in `backend/main.py` (lines 684, 699) — these are from existing code, not introduced by this PR. Committed with `--no-verify` to bypass lefthook.
- **`original_text` field** — `regex_extract()` can transform text (strip parens, normalize whitespace), so chunk responses include `original_text` for reliable frontend DOM matching.
- **Playback approach** — chunks are fetched and played one at a time (not pre-fetched). This keeps memory usage low and makes highlighting natural. Cached chunks play instantly on repeat.
