### PR TITLE
Reapply "track real cache hits from provider, fix inconsistent direct_scene tool schema causing cache busts"

### DIFF
--- a/backend/kv_tracker.py
+++ b/backend/kv_tracker.py
@@ -1,13 +1,30 @@
 """
-kv_tracker.py — Lightweight KV-cache hit/miss estimator shared across passes.
+kv_tracker.py — KV-cache hit/miss tracker shared across passes.
 
-Serializes the full prompt (messages + tools) for each LLM call, then computes
-the actual character-level common prefix between consecutive calls to estimate
-cache reuse.  Character counts are a proxy for token counts — no tokeniser needed.
+Reports two views per LLM call:
 
-Cross-turn tracking: when a pass has no same-model predecessor in the current
-turn (would show "baseline"), it falls back to the matching label from the
-previous turn so inter-turn cache reuse is visible.
+  1. Provider — ground truth. The ``usage`` field from each response is parsed
+     with fallbacks across OpenAI / Anthropic / DeepSeek / vLLM naming and
+     printed as ``cached/total`` tokens. This is the only number that
+     reconciles with your provider's billing dashboard.
+
+  2. Local estimate — a debugging aid, NOT a prediction of the provider
+     number. We track two things separately:
+       - ``msgs_overlap``: char-prefix overlap of the messages list serialized
+         alone.  Captures whether system prompt + history + most of the final
+         user message are shared with the previous same-model call.
+       - ``tools_match``:  whether the tools list is byte-identical to the
+         previous same-model call.
+
+     We deliberately do NOT combine these into a single "estimated hit
+     percentage." Where the chat template renders tools (start vs. end of the
+     system block vs. before the final user turn) determines whether a tools
+     diff actually breaks the wire-level cache, and the tracker has no way to
+     know that. Two split numbers + provider truth lets a human read both
+     failure modes:
+       - msgs_overlap high, tools_match False → cache may or may not hold;
+         provider number tells you which.
+       - msgs_overlap low                     → cache is broken regardless.
 """
 
 from __future__ import annotations
@@ -21,21 +38,84 @@ logger = logging.getLogger(__name__)
 _prev_turn_entries: dict[str, list[dict]] = {}
 
 
-def _serialize_prompt(messages: list[dict], tools: list[dict] | None) -> str:
-    """Compact JSON serialization of the full prompt for prefix comparison."""
-    parts = [json.dumps(m, separators=(",", ":")) for m in messages]
-    if tools:
-        parts.append(json.dumps(tools, separators=(",", ":")))
-    return "\n".join(parts)
+def _serialize_messages(messages: list[dict]) -> str:
+    """Compact JSON serialization of a messages list; sort_keys for byte-stable output regardless of dict construction order."""
+    return "\n".join(json.dumps(m, separators=(",", ":"), sort_keys=True) for m in messages)
+
+
+def _serialize_tools(tools: list[dict] | None) -> str:
+    """Compact, order-deterministic JSON for tools. Empty string when no tools."""
+    if not tools:
+        return ""
+    return json.dumps(tools, separators=(",", ":"), sort_keys=True)
 
 
 def _common_prefix_len(a: str, b: str) -> int:
-    """Length of the longest common prefix between two strings."""
     i = 0
     limit = min(len(a), len(b))
     while i < limit and a[i] == b[i]:
         i += 1
     return i
+
+
+def extract_cache_stats(usage: dict | None) -> dict:
+    """Pull cache hit / write / total token counts from a provider ``usage``
+    dict, with fallbacks across naming conventions.
+
+    Recognises:
+      - OpenAI / vLLM / llama.cpp:  usage.prompt_tokens_details.cached_tokens
+      - Anthropic:                  usage.cache_read_input_tokens,
+                                    usage.cache_creation_input_tokens
+      - DeepSeek:                   usage.prompt_cache_hit_tokens
+
+    Returns ``prompt_tokens``, ``cached_tokens``, ``cache_write_tokens``, and
+    ``source`` (which field path was used — useful when debugging why a
+    provider's numbers look off). When ``usage`` is missing or unrecognized,
+    counts are 0 and ``source`` distinguishes "missing", "unrecognized", and
+    "no_cache_fields" so callers can tell "no data" from a real zero.
+    """
+    if not isinstance(usage, dict):
+        return {
+            "prompt_tokens": 0,
+            "cached_tokens": 0,
+            "cache_write_tokens": 0,
+            "source": "missing",
+        }
+
+    prompt_tokens = usage.get("prompt_tokens") or usage.get("input_tokens") or 0
+
+    cached = 0
+    source = "unrecognized"
+
+    details = usage.get("prompt_tokens_details") or usage.get("input_tokens_details")
+    if isinstance(details, dict):
+        v = details.get("cached_tokens") or details.get("cache_read_tokens") or 0
+        if v:
+            cached, source = int(v), "prompt_tokens_details.cached_tokens"
+
+    if not cached:
+        v = usage.get("cache_read_input_tokens") or 0
+        if v:
+            cached, source = int(v), "cache_read_input_tokens"
+
+    if not cached:
+        v = usage.get("prompt_cache_hit_tokens") or 0
+        if v:
+            cached, source = int(v), "prompt_cache_hit_tokens"
+
+    cache_write = int(usage.get("cache_creation_input_tokens") or 0)
+    if cache_write and source == "unrecognized":
+        source = "cache_creation_input_tokens"
+
+    if int(prompt_tokens or 0) > 0 and source == "unrecognized" and not cache_write:
+        source = "no_cache_fields"
+
+    return {
+        "prompt_tokens": int(prompt_tokens or 0),
+        "cached_tokens": cached,
+        "cache_write_tokens": cache_write,
+        "source": source,
+    }
 
 
 class _KVCacheTracker:
@@ -51,60 +131,96 @@ class _KVCacheTracker:
         tools: list[dict] | None,
         model: str = "",
     ) -> None:
-        """Snapshot a single LLM call. Call once per pass (or per tool in the director)."""
-        serialized = _serialize_prompt(messages, tools)
+        """Snapshot a single LLM call. Call once per pass (or per tool in director)."""
+        msgs_serialized = _serialize_messages(messages)
+        tools_serialized = _serialize_tools(tools)
         self._entries.append(
             {
                 "label": label,
                 "model": model,
-                "serialized": serialized,
-                "total_chars": len(serialized),
-                "tools_names": ([t.get("function", {}).get("name", "") for t in tools] if tools else []),
+                "msgs_serialized": msgs_serialized,
+                "tools_serialized": tools_serialized,
+                "msgs_chars": len(msgs_serialized),
+                "tools_chars": len(tools_serialized),
+                "tools_names": [t.get("function", {}).get("name", "") for t in (tools or [])],
+                "usage": None,
             }
         )
+
+    def record_usage(self, label: str, usage: dict | None) -> None:
+        """Attach the provider's ``usage`` dict to the most recent entry with this label."""
+        for entry in reversed(self._entries):
+            if entry["label"] == label:
+                entry["usage"] = usage
+                return
+        logger.debug("record_usage: no prior record() for label=%r, dropping", label)
+
+    def _find_prev(self, i: int, model: str, label: str) -> tuple[dict | None, bool]:
+        """Return (prev_entry, is_cross_turn). Matches same-model first within
+        this turn, then falls back to same-(label, model) from the previous turn."""
+        for j in range(i - 1, -1, -1):
+            if self._entries[j].get("model", "") == model:
+                return self._entries[j], False
+        if self._prev_entries:
+            for p in self._prev_entries:
+                if p["label"] == label and p.get("model", "") == model:
+                    return p, True
+        return None, False
 
     def log_summary(self) -> None:
         if not self._entries:
             return
 
-        lines = ["KV cache comparison  (serialized prompt overlap):"]
-        total_saved = 0
+        lines = ["KV cache report  (provider = truth; local = msgs-prefix + tools-match, template-dependent):"]
+        total_cached = 0
+        total_prompt = 0
 
         for i, e in enumerate(self._entries):
-            e_model = e.get("model", "")
-            # Look for same-model predecessor within this turn first.
-            prev = next(
-                (self._entries[j] for j in range(i - 1, -1, -1) if self._entries[j].get("model", "") == e_model),
-                None,
-            )
-            cross_turn = False
-            if prev is None and self._prev_entries:
-                # Fall back to the same-label entry from the previous turn.
-                prev = next(
-                    (p for p in self._prev_entries if p["label"] == e["label"]),
-                    None,
-                )
-                cross_turn = prev is not None
+            model = e.get("model", "")
+            prev, cross_turn = self._find_prev(i, model, e["label"])
 
+            # ── Local view: messages prefix + tools identity, reported separately
             if prev is None:
-                overlap = 0
-                cache_note = "baseline"
+                local_note = "local: baseline"
             else:
-                prev_serialized = prev["serialized"]
-                overlap = _common_prefix_len(prev_serialized, e["serialized"])
-                if overlap > 0:
-                    total_saved += overlap
-                    pct = overlap / len(prev_serialized) * 100 if prev_serialized else 0
-                    turn_tag = "prev-turn " if cross_turn else ""
-                    cache_note = f"HIT  overlap={overlap} ({pct:.1f}%)  vs {turn_tag}{prev['label']!r}"
+                msgs_overlap = _common_prefix_len(prev["msgs_serialized"], e["msgs_serialized"])
+                msgs_total = e["msgs_chars"]
+                msgs_pct = (msgs_overlap / msgs_total * 100) if msgs_total else 0
+                tools_match = e["tools_serialized"] == prev["tools_serialized"] and e["tools_chars"] > 0
+                if e["tools_chars"] == 0 and prev["tools_chars"] == 0:
+                    tools_note = "tools=none"
+                elif tools_match:
+                    tools_note = "tools_MATCH"
                 else:
-                    cache_note = "BUST  no_overlap"
+                    tools_note = f"tools_DIFFER (prev={prev['tools_chars']}c, this={e['tools_chars']}c)"
+                turn_tag = "prev-turn " if cross_turn else ""
+                local_note = (
+                    f"local: msgs_overlap={msgs_overlap}/{msgs_total}c ({msgs_pct:.1f}%) "
+                    f"vs {turn_tag}{prev['label']!r}; {tools_note}"
+                )
 
-            tail = e["total_chars"] - overlap
+            # ── Provider view: ground truth from usage
+            stats = extract_cache_stats(e.get("usage"))
+            if stats["source"] == "missing":
+                provider_note = "provider: N/A (no usage returned)"
+            elif stats["source"] in ("unrecognized", "no_cache_fields"):
+                provider_note = f"provider: prompt={stats['prompt_tokens']} tok  cached=N/A [{stats['source']}]"
+            else:
+                pt, ct, cw = stats["prompt_tokens"], stats["cached_tokens"], stats["cache_write_tokens"]
+                total_cached += ct
+                total_prompt += pt
+                pct = (ct / pt * 100) if pt else 0.0
+                write_part = f"  write={cw}" if cw else ""
+                provider_note = f"provider: cached={ct}/{pt} tok ({pct:.1f}%){write_part} [{stats['source']}]"
 
-            lines.append(f"  {e['label']:<28}  total={e['total_chars']:7d}  " f"tail={tail:6d}  {cache_note}")
+            lines.append(f"  {e['label']:<28}  {provider_note}  |  {local_note}")
 
-        lines.append(f"  Total estimated KV cache char savings: {total_saved}")
+        if total_prompt:
+            pct_total = total_cached / total_prompt * 100
+            lines.append(f"  Totals — provider cached: {total_cached}/{total_prompt} tok ({pct_total:.1f}%)")
+        else:
+            lines.append("  Totals — provider cached: N/A (server returned no usage data)")
+
         logger.info("\n".join(lines))
 
         if self._conversation_id:

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -76,7 +76,10 @@ class LLMClient:
 
         Yields:
             {"type": "reasoning", "delta": str}  — zero or more reasoning chunks
-            {"type": "done", "message": dict}    — assembled message with content/tool_calls
+            {"type": "content",   "delta": str}  — zero or more content chunks
+            {"type": "done", "message": dict, "usage": dict | None}
+                — assembled message with content/tool_calls, plus the provider's
+                  usage object if returned (None when the server doesn't emit it).
         """
         body = {
             "model": model,
@@ -88,6 +91,8 @@ class LLMClient:
             body["tools"] = tools
         if tool_choice:
             body["tool_choice"] = tool_choice
+        # Requests usage in the terminal SSE chunk; servers that don't support it silently ignore this field.
+        body.setdefault("stream_options", {"include_usage": True})
 
         if self.profile is not None:
             for action in self.profile.apply(body):
@@ -105,6 +110,7 @@ class LLMClient:
         reasoning_parts: list[str] = []
         tool_calls_acc: dict[int, dict] = {}
         finish_reason: str | None = None
+        usage: dict | None = None
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             async with client.stream("POST", self._url(), json=body, headers=self._headers()) as resp:
@@ -163,7 +169,21 @@ class LLMClient:
                             break
                         try:
                             chunk = json.loads(payload)
-                            choice = chunk["choices"][0]
+                        except json.JSONDecodeError:
+                            continue
+
+                        # Usage may appear in a terminal chunk (choices=[]) or on the final content chunk; last-write-wins since totals are monotonic.
+                        u = chunk.get("usage")
+                        if isinstance(u, dict):
+                            usage = u
+
+                        choices = chunk.get("choices") or []
+                        if not choices:
+                            # Pure usage/metadata chunk — nothing else to do.
+                            continue
+
+                        try:
+                            choice = choices[0]
                             delta = choice.get("delta", {})
 
                             # Reasoning delta (field name varies by server)
@@ -199,7 +219,7 @@ class LLMClient:
                             if choice.get("finish_reason"):
                                 finish_reason = choice["finish_reason"]
 
-                        except (json.JSONDecodeError, KeyError, IndexError):
+                        except (KeyError, IndexError):
                             continue
                 finally:
                     abort_wait.cancel()
@@ -232,12 +252,13 @@ class LLMClient:
             message["finish_reason"] = finish_reason
 
         logger.info(
-            "LLM complete: assembled keys=%s, has_tool_calls=%s, content_len=%s",
+            "LLM complete: assembled keys=%s, has_tool_calls=%s, content_len=%s, usage=%s",
             list(message.keys()),
             "tool_calls" in message,
             len(message.get("content", "") or "") if message.get("content") else "null",
+            usage,
         )
-        yield {"type": "done", "message": message}
+        yield {"type": "done", "message": message, "usage": usage}
 
 
 def _sanitize_args(obj):

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -12,7 +12,7 @@ from typing import AsyncIterator, List, Optional
 from . import database as db
 from .llm_client import LLMClient, reasoning_cfg
 from .endpoint_profiles import profile_for
-from .tool_defs import TOOLS, POST_WRITER_TOOLS
+from .tool_defs import TOOLS, POST_WRITER_TOOLS, build_direct_scene_tool
 from .prompt_builder import (
     build_prefix,
     compute_style_injection_block,
@@ -126,6 +126,12 @@ async def _run_pipeline(
 
     kv_tracker = _KVCacheTracker(conversation_id=conversation_id)
 
+    # All three passes must send byte-identical tools; direct_scene is dynamic
+    # so it's built once here and shared via schema_overrides.
+    schema_overrides = {
+        "direct_scene": build_direct_scene_tool(director_fragments),
+    }
+
     # --- Director pass ---
     has_pre_writer_tools = any(enabled_tools.get(n, False) for n in TOOLS if n not in POST_WRITER_TOOLS)
     if agent_on and has_pre_writer_tools:
@@ -145,6 +151,7 @@ async def _run_pipeline(
             lorebook_block=lorebook_block,
             model=agent_model,
             progressive_state=progressive_state,
+            schema_overrides=schema_overrides,
         ):
             if event["type"] == "reasoning":
                 reasoning_director_text += event["delta"]
@@ -223,6 +230,7 @@ async def _run_pipeline(
         length_guard=length_guard,
         kv_tracker=kv_tracker,
         reasoning_on=writer_reasoning_on,
+        schema_overrides=schema_overrides,
     ):
         if item["type"] == "reasoning":
             reasoning_writer_text += item["delta"]
@@ -278,6 +286,7 @@ async def _run_pipeline(
                 audit_context_msgs=editor_audit_msgs,
                 model=agent_model,
                 writer_user_msg=writer_content,
+                schema_overrides=schema_overrides,
             ):
                 if event["type"] == "reasoning":
                     reasoning_editor_text += event["delta"]

--- a/backend/passes/director.py
+++ b/backend/passes/director.py
@@ -16,7 +16,6 @@ from ..tool_defs import (
     TOOLS,
     POST_WRITER_TOOLS,
     enabled_schemas,
-    build_direct_scene_tool,
 )
 from ..prompt_builder import build_director_tool_prompt
 from ..utils import extract_hyperparams, build_multimodal_content
@@ -69,6 +68,7 @@ async def _director_pass(
     lorebook_block: str = "",
     model: str | None = None,
     progressive_state: dict | None = None,
+    schema_overrides: dict | None = None,
 ) -> AsyncIterator[dict]:
     """Yields reasoning dicts during each tool call, then a single done dict.
 
@@ -100,10 +100,7 @@ async def _director_pass(
         }
         return
 
-    # Build base schemas, replacing the static direct_scene with the dynamic one.
-    base_schemas = enabled_schemas(enabled_tools)
-    dynamic_direct_scene = build_direct_scene_tool(director_fragments, progressive_state)
-    tool_schemas = [dynamic_direct_scene if s["function"]["name"] == "direct_scene" else s for s in base_schemas]
+    tool_schemas = enabled_schemas(enabled_tools, schema_overrides)
 
     logger.info(
         "Director pass: tools included=%s",
@@ -156,6 +153,8 @@ async def _director_pass(
                     yield {"type": "reasoning", "delta": event["delta"]}
                 elif event["type"] == "done":
                     resp = event["message"]
+                    if kv_tracker is not None:
+                        kv_tracker.record_usage(f"director:{name}", event.get("usage"))
             last_raw = json.dumps(resp, default=str)
             logger.info("Agent tool=%s output:\n%s", name, last_raw)
             if parsed := parse_tool_calls(resp):

--- a/backend/passes/editor/editor.py
+++ b/backend/passes/editor/editor.py
@@ -280,6 +280,7 @@ async def editor_pass(
     ) = None,  # explicit previous-assistant list for repetition scanning; if None, derived from prefix
     model: str | None = None,
     writer_user_msg: "str | list | None" = None,  # writer's exact last user message; when provided replaces bare effective_msg so the editor extends the writer's KV-cached prefix
+    schema_overrides: dict | None = None,
 ) -> AsyncIterator[dict]:
     """ReAct-style editor loop with optional audit and/or length guard.
 
@@ -334,12 +335,10 @@ async def editor_pass(
     length_guard_triggered = False
     length_guard_instruction = ""
 
-    # Start from the same enabled-tool set used by the director and writer
-    # passes so the KV-cache prefix stays aligned.  EDITOR_APPLY_PATCH_TOOL
-    # is included when audit_enabled is True; EDITOR_REWRITE_TOOL is included
-    # when length_guard is enabled — both injected by the orchestrator into
-    # enabled_tools before reaching this pass.
-    editor_tools: list[dict] = enabled_schemas(enabled_tools)
+    # Uses the same enabled-tool set as director and writer for KV-cache
+    # alignment. EDITOR_APPLY_PATCH_TOOL and EDITOR_REWRITE_TOOL are injected
+    # into enabled_tools by the orchestrator before this pass runs.
+    editor_tools: list[dict] = enabled_schemas(enabled_tools, schema_overrides)
 
     if length_guard and length_guard.get("enabled"):
         word_count = len(draft.split())
@@ -437,6 +436,8 @@ async def editor_pass(
                         yield {"type": "reasoning", "delta": event["delta"]}
                     elif event["type"] == "done":
                         resp = event["message"]
+                        if kv_tracker is not None and iteration == 0:
+                            kv_tracker.record_usage("editor", event.get("usage"))
             except Exception as llm_err:
                 logger.error(
                     "Editor iteration %d: client.complete() raised %s: %s",

--- a/backend/passes/writer.py
+++ b/backend/passes/writer.py
@@ -59,6 +59,7 @@ async def _writer_pass(
     length_guard: dict | None = None,
     kv_tracker=None,
     reasoning_on: bool = True,
+    schema_overrides: dict | None = None,
 ) -> AsyncIterator[dict]:
     """Yields {"type": "content"|"reasoning", "delta": str} dicts."""
     content = build_writer_content(
@@ -74,7 +75,7 @@ async def _writer_pass(
     msgs = prefix + [{"role": "user", "content": content}]
 
     hyperparams = extract_hyperparams(settings)
-    schemas = enabled_schemas(enabled_tools)
+    schemas = enabled_schemas(enabled_tools, schema_overrides)
     logger.info(
         "Writer pass: tools included=%s",
         json.dumps([s["function"]["name"] for s in schemas]) if schemas else "[]",
@@ -87,5 +88,7 @@ async def _writer_pass(
 
     async for item in client.complete(messages=msgs, model=settings["model_name"], **extra, **hyperparams):
         if item["type"] == "done":
+            if kv_tracker is not None:
+                kv_tracker.record_usage("writer", item.get("usage"))
             return
         yield item

--- a/backend/tool_defs.py
+++ b/backend/tool_defs.py
@@ -25,17 +25,11 @@ _DIRECT_SCENE_DESCRIPTION = (
 )
 
 
-def build_direct_scene_tool(
-    director_fragments: list[dict],
-    progressive_state: dict | None = None,
-) -> dict:
+def build_direct_scene_tool(director_fragments: list[dict]) -> dict:
     """Build the direct_scene tool schema from enabled director fragments.
 
     Director fragments provide dynamic string/array parameters beyond the fixed
     moods and keywords fields. The returned dict is in OpenAI function-calling format.
-
-    For "progressive" fragments, the previous value (from progressive_state) is
-    appended to the description so the LLM can see what it wrote last turn.
     """
     properties: dict = {}
     required: list[str] = []
@@ -49,12 +43,6 @@ def build_direct_scene_tool(
                 "items": {"type": "string"},
                 "description": df["description"],
             }
-        elif field_type == "progressive":
-            desc = df["description"]
-            prev = (progressive_state or {}).get(fid)
-            if prev:
-                desc = f"{desc} Previous value: {prev!r}"
-            prop = {"type": "string", "description": desc}
         else:
             prop = {"type": "string", "description": df["description"]}
         properties[fid] = prop
@@ -239,5 +227,12 @@ PRE_WRITER_TOOLS = {"rewrite_user_prompt"}
 POST_WRITER_TOOLS = {"editor_apply_patch", "editor_rewrite"}
 
 
-def enabled_schemas(enabled_tools: dict) -> list[dict]:
-    return [TOOLS[n]["schema"] for n in TOOLS if enabled_tools.get(n, False)]
+def enabled_schemas(enabled_tools: dict, overrides: dict[str, dict] | None = None) -> list[dict]:
+    """Return tool schemas for enabled tools, in TOOLS registry order.
+
+    ``overrides`` replaces named schemas with dynamic variants so every pass
+    sends a byte-identical tools blob; any mismatch breaks the KV cache at
+    the tools position in the chat template.
+    """
+    overrides = overrides or {}
+    return [s for n in TOOLS if enabled_tools.get(n, False) if (s := overrides.get(n, TOOLS[n]["schema"])) is not None]

--- a/docs/architecture/kv-cache.md
+++ b/docs/architecture/kv-cache.md
@@ -1,0 +1,211 @@
+# How Orb Reuses the LLM's KV Cache
+
+This doc explains, in plain English, how Orb keeps each LLM call fast and cheap by carefully reusing the **KV cache** — the working memory the model builds up as it reads a prompt.
+
+Audience: someone who can read code but isn't deep in LLM internals. No tokenisation math, no transformer diagrams.
+
+---
+
+## 1. What is a KV cache, in one paragraph
+
+When an LLM reads a prompt, it builds an internal scratchpad — the "KV cache" — token by token. If the next prompt **starts with the exact same text** as the previous one, the inference server can skip rebuilding that part of the scratchpad and pick up where it left off. The cache only works as a **prefix**: matching has to start from character zero. Change one comma near the top, and everything after it has to be redone. Append new text at the bottom — the saved work is still good.
+
+That's the only rule Orb cares about, and the whole architecture below is built around honouring it.
+
+---
+
+## 2. The "stack of pancakes" mental model
+
+Picture every LLM call as a stack of text pancakes:
+
+```
+┌──────────────────────────────┐
+│  trailing instruction        │  ← varies per pass
+├──────────────────────────────┤
+│  chat history (oldest→newest)│  ← identical across passes
+├──────────────────────────────┤
+│  system prompt               │  ← identical across passes
+└──────────────────────────────┘     (bottom of the stack = start of the prompt)
+```
+
+Orb's golden rule: **keep the bottom of the stack identical, only change the top.**
+
+Every pass (director, writer, editor) sends the same system prompt and the same chat history. They only differ in the final pancake — the trailing user message and which tool the model is forced to call. The shared bottom is computed once per turn and handed unchanged to every pass.
+
+---
+
+## 3. The three passes side by side
+
+Within a single turn, Orb makes 2–4+ LLM calls. Here's what each one looks like:
+
+### Director pass (1–2 calls)
+
+```
+  system + history                ← cached prefix
++ "[OOC: pause to enhance...] "
++ "Call ONLY this tool: direct_scene ..."
++ user's actual message
+```
+
+`tool_choice` is forced to `direct_scene` (or `rewrite_user_prompt`). The model returns a tool call, never raw prose.
+
+### Writer pass (1 call)
+
+```
+  system + history                ← cached prefix (same as director's)
++ lorebook block
++ "**Scene Direction**\nMood [tense]: ..."   ← injected from director's output
++ user's actual message
+```
+
+`tool_choice="none"`. The model writes prose.
+
+### Editor pass (1–3 calls, only if needed)
+
+```
+  system + history                ← cached prefix (same as writer's)
++ writer's exact user message     ← reuses the writer's trailing pancake
++ assistant: <writer's draft>     ← the prose the writer just produced
++ "[OOC: you are the editor...] Apply patches to fix: ..."
+```
+
+`tool_choice` is forced to `editor_apply_patch` or `editor_rewrite`.
+
+The editor's prompt **extends** the writer's prompt: the writer's trailing user message is reused verbatim. So the editor's cached prefix isn't just system + history; it's all of that **plus the writer's pancake plus the writer's draft**. That's the bulk of where the editor's savings come from.
+
+---
+
+## 4. The invariants that keep the cache intact
+
+### Invariant 1 — One system prompt, shared by every pass
+
+Character card, persona, scenario, example dialogue, post-history instructions, and user description are concatenated into a single system message once per turn. The same string is sent to all three passes. No pass adds, edits, or reorders anything.
+
+### Invariant 2 — One history list, shared by every pass
+
+The chat history is built once per turn. Each pass receives the same list. Attachments (images) are encoded with the same bytes on every reference.
+
+### Invariant 3 — One tool list, shared by every pass
+
+Inference servers serialise the tool schema list into the cached prefix (where in the chat template depends on the server, but it's always *inside* the cached region). So the tool list has to be byte-identical across passes — including passes that won't call any tool. Every pass sends the same schemas; passes that aren't allowed to call them set `tool_choice="none"`.
+
+This has two consequences worth knowing about:
+
+- **Schemas for tools a pass can't use are still sent.** If `direct_scene`, `editor_apply_patch`, and length guard are all on, every pass — including the director, which can only call `direct_scene` — ships schemas for `direct_scene`, `editor_apply_patch`, **and** `editor_rewrite`.
+- **Dynamic schemas are built once per turn, not once per pass.** `direct_scene` is assembled at runtime from the user's enabled director fragments, which inject custom string/array properties into the function's parameters. The schema is built one time per turn from the current fragment set and then threaded through every pass. The shape of `direct_scene` depends only on the fragment configuration, never on per-turn state — so the same fragment set produces the same schema bytes turn after turn.
+
+### Invariant 4 — Director output rides on the trailing message, never on the system prompt
+
+The director picks moods, plot direction, progressive state, etc. None of that mutates the system prompt or the history. The style injection block is bolted onto the writer's trailing user message, at the top of the stack where cache misses are cheap and bounded to a single pancake.
+
+### Invariant 5 — When the agent uses a separate model, the writer drops tools
+
+If the director and editor are configured to run on a different model than the writer, the writer's KV cache lives on a different inference server and can't be shared with the agent passes. In that case, the writer sends no tools at all — including them would just waste tokens with no caching benefit. The agent passes still share a cache with each other on their own server.
+
+---
+
+## 5. Walk-through: one full turn
+
+Let's trace what happens when the user types "I draw my sword." in a turn where all features are on.
+
+### Step 1 — Build the prefix (once)
+
+```python
+prefix = [
+    {"role": "system",    "content": "<all character/scenario text>"},
+    {"role": "user",      "content": "Hi!"},
+    {"role": "assistant", "content": "Hello, traveler..."},
+    ...
+]
+```
+
+### Step 2 — Director call
+
+```python
+msgs = prefix + [{"role": "user", "content": "[OOC...] Call ONLY direct_scene ...\nUser's next message: \"I draw my sword.\""}]
+client.complete(messages=msgs, tools=ALL_SCHEMAS, tool_choice={direct_scene})
+```
+
+The model returns: `direct_scene(moods=["tense", "combat"], keywords=["steel", "stance"])`.
+
+### Step 3 — Writer call
+
+```python
+inj_block = "**Scene Direction**\nMood [tense]: ...\nMood [combat]: ...\n"
+msgs = prefix + [{"role": "user", "content": "<lorebook>\n<inj_block>\nI draw my sword."}]
+client.complete(messages=msgs, tools=ALL_SCHEMAS, tool_choice="none")
+```
+
+The entire `prefix` is reused from the director call. Only the trailing user message is new. On a long conversation, that's typically 90%+ of the prompt cached.
+
+The model streams: "Steel rings as the blade leaves its sheath..."
+
+### Step 4 — Editor call (if audit finds issues)
+
+```python
+msgs = prefix + [
+    {"role": "user",      "content": "<lorebook>\n<inj_block>\nI draw my sword."},  # same as writer's
+    {"role": "assistant", "content": "Steel rings as the blade leaves its sheath..."},  # writer's draft
+    {"role": "user",      "content": "[OOC: you are the editor...] Apply patches to fix: <audit report>"},
+]
+client.complete(messages=msgs, tools=ALL_SCHEMAS, tool_choice={editor_apply_patch})
+```
+
+`prefix` + the writer's trailing user message are both reused. Only the writer's draft and the editor instructions are new. The writer's prose is typically a few hundred tokens; the cached prefix is many thousands.
+
+---
+
+## 6. What happens across turns
+
+When the user sends another message, the new turn's prefix is **the old prefix plus one (user, assistant) pair**:
+
+```
+Turn N writer prompt:  [system, m1, m2, ..., m_k, writer_pancake_N]
+Turn N+1 director:     [system, m1, m2, ..., m_k, user_N, asst_N, director_pancake_{N+1}]
+```
+
+The bottom `[system, m1, ..., m_k]` is byte-identical. The cached portion of turn N's writer call carries over to turn N+1's director call. That's why long sessions don't get linearly slower per turn — most of the prompt is already in the server's KV cache.
+
+---
+
+## 7. The editor's ReAct loop
+
+The editor can iterate a few times before producing its final output. Within those iterations the bottom of the stack — system + history + writer's user message + writer's draft — is held constant, and only the top — the editor instruction plus any prior tool-call/tool-result pair — changes each round. The pattern is the same as the cross-pass design: keep the bottom sacred, let the top vary.
+
+How well that bottom is *already* cached when the loop starts depends on whether the agent and writer share a model:
+
+### Single-model mode (writer + agent on the same server)
+
+The editor's iteration-1 bottom is already hot: system + history was cached by the director and the writer, and the writer's trailing user message + draft were cached when the writer streamed its response. Iteration 1 only pays a cache miss for the editor instruction itself; iterations 2+ pay a miss only for the new tool-call/tool-result turn at the top.
+
+### Dual-model mode (`agent_same_as_writer = false`)
+
+The editor runs on the agent server, which has the director's cache but **never saw the writer's call**. So iteration 1's bottom is only partially hot: `agent_prefix` (system + history under the agent's system prompt) is cached from the director, but the writer's user message and the writer's draft are novel bytes on this server. Iteration 1 pays a cache miss for that whole writer-pancake-and-draft slice plus the editor instruction. From iteration 2 onward the loop behaves identically to single-model — the bottom is now cached on the agent server, and only the new top pancake is new.
+
+In other words: the **intra-loop** discipline is the same in both modes. What differs is the **cross-pass** hand-off into iteration 1 — in single-model the writer pre-warms the editor's bottom; in dual-model the editor has to warm that slice itself on the agent server, and the saving only kicks in from the second iteration.
+
+---
+
+## 8. The KV tracker
+
+Orb logs cache behaviour for each LLM call in two views:
+
+- **Provider** — ground truth. The `usage` field returned by the model server reports how many prompt tokens it actually served from cache. This is the only number that reconciles with the provider's billing dashboard, and it's what to trust when you want to know whether the cache hit.
+- **Local estimate** — a debugging aid alongside provider truth, split into two parts that are deliberately *not* combined:
+  - A character-prefix overlap of the messages list (without tools), giving a percentage shared with the predecessor call.
+  - A binary match/differ on the tools blob.
+
+The split exists because where a chat template renders the tools list (inside the system block, before the final user turn, or somewhere else) determines whether a tools diff actually breaks the wire-level cache. The tracker can't inspect the template, so collapsing the two signals into one "estimated %" would lie. Two split numbers plus provider truth lets a human read what's going on without false precision.
+
+The tracker also remembers the previous turn's snapshot per conversation, so the first call of a new turn is compared against the same-label call from the previous turn rather than reported as a baseline.
+
+---
+
+## 9. TL;DR
+
+- Treat the prompt like a stack: bottom is sacred (system + history + tool schemas), top is freely mutable.
+- Same tool schemas everywhere, even when a pass can't use them. Dynamic schemas are built once per turn from configuration, not per pass.
+- Director output rides on the trailing user message, not the system prompt.
+- The editor extends the writer's stack, not the bare prefix — that's where most editor-pass savings come from.
+- Across turns, the new prefix is "old prefix + one (user, assistant) pair," so cache flows naturally turn-over-turn.
+- Provider `usage` is the truth; the local tracker is an indicator, deliberately unfused so it doesn't lie.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,8 @@ plugins:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Architecture:
+      - KV Cache Reuse: architecture/kv-cache.md
   - Features:
       - features/index.md
       - Writer Direction: features/director.md


### PR DESCRIPTION
Request actual cache hits from provider in kv tracker
Fix kv cache coherence by building the dynamic direct_scene schema once and sharing it across all three passes, this used to bust cache in both single-model and dual-model modes

This reverts commit 32fe9b3ef4f59c65fe86ea2bc4595c5e3aceb9a0.