### PR TITLE
[Refactor] Enforce datatypes to best effort

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ Orb/
 │   ├── orchestrator.py      # Pipeline orchestration: handle_turn, _run_pipeline
 │   ├── database/            # DB package (aiosqlite). __init__.py re-exports the
 │   │                        # full public API for backwards-compatible imports.
+│   │   ├── models.py        # Model layer: TypedDict row contracts + PhraseGroup;
+│   │   │                    # depends on nothing else (see Data Contracts below)
 │   │   ├── connection.py    # DB_PATH, get_db() async context manager, _build_set_clause
 │   │   ├── schema.py        # CREATE TABLES script
 │   │   ├── seeds.py         # SEED_* / DEFAULT_* constants
@@ -225,6 +227,25 @@ erDiagram
     character_cards }o--o| worlds : "world_id"
     worlds ||--o{ lorebook_entries : has
 ```
+
+## Data Contracts (the model layer)
+
+`backend/database/models.py` is the **model layer**: domain data contracts (a `TypedDict` per table-group row, plus the `PhraseGroup` union — `list[str] | LiteralPhraseGroup | RegexPhraseGroup`, a discriminated union keyed on `kind`) that describe the *shape* of persisted data and depend on nothing else in the codebase. The dependency rule is one-way — every other layer points its dependencies **inward**, toward the data, and `backend/database/` must never import "up" into `passes/` or `orchestrator.py`. (The introducing commit moved `PhraseGroup` *down* into `models.py` from `slop_detector.py` to kill the last upward import; anything in `database/` that reaches up for a shared shape is an architectural inversion — put the shape here instead.)
+
+- **The TypedDicts label plain dicts, with zero runtime change.** The query layer still returns ordinary `dict(row)` objects; each query stamps the shape at its boundary with `cast(SomeRow, ...)` (a `TypedDict` is not assignable from a bare `dict`). So `row["col"]` access is checked against the schema without any wrapper object, validation, or runtime cost. Each `queries/*.py` module imports just the contract(s) for its tables (`SettingsRow`, `ConversationRow`/`ConversationListRow`, `MessageRow`/`MessageWithAttachments`, `EndpointRow`, `ModelConfigRow`, `WorldRow`, `LorebookEntryRow`, `CharacterCardRow`, `DirectorStateRow`, `DirectorFragmentRow`, `MoodFragmentRow`, `UserPersonaRow`, `ConversationLogRow`, `PhraseBankRow`, and the attachment rows).
+- **Every row-shaped query return is typed; only free-form blobs stay `dict`.** A query that returns table rows uses a contract. The lone exception is the per-workflow JSON state/config accessors (`get_workflow_state`, `get_workflow_message_state`, `get_workflow_character_state`, `get_workflow_config`) — these decode an arbitrary per-workflow slot with no fixed schema, so they correctly return bare `dict`/`dict | None`. Don't invent a contract for those.
+- **JSON columns are typed as their *decoded* shape** (`dict`/`list`) **only on the queries that actually decode them.** Where a query leaves the column as a raw JSON string it stays `str` — e.g. `MessageRow.progressive_fields` is `dict` because `get_path_to_leaf()` decodes it, while `get_message_by_id()` leaves it a string; `ConversationLogRow` decodes `tool_calls`/`active_moods_after` to lists but leaves `progressive_fields_after` a raw string. The label makes those pre-existing inconsistencies visible rather than fixing them.
+- **SQLite has no boolean type**, so flag columns (`enabled`, `required`, `case_insensitive`, `constant`, …) are typed `int` to match the 0/1 that `dict(row)` returns — not `bool`.
+- **`total=False`** marks contracts whose keys are only conditionally present: the `DEFAULT_SETTINGS` fallback vs the `SELECT *` branch, the column subsets different readers project, and the attachment/branch-nav metadata glued on after the base row.
+- **Required base + optional extension** is the idiom when one reader projects a strict superset of another's columns: a `total=True` base holds the always-present keys (so consumers can subscript them) and a subclass adds the rest. `_SettingsBase` → `SettingsRow`, and `WorkflowAttachmentRowBase` → `WorkflowAttachmentRow` (the base is what `get_workflow_attachments_for_message()` returns — it omits the redundant `message_id` it filters on; the full row that single-row and glue readers return adds it).
+- **The write side mirrors the read side.** `SettingsRow` ⇄ the Pydantic `SettingsUpdate` in `main.py`; `database/schema.py` is the source of truth for columns. When you add, rename, or retype a column, update all three (schema, the row contract, the write-side Pydantic model) in lockstep.
+
+### Type checking (pyright)
+
+`pyrightconfig.json` runs pyright in **standard** mode over `backend/` (target Python 3.12, missing imports downgraded to warnings), and the **whole backend passes clean — zero errors, no file-level suppressions.** (An earlier stage suppressed four rules in `main.py`/`orchestrator.py` while the row TypedDicts were threaded through bare-`dict` helpers; those suppressions are gone now that the consumer signatures were widened.) Keep it at zero:
+
+- **Widen consumers, don't re-tighten producers.** When a typed row flows into a helper, the helper takes `Mapping[str, Any]` (read-only dict) and `Sequence[Mapping[str, Any]]` (read-only list), not bare `dict`/`list[dict]` — `list[SomeRow]` is *not* assignable to `list[dict]` (list is invariant), but it *is* to `Sequence[Mapping[str, Any]]` (covariant). The pipeline already types `history`, `settings`, and the fragment lists this way; `attachments` now matches. Use the concrete `dict`/`list[dict]` only where the code actually mutates the value (e.g. the attachment-cache writer tags and copies dicts — `add_message` materializes `dict(att)` at that boundary).
+- **Don't add suppressions to dodge a type error** — fix the contract or widen the consumer. A `# pyright: ignore` or file-level `# pyright:` header reintroduced here is a regression.
 
 ## API Endpoints
 
@@ -430,7 +451,7 @@ See [docs/architecture/secondary-workflow.md](docs/architecture/secondary-workfl
 
 3. **Tool call parsing** — The Director pass parses JSON tool call arguments. Malformed JSON from the LLM can crash the pipeline. Error handling wraps these in try/except but edge cases exist.
 
-4. **SQLite + aiosqlite** — All DB operations are async via aiosqlite. No ORM — raw SQL inside `backend/database/queries/`, one module per table group. The package's `__init__.py` re-exports every public function so callers can keep importing from `backend.database` directly. Migrations run sequentially by number prefix.
+4. **SQLite + aiosqlite** — All DB operations are async via aiosqlite. No ORM — raw SQL inside `backend/database/queries/`, one module per table group. Rows come back as plain `dict(row)` objects, `cast(...)` to the `TypedDict` contracts in `database/models.py` at the query boundary (see **Data Contracts** above) — there is no runtime row class. The package's `__init__.py` re-exports every public function so callers can keep importing from `backend.database` directly. Migrations run sequentially by number prefix.
 
 5. **Endpoint profiles** — Middleware layer to handle unsupported params where the provider returns an error instead of ignoring them. Not every provider needs its own profile — only add one when a provider's API quirks require body transformation.
 

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -29,22 +29,16 @@ PhraseGroup = Union[list[str], dict]
 # them -- see the per-field notes below.
 
 
-class SettingsRow(TypedDict, total=False):
-    """The merged settings dict returned by ``get_settings()``.
-
-    ``total=False`` on purpose: the dict is assembled from three sources and no
-    single key is guaranteed present everywhere --
-      1. the ``SELECT *`` row off the ``settings`` table,
-      2. the ``DEFAULT_SETTINGS`` fallback (seeds.py) when no row exists, which
-         omits several keys, and
-      3. the agent-endpoint cascade, which overlays the ``agent_*`` /
-         ``endpoint_url`` extras only when an active model config resolves.
-    So this catches key *typos* and value-*type* mismatches without falsely
-    asserting presence. The write side of the same table is the Pydantic
-    ``SettingsUpdate`` in backend/main.py -- keep the two in sync.
+class _SettingsBase(TypedDict):
+    """The keys ``get_settings()`` *always* returns, in either branch -- the
+    ``DEFAULT_SETTINGS`` fallback (seeds.py) supplies exactly this set, and the
+    ``SELECT *`` branch supplies them too (every one is a persisted column or a
+    field the query unconditionally sets). Splitting these out as a ``total=True``
+    base lets readers subscript them (``settings["endpoint_url"]``) without a
+    not-required-access warning, while genuinely-conditional keys stay optional
+    on ``SettingsRow`` below. Keep this set in lockstep with ``DEFAULT_SETTINGS``.
     """
 
-    # Persisted scalar columns (schema.py: settings).
     endpoint_url: str
     api_key: str
     model_name: str
@@ -63,23 +57,41 @@ class SettingsRow(TypedDict, total=False):
     length_guard_max_paragraphs: int
     length_guard_enabled: int
     length_guard_enforce: int
-    active_persona_id: int | None
-    active_endpoint_id: int | None
     character_library_view: str
     character_library_sort: str
     show_editor_diff: int
+    editor_audit_toggles: dict  # decoded to its in-memory shape by get_settings()
     hide_streaming_until_baked: int
     prevent_prompt_overrides: int
     agent_same_as_writer: bool
-    agent_endpoint_id: int | None
     agent_shared_system_prompt: str
+
+
+class SettingsRow(_SettingsBase, total=False):
+    """The merged settings dict returned by ``get_settings()``.
+
+    The always-present keys live on :class:`_SettingsBase`; the keys here are
+    ``total=False`` because they are *not* guaranteed present --
+      1. several columns / JSON fields appear only on the ``SELECT *`` branch and
+         are omitted by the ``DEFAULT_SETTINGS`` fallback, and
+      2. the agent-endpoint cascade overlays the ``agent_*`` / ``endpoint_url``
+         extras only when an active model config resolves.
+    So this catches key *typos* and value-*type* mismatches without falsely
+    asserting presence. The write side of the same table is the Pydantic
+    ``SettingsUpdate`` in backend/main.py -- keep the two in sync.
+    """
+
+    # Columns present on the SELECT * branch but omitted by DEFAULT_SETTINGS.
+    active_persona_id: int | None
+    active_endpoint_id: int | None
+    agent_endpoint_id: int | None
     attachment_cache_budget_bytes: int
     attachment_access_counter: int
-    # JSON columns, decoded to their in-memory shape by get_settings().
+    # JSON columns, decoded to their in-memory shape by get_settings() on the
+    # SELECT * branch only (DEFAULT_SETTINGS omits them).
     enabled_tools: dict
     reasoning_enabled_passes: dict
     inspector_open_states: dict
-    editor_audit_toggles: dict
     workflow_config: str  # left raw; decoded per-slot by get_workflow_config()
     # Agent-endpoint cascade overlays (present only when it resolves).
     agent_endpoint_url: str

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -11,10 +11,40 @@ from __future__ import annotations
 
 from typing import Literal, TypedDict, Union
 
-# A phrase-bank group is either a legacy list of literal variant strings, or a
-# {"kind": "literal"|"regex", ...} dict. The matching semantics that consume
-# this shape live in backend/passes/editor/slop_detector.py.
-PhraseGroup = Union[list[str], dict]
+
+# A phrase-bank group is one of three shapes. ``get_phrase_bank()`` emits the
+# two ``{"kind": ...}`` dicts; the bare ``list[str]`` is a legacy literal group
+# still accepted by the detector for backwards compatibility. The matching
+# semantics that consume these shapes live in
+# backend/passes/editor/slop_detector.py.
+class LiteralPhraseGroup(TypedDict):
+    """A set of equivalent literal variant phrases."""
+
+    kind: Literal["literal"]
+    variants: list[str]
+
+
+class RegexPhraseGroup(TypedDict):
+    """A single regex, matched case-insensitively against each sentence."""
+
+    kind: Literal["regex"]
+    pattern: str
+
+
+PhraseGroup = Union[list[str], LiteralPhraseGroup, RegexPhraseGroup]
+
+
+class PhraseBankRow(TypedDict):
+    """A ``phrase_bank`` row as get_phrase_bank_rows() exposes it for UI
+    management -- distinct from :data:`PhraseGroup` (the detector-facing shape).
+    ``variants`` is the JSON-*decoded* list; ``kind`` is normalised to
+    ``"literal"`` when the column is NULL, and ``pattern`` to ``""``.
+    """
+
+    id: int
+    kind: str
+    variants: list[str]
+    pattern: str
 
 
 # ── Row contracts ──────────────────────────────────────────────────────────
@@ -167,11 +197,21 @@ class UserAttachmentRow(TypedDict, total=False):
     created_at: str
 
 
-class WorkflowAttachmentRow(TypedDict, total=False):
-    """A row from ``workflow_attachments`` (schema.py)."""
+class WorkflowAttachmentRowBase(TypedDict):
+    """The columns every ``workflow_attachments`` reader projects.
+
+    ``get_workflow_attachments_for_message()`` filters by ``message_id`` and
+    omits that redundant column, so it returns this base directly; the
+    single-row reader and the per-message attachment glue also project
+    ``message_id`` and return the fuller :class:`WorkflowAttachmentRow`. Split
+    out as a ``total=True`` base so those full-row readers can require the FK
+    (consumers subscript it) while the projection reader stays honest. Mirrors
+    the ``_SettingsBase`` / :class:`SettingsRow` split. ``data_b64`` is the
+    EVICTED_MARKER sentinel string once an artifact's bytes are evicted -- see
+    secondary-workflow.md §9.
+    """
 
     id: int
-    message_id: int
     mime_type: str
     data_b64: str
     filename: str | None
@@ -184,6 +224,15 @@ class WorkflowAttachmentRow(TypedDict, total=False):
     consumption_metadata: str | None
     active_sibling_id: int | None
     recent_accesses: str | None
+
+
+class WorkflowAttachmentRow(WorkflowAttachmentRowBase):
+    """A fully-projected ``workflow_attachments`` row -- the shared columns plus
+    the ``message_id`` FK -- as get_workflow_attachment_by_id() and the
+    per-message attachment glue return it.
+    """
+
+    message_id: int
 
 
 class MessageWithAttachments(MessageRow, total=False):
@@ -309,6 +358,33 @@ class DirectorStateRow(TypedDict):
     active_moods: list
     keywords: list
     progressive_fields: dict
+
+
+class ConversationLogRow(TypedDict):
+    """A ``conversation_logs`` row as get_conversation_logs() /
+    get_director_log_for_message() expose it.
+
+    ``tool_calls`` and ``active_moods_after`` are JSON-*decoded* to lists;
+    ``progressive_fields_after`` is left as the raw JSON string (neither reader
+    decodes it). The nullable TEXT/INTEGER columns come back ``None`` when unset
+    -- get_director_log_for_message() additionally defaults the ``reasoning_*``
+    keys to ``""``, but get_conversation_logs() leaves them as stored.
+    """
+
+    id: int
+    conversation_id: str
+    turn_index: int
+    agent_raw_output: str | None
+    tool_calls: list
+    active_moods_after: list
+    progressive_fields_after: str
+    injection_block: str | None
+    agent_latency_ms: int | None
+    created_at: str
+    message_id: int | None
+    reasoning_director: str | None
+    reasoning_writer: str | None
+    reasoning_editor: str | None
 
 
 class CharacterCardRow(TypedDict, total=False):

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -94,6 +94,35 @@ class SettingsRow(TypedDict, total=False):
     agent_system_prompt: str
 
 
+class ConversationRow(TypedDict):
+    """A row from the ``conversations`` table (schema.py).
+
+    ``workflow_state`` is left as the raw JSON string; it is decoded per-slot by
+    get_workflow_state(), not eagerly here.
+    """
+
+    id: str
+    title: str
+    character_card_id: str | None
+    character_name: str
+    character_scenario: str
+    post_history_instructions: str
+    created_at: str
+    updated_at: str | None
+    active_leaf_id: int | None
+    workflow_state: str | None
+
+
+class ConversationListRow(ConversationRow, total=False):
+    """A ``ConversationRow`` plus the two aggregate columns list_conversations()
+    selects for the sidebar. ``total=False`` because they exist only on that
+    query's rows, not on the base table.
+    """
+
+    last_message_preview: str | None
+    message_count: int
+
+
 class MessageRow(TypedDict):
     """A row from the ``messages`` table.
 

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -119,7 +119,7 @@ class SettingsRow(_SettingsBase, total=False):
     attachment_access_counter: int
     # JSON columns, decoded to their in-memory shape by get_settings() on the
     # SELECT * branch only (DEFAULT_SETTINGS omits them).
-    enabled_tools: dict
+    enabled_tools: dict[str, bool]
     reasoning_enabled_passes: dict
     inspector_open_states: dict
     workflow_config: str  # left raw; decoded per-slot by get_workflow_config()

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -1,0 +1,17 @@
+"""Domain data contracts owned by the database (the model layer).
+
+These describe the *shape* of persisted data and depend on nothing else in the
+codebase, so every other layer can point its dependencies inward, toward the
+data — never the reverse. Anything in backend/database/ that reaches "up" into
+passes/ or the orchestrator for a shared shape is an architectural inversion;
+put the shape here instead.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+# A phrase-bank group is either a legacy list of literal variant strings, or a
+# {"kind": "literal"|"regex", ...} dict. The matching semantics that consume
+# this shape live in backend/passes/editor/slop_detector.py.
+PhraseGroup = Union[list[str], dict]

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -9,9 +9,152 @@ put the shape here instead.
 
 from __future__ import annotations
 
-from typing import Union
+from typing import Literal, TypedDict, Union
 
 # A phrase-bank group is either a legacy list of literal variant strings, or a
 # {"kind": "literal"|"regex", ...} dict. The matching semantics that consume
 # this shape live in backend/passes/editor/slop_detector.py.
 PhraseGroup = Union[list[str], dict]
+
+
+# ── Row contracts ──────────────────────────────────────────────────────────
+#
+# These TypedDicts label the plain dicts the query layer fetches from SQLite
+# (``dict(row)``), so callers' ``row["key"]`` access is checked against the
+# schema with *zero* runtime change -- the rows stay ordinary dicts. They are
+# introduced at the query boundary with ``cast(...)`` (a TypedDict is not
+# assignable from a bare ``dict``). Add tables here one at a time; mirror the
+# columns in backend/database/schema.py. JSON-encoded columns are typed as the
+# *decoded* shape (``dict``/``list``) only on the queries that actually decode
+# them -- see the per-field notes below.
+
+
+class SettingsRow(TypedDict, total=False):
+    """The merged settings dict returned by ``get_settings()``.
+
+    ``total=False`` on purpose: the dict is assembled from three sources and no
+    single key is guaranteed present everywhere --
+      1. the ``SELECT *`` row off the ``settings`` table,
+      2. the ``DEFAULT_SETTINGS`` fallback (seeds.py) when no row exists, which
+         omits several keys, and
+      3. the agent-endpoint cascade, which overlays the ``agent_*`` /
+         ``endpoint_url`` extras only when an active model config resolves.
+    So this catches key *typos* and value-*type* mismatches without falsely
+    asserting presence. The write side of the same table is the Pydantic
+    ``SettingsUpdate`` in backend/main.py -- keep the two in sync.
+    """
+
+    # Persisted scalar columns (schema.py: settings).
+    endpoint_url: str
+    api_key: str
+    model_name: str
+    temperature: float
+    min_p: float
+    top_k: int
+    top_p: float
+    repetition_penalty: float
+    max_tokens: int
+    shared_system_prompt: str
+    system_prompt: str
+    user_name: str
+    user_description: str
+    enable_agent: bool
+    length_guard_max_words: int
+    length_guard_max_paragraphs: int
+    length_guard_enabled: int
+    length_guard_enforce: int
+    active_persona_id: int | None
+    active_endpoint_id: int | None
+    character_library_view: str
+    character_library_sort: str
+    show_editor_diff: int
+    hide_streaming_until_baked: int
+    prevent_prompt_overrides: int
+    agent_same_as_writer: bool
+    agent_endpoint_id: int | None
+    agent_shared_system_prompt: str
+    attachment_cache_budget_bytes: int
+    attachment_access_counter: int
+    # JSON columns, decoded to their in-memory shape by get_settings().
+    enabled_tools: dict
+    reasoning_enabled_passes: dict
+    inspector_open_states: dict
+    editor_audit_toggles: dict
+    workflow_config: str  # left raw; decoded per-slot by get_workflow_config()
+    # Agent-endpoint cascade overlays (present only when it resolves).
+    agent_endpoint_url: str
+    agent_api_key: str
+    agent_model_name: str
+    agent_temperature: float
+    agent_min_p: float
+    agent_top_k: int
+    agent_top_p: float
+    agent_repetition_penalty: float
+    agent_max_tokens: int
+    agent_system_prompt: str
+
+
+class MessageRow(TypedDict):
+    """A row from the ``messages`` table.
+
+    NOTE: ``progressive_fields`` is the JSON-*decoded* dict, which is how
+    get_path_to_leaf()/get_messages() expose it. ``get_message_by_id()`` does a
+    plain ``dict(row)`` and leaves it as the raw JSON *string* -- a pre-existing
+    inconsistency this label makes visible rather than fixes.
+    """
+
+    id: int
+    conversation_id: str
+    role: Literal["user", "assistant"]
+    content: str
+    turn_index: int
+    parent_id: int | None
+    progressive_fields: dict
+    created_at: str
+    workflow_state: str | None
+
+
+class UserAttachmentRow(TypedDict, total=False):
+    """A row from ``user_attachments`` (schema.py)."""
+
+    id: int
+    message_id: int
+    mime_type: str
+    data_b64: str
+    filename: str | None
+    size: int | None
+    created_at: str
+
+
+class WorkflowAttachmentRow(TypedDict, total=False):
+    """A row from ``workflow_attachments`` (schema.py)."""
+
+    id: int
+    message_id: int
+    mime_type: str
+    data_b64: str
+    filename: str | None
+    created_at: str
+    workflow_id: str
+    parent_attachment_id: int | None
+    annotation: str | None
+    seed: str | None
+    generation_metadata: str | None
+    consumption_metadata: str | None
+    active_sibling_id: int | None
+    recent_accesses: str | None
+
+
+class MessageWithAttachments(MessageRow, total=False):
+    """A ``MessageRow`` after the query layer glues on related rows and branch
+    navigation metadata in place. The extra keys are not columns; they are
+    populated by _attach_attachments() and get_messages_with_branch_info(),
+    hence ``total=False``.
+    """
+
+    user_attachments: list[UserAttachmentRow]
+    workflow_attachments: list[WorkflowAttachmentRow]
+    branch_count: int
+    branch_index: int
+    prev_branch_id: int | None
+    next_branch_id: int | None

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -187,3 +187,147 @@ class MessageWithAttachments(MessageRow, total=False):
     branch_index: int
     prev_branch_id: int | None
     next_branch_id: int | None
+
+
+# NOTE on the ``int`` columns below: SQLite has no boolean type. Columns the
+# schema declares ``BOOLEAN`` / flags (enabled, required, case_insensitive,
+# constant, ...) come back from ``dict(row)`` as 0/1 ints, so they are typed
+# ``int`` to match the runtime value, not ``bool``.
+
+
+class EndpointRow(TypedDict):
+    """A row from the ``endpoints`` table. Every query selects exactly these
+    five columns (avatar/secret columns are never projected here)."""
+
+    id: int
+    url: str
+    api_key: str
+    active_model_config_id: int | None
+    agent_active_model_config_id: int | None
+
+
+class ModelConfigRow(TypedDict):
+    """A row from the ``model_configs`` table (``SELECT *``)."""
+
+    id: int
+    endpoint_id: int
+    model_name: str
+    system_prompt: str
+    temperature: float
+    min_p: float
+    top_k: int
+    top_p: float
+    repetition_penalty: float
+    max_tokens: int
+    role: Literal["writer", "agent"]
+
+
+class WorldRow(TypedDict):
+    """A row from the ``worlds`` table (``SELECT *``)."""
+
+    id: str
+    name: str
+    enabled: int
+    created_at: str
+    updated_at: str
+
+
+class LorebookEntryRow(TypedDict):
+    """A row from ``lorebook_entries``. ``keywords`` is the JSON-*decoded* list
+    (every reader runs it through _parse_lorebook_entry / an inline decode)."""
+
+    id: int
+    world_id: str
+    name: str
+    content: str
+    keywords: list
+    case_insensitive: int
+    constant: int
+    priority: int
+    enabled: int
+    sort_order: int
+    created_at: str
+    updated_at: str
+
+
+class UserPersonaRow(TypedDict):
+    """A row from ``user_personas`` (the queries select these six columns)."""
+
+    id: int
+    name: str
+    description: str
+    avatar_color: str | None
+    created_at: str
+    updated_at: str
+
+
+class DirectorFragmentRow(TypedDict):
+    """A row from ``director_fragments`` (``SELECT *``)."""
+
+    id: str
+    label: str
+    description: str
+    field_type: str
+    required: int
+    enabled: int
+    injection_label: str
+    sort_order: int
+
+
+class MoodFragmentRow(TypedDict):
+    """A row from ``mood_fragments`` (``SELECT *``)."""
+
+    id: str
+    label: str
+    description: str
+    prompt_text: str
+    negative_prompt: str
+    enabled: int
+
+
+class DirectorStateRow(TypedDict):
+    """The director-state dict returned by ``get_director_state()``.
+
+    The JSON columns are decoded before return: ``active_moods`` and
+    ``keywords`` to lists, ``progressive_fields`` to a dict. When no row exists
+    the query synthesizes the same shape with empty containers.
+    """
+
+    conversation_id: str
+    active_moods: list
+    keywords: list
+    progressive_fields: dict
+
+
+class CharacterCardRow(TypedDict, total=False):
+    """A row from ``character_cards``.
+
+    ``total=False`` because the readers project different column subsets:
+    ``list_character_cards`` drops ``avatar_mime`` (and adds ``has_avatar``),
+    ``get_character_card`` includes ``avatar_b64`` only when ``include_avatar``.
+    ``tags`` and ``alternate_greetings`` are the JSON-*decoded* lists;
+    ``has_avatar`` is a derived bool, not a column.
+    """
+
+    id: str
+    name: str
+    description: str
+    personality: str
+    scenario: str
+    first_mes: str
+    mes_example: str
+    creator_notes: str
+    system_prompt: str
+    post_history_instructions: str
+    tags: list
+    creator: str
+    character_version: str
+    alternate_greetings: list
+    avatar_b64: str | None
+    avatar_mime: str | None
+    source_format: str
+    world_id: str | None
+    created_at: str
+    updated_at: str
+    workflow_state: str | None
+    has_avatar: bool

--- a/backend/database/queries/character_cards.py
+++ b/backend/database/queries/character_cards.py
@@ -3,30 +3,32 @@ from __future__ import annotations
 import base64
 import json
 from datetime import datetime, timezone
+from typing import cast
 
 import aiosqlite
 
 from ..connection import _build_set_clause, get_db
+from ..models import CharacterCardRow
 
 
-async def list_character_cards() -> list[dict]:
+async def list_character_cards() -> list[CharacterCardRow]:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
                 "SELECT id, name, description, personality, scenario, first_mes, creator_notes, system_prompt, tags, creator, source_format, created_at, updated_at, avatar_mime, world_id FROM character_cards ORDER BY updated_at DESC"
             )
         )
-        result = []
+        result: list[CharacterCardRow] = []
         for r in rows:
             d = dict(r)
             d["tags"] = json.loads(d["tags"]) if d["tags"] else []
             d["has_avatar"] = d["avatar_mime"] is not None
             del d["avatar_mime"]
-            result.append(d)
+            result.append(cast(CharacterCardRow, d))
         return result
 
 
-async def get_character_card(card_id: str, include_avatar: bool = False) -> dict | None:
+async def get_character_card(card_id: str, include_avatar: bool = False) -> CharacterCardRow | None:
     async with get_db() as db:
         cols = (
             "*"
@@ -49,10 +51,10 @@ async def get_character_card(card_id: str, include_avatar: bool = False) -> dict
         d["tags"] = json.loads(d["tags"]) if d.get("tags") else []
         d["alternate_greetings"] = json.loads(d["alternate_greetings"]) if d.get("alternate_greetings") else []
         d["has_avatar"] = d.get("avatar_mime") is not None
-        return d
+        return cast(CharacterCardRow, d)
 
 
-async def create_character_card(data: dict) -> dict:
+async def create_character_card(data: dict) -> CharacterCardRow:
     async with get_db() as db:
         now = datetime.now(timezone.utc).isoformat()
         try:
@@ -119,7 +121,7 @@ async def insert_alternate_greeting_swipes(cid: str, alternate_greetings: list[s
         return count
 
 
-async def update_character_card(card_id: str, data: dict) -> dict | None:
+async def update_character_card(card_id: str, data: dict) -> CharacterCardRow | None:
     async with get_db() as db:
         allowed = [
             "name",
@@ -211,7 +213,7 @@ async def delete_character_card(card_id: str, delete_conversations: bool = False
 
 
 async def resolve_char_context(
-    conv: dict, settings: dict, shared_key: str = "shared_system_prompt", card: dict | None = None
+    conv: dict, settings: dict, shared_key: str = "shared_system_prompt", card: CharacterCardRow | None = None
 ) -> tuple[str, str, str]:
     """Resolve the effective system prompt, persona, and example messages.
 
@@ -235,8 +237,9 @@ async def resolve_char_context(
     if card:
         char_persona = "\n\n".join(filter(None, [card.get("description", ""), card.get("personality", "")]))
         mes_example = card.get("mes_example", "")
-        if card.get("system_prompt") and not settings.get("prevent_prompt_overrides"):
-            system_prompt = card["system_prompt"]
+        card_system_prompt = card.get("system_prompt")
+        if card_system_prompt and not settings.get("prevent_prompt_overrides"):
+            system_prompt = card_system_prompt
     return system_prompt, char_persona, mes_example
 
 

--- a/backend/database/queries/character_cards.py
+++ b/backend/database/queries/character_cards.py
@@ -164,7 +164,7 @@ async def update_character_card(card_id: str, data: dict) -> CharacterCardRow | 
         return await get_character_card(card_id)
 
 
-async def sync_conversations_for_card(card_id: str, card: dict, old_name: str | None = None) -> None:
+async def sync_conversations_for_card(card_id: str, card: Mapping[str, Any], old_name: str | None = None) -> None:
     """Propagate mutable card fields to all conversations linked to this card.
 
     Only syncs fields that are denormalised onto the conversation row and

--- a/backend/database/queries/character_cards.py
+++ b/backend/database/queries/character_cards.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import json
 from datetime import datetime, timezone
-from typing import cast
+from typing import Any, Mapping, cast
 
 import aiosqlite
 
@@ -213,7 +213,10 @@ async def delete_character_card(card_id: str, delete_conversations: bool = False
 
 
 async def resolve_char_context(
-    conv: dict, settings: dict, shared_key: str = "shared_system_prompt", card: CharacterCardRow | None = None
+    conv: Mapping[str, Any],
+    settings: Mapping[str, Any],
+    shared_key: str = "shared_system_prompt",
+    card: CharacterCardRow | None = None,
 ) -> tuple[str, str, str]:
     """Resolve the effective system prompt, persona, and example messages.
 

--- a/backend/database/queries/conversation_logs.py
+++ b/backend/database/queries/conversation_logs.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
+from typing import cast
 
 from ..connection import get_db
+from ..models import ConversationLogRow
 
 
 async def add_conversation_log(
@@ -57,7 +59,7 @@ async def get_moods_before_turn(cid: str, turn_index: int) -> list[str]:
         return []
 
 
-async def get_conversation_logs(cid: str) -> list[dict]:
+async def get_conversation_logs(cid: str) -> list[ConversationLogRow]:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
@@ -70,11 +72,11 @@ async def get_conversation_logs(cid: str) -> list[dict]:
             d = dict(r)
             d["tool_calls"] = json.loads(d["tool_calls"]) if d["tool_calls"] else []
             d["active_moods_after"] = json.loads(d["active_moods_after"]) if d["active_moods_after"] else []
-            result.append(d)
+            result.append(cast(ConversationLogRow, d))
         return result
 
 
-async def get_director_log_for_message(message_id: int) -> dict | None:
+async def get_director_log_for_message(message_id: int) -> ConversationLogRow | None:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
@@ -90,4 +92,4 @@ async def get_director_log_for_message(message_id: int) -> dict | None:
         d.setdefault("reasoning_director", "")
         d.setdefault("reasoning_writer", "")
         d.setdefault("reasoning_editor", "")
-        return d
+        return cast(ConversationLogRow, d)

--- a/backend/database/queries/conversations.py
+++ b/backend/database/queries/conversations.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
+from typing import cast
 
 from ..connection import _build_set_clause, get_db
+from ..models import ConversationListRow, ConversationRow
 
 
-async def list_conversations() -> list[dict]:
+async def list_conversations() -> list[ConversationListRow]:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
@@ -22,13 +24,13 @@ async def list_conversations() -> list[dict]:
         """
             )
         )
-        return [dict(r) for r in rows]
+        return [cast(ConversationListRow, dict(r)) for r in rows]
 
 
-async def get_conversation(cid: str) -> dict | None:
+async def get_conversation(cid: str) -> ConversationRow | None:
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT * FROM conversations WHERE id = ?", (cid,)))
-        return dict(rows[0]) if rows else None
+        return cast(ConversationRow, dict(rows[0])) if rows else None
 
 
 async def create_conversation(
@@ -38,7 +40,7 @@ async def create_conversation(
     char_scenario: str,
     post_history_instructions: str = "",
     character_card_id: str | None = None,
-) -> dict:
+) -> ConversationRow:
     async with get_db() as db:
         now = datetime.now(timezone.utc).isoformat()
         await db.execute(
@@ -83,7 +85,7 @@ async def touch_conversation(cid: str) -> bool:
         return cur.rowcount > 0
 
 
-async def update_conversation(cid: str, data: dict) -> dict | None:
+async def update_conversation(cid: str, data: dict) -> ConversationRow | None:
     async with get_db() as db:
         allowed = ["title"]
         sets, vals = _build_set_clause(allowed, data)

--- a/backend/database/queries/director_fragments.py
+++ b/backend/database/queries/director_fragments.py
@@ -1,21 +1,24 @@
 from __future__ import annotations
 
+from typing import cast
+
 from ..connection import _build_set_clause, get_db
+from ..models import DirectorFragmentRow
 
 
-async def get_director_fragments() -> list[dict]:
+async def get_director_fragments() -> list[DirectorFragmentRow]:
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT * FROM director_fragments ORDER BY sort_order ASC, label ASC"))
-        return [dict(r) for r in rows]
+        return [cast(DirectorFragmentRow, dict(r)) for r in rows]
 
 
-async def get_director_fragment(fid: str) -> dict | None:
+async def get_director_fragment(fid: str) -> DirectorFragmentRow | None:
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT * FROM director_fragments WHERE id = ?", (fid,)))
-        return dict(rows[0]) if rows else None
+        return cast(DirectorFragmentRow, dict(rows[0])) if rows else None
 
 
-async def create_director_fragment(data: dict) -> dict | None:
+async def create_director_fragment(data: dict) -> DirectorFragmentRow | None:
     async with get_db() as db:
         await db.execute(
             "INSERT INTO director_fragments (id, label, description, field_type, required, enabled, injection_label, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
@@ -34,7 +37,7 @@ async def create_director_fragment(data: dict) -> dict | None:
         return await get_director_fragment(data["id"])
 
 
-async def update_director_fragment(fid: str, data: dict) -> dict | None:
+async def update_director_fragment(fid: str, data: dict) -> DirectorFragmentRow | None:
     async with get_db() as db:
         allowed = [
             "label",

--- a/backend/database/queries/director_state.py
+++ b/backend/database/queries/director_state.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import json
+from typing import cast
 
 from ..connection import get_db
+from ..models import DirectorStateRow
 
 
-async def get_director_state(cid: str) -> dict:
+async def get_director_state(cid: str) -> DirectorStateRow:
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT * FROM director_state WHERE conversation_id = ?", (cid,)))
         if rows:
@@ -19,7 +21,7 @@ async def get_director_state(cid: str) -> dict:
             # Handle progressive_fields column (may be missing in older DBs)
             raw_pf = r.get("progressive_fields")
             r["progressive_fields"] = json.loads(raw_pf) if raw_pf else {}
-            return r
+            return cast(DirectorStateRow, r)
         return {
             "conversation_id": cid,
             "active_moods": [],

--- a/backend/database/queries/endpoints.py
+++ b/backend/database/queries/endpoints.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
+from typing import cast
+
 from ..connection import _build_set_clause, get_db
+from ..models import EndpointRow, ModelConfigRow
 
 
-async def get_endpoints() -> list[dict]:
+async def get_endpoints() -> list[EndpointRow]:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
                 "SELECT id, url, api_key, active_model_config_id, agent_active_model_config_id FROM endpoints ORDER BY id ASC"
             )
         )
-        return [dict(r) for r in rows]
+        return [cast(EndpointRow, dict(r)) for r in rows]
 
 
-async def get_endpoint(endpoint_id: int) -> dict | None:
+async def get_endpoint(endpoint_id: int) -> EndpointRow | None:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
@@ -21,10 +24,10 @@ async def get_endpoint(endpoint_id: int) -> dict | None:
                 (endpoint_id,),
             )
         )
-        return dict(rows[0]) if rows else None
+        return cast(EndpointRow, dict(rows[0])) if rows else None
 
 
-async def create_endpoint(url: str, api_key: str = "") -> dict:
+async def create_endpoint(url: str, api_key: str = "") -> EndpointRow:
     async with get_db() as db:
         cur = await db.execute("INSERT INTO endpoints (url, api_key) VALUES (?, ?)", (url, api_key))
         endpoint_id = cur.lastrowid
@@ -47,10 +50,10 @@ async def create_endpoint(url: str, api_key: str = "") -> dict:
                 (endpoint_id,),
             )
         )
-        return dict(rows[0])
+        return cast(EndpointRow, dict(rows[0]))
 
 
-async def update_endpoint(endpoint_id: int, data: dict) -> dict | None:
+async def update_endpoint(endpoint_id: int, data: dict) -> EndpointRow | None:
     async with get_db() as db:
         allowed = [
             "url",
@@ -72,7 +75,7 @@ async def update_endpoint(endpoint_id: int, data: dict) -> dict | None:
                 (endpoint_id,),
             )
         )
-        return dict(rows[0]) if rows else None
+        return cast(EndpointRow, dict(rows[0])) if rows else None
 
 
 async def delete_endpoint(endpoint_id: int) -> bool:
@@ -82,7 +85,7 @@ async def delete_endpoint(endpoint_id: int) -> bool:
         return cur.rowcount > 0
 
 
-async def get_model_configs(endpoint_id: int) -> list[dict]:
+async def get_model_configs(endpoint_id: int) -> list[ModelConfigRow]:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
@@ -90,10 +93,10 @@ async def get_model_configs(endpoint_id: int) -> list[dict]:
                 (endpoint_id,),
             )
         )
-        return [dict(r) for r in rows]
+        return [cast(ModelConfigRow, dict(r)) for r in rows]
 
 
-async def create_model_config(endpoint_id: int, data: dict) -> dict:
+async def create_model_config(endpoint_id: int, data: dict) -> ModelConfigRow:
     async with get_db() as db:
         cur = await db.execute(
             "INSERT INTO model_configs (endpoint_id, model_name, system_prompt, temperature, min_p, top_k, top_p, repetition_penalty, max_tokens, role) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -112,10 +115,10 @@ async def create_model_config(endpoint_id: int, data: dict) -> dict:
         )
         await db.commit()
         rows = list(await db.execute_fetchall("SELECT * FROM model_configs WHERE id = ?", (cur.lastrowid,)))
-        return dict(rows[0])
+        return cast(ModelConfigRow, dict(rows[0]))
 
 
-async def update_model_config(config_id: int, data: dict) -> dict | None:
+async def update_model_config(config_id: int, data: dict) -> ModelConfigRow | None:
     async with get_db() as db:
         allowed = [
             "model_name",
@@ -136,7 +139,7 @@ async def update_model_config(config_id: int, data: dict) -> dict | None:
             )
             await db.commit()
         rows = list(await db.execute_fetchall("SELECT * FROM model_configs WHERE id = ?", (config_id,)))
-        return dict(rows[0]) if rows else None
+        return cast(ModelConfigRow, dict(rows[0])) if rows else None
 
 
 async def delete_model_config(config_id: int) -> bool:

--- a/backend/database/queries/messages.py
+++ b/backend/database/queries/messages.py
@@ -3,16 +3,17 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from ..connection import get_db
+from ..models import MessageRow, MessageWithAttachments
 from .conversations import get_conversation
 
 
-async def get_path_to_leaf(cid: str, leaf_id: int) -> list[dict]:
+async def get_path_to_leaf(cid: str, leaf_id: int) -> list[MessageWithAttachments]:
     """Walk parent_id chain from leaf to root, return ordered root→leaf."""
     async with get_db() as db:
-        path = []
+        path: list[MessageWithAttachments] = []
         current_id = leaf_id
         while current_id is not None:
             rows = list(
@@ -23,16 +24,20 @@ async def get_path_to_leaf(cid: str, leaf_id: int) -> list[dict]:
             )
             if not rows:
                 break
+            # Raw row: progressive_fields is still the JSON string here. Decode
+            # it before labeling the dict a MessageWithAttachments, whose
+            # progressive_fields is typed as the decoded dict.
             msg = dict(rows[0])
             raw_pf = msg.get("progressive_fields")
             msg["progressive_fields"] = json.loads(raw_pf) if raw_pf else {}
-            path.append(msg)
-            current_id = msg.get("parent_id")
+            typed_msg = cast(MessageWithAttachments, msg)
+            path.append(typed_msg)
+            current_id = typed_msg.get("parent_id")
         path.reverse()
         return path
 
 
-async def _attach_user_attachments(messages: list[dict]) -> None:
+async def _attach_user_attachments(messages: list[MessageWithAttachments]) -> None:
     if not messages:
         return
     ids = [m["id"] for m in messages]
@@ -52,7 +57,7 @@ async def _attach_user_attachments(messages: list[dict]) -> None:
         m["user_attachments"] = by_msg[m["id"]]
 
 
-async def _attach_workflow_attachments(messages: list[dict]) -> None:
+async def _attach_workflow_attachments(messages: list[MessageWithAttachments]) -> None:
     if not messages:
         return
     ids = [m["id"] for m in messages]
@@ -74,12 +79,12 @@ async def _attach_workflow_attachments(messages: list[dict]) -> None:
         m["workflow_attachments"] = by_msg[m["id"]]
 
 
-async def _attach_attachments(messages: list[dict]) -> None:
+async def _attach_attachments(messages: list[MessageWithAttachments]) -> None:
     await _attach_user_attachments(messages)
     await _attach_workflow_attachments(messages)
 
 
-async def get_messages(cid: str) -> list[dict]:
+async def get_messages(cid: str) -> list[MessageWithAttachments]:
     """Get active path messages (root→leaf) for LLM prompt construction."""
     conv = await get_conversation(cid)
     if not conv:
@@ -92,7 +97,7 @@ async def get_messages(cid: str) -> list[dict]:
     return messages
 
 
-async def get_messages_before(cid: str, message_id: int) -> list[dict]:
+async def get_messages_before(cid: str, message_id: int) -> list[MessageWithAttachments]:
     """Return active-path messages strictly before ``message_id``.
 
     The result is shaped to pass through ``format_message_with_attachments``
@@ -119,7 +124,7 @@ async def get_messages_before(cid: str, message_id: int) -> list[dict]:
     return messages
 
 
-async def get_messages_with_branch_info(cid: str) -> list[dict]:
+async def get_messages_with_branch_info(cid: str) -> list[MessageWithAttachments]:
     """Get active path messages with branch navigation metadata for the frontend."""
     messages = await get_messages(cid)
     if not messages:
@@ -275,11 +280,16 @@ async def update_message_content(msg_id: int, content: str) -> None:
         await db.commit()
 
 
-async def get_message_by_id(msg_id: int) -> dict | None:
-    """Fetch a single message by its primary key."""
+async def get_message_by_id(msg_id: int) -> MessageRow | None:
+    """Fetch a single message by its primary key.
+
+    NOTE: unlike get_path_to_leaf(), this does not JSON-decode
+    ``progressive_fields``; it stays the raw string at runtime even though
+    ``MessageRow`` types it as the decoded dict. See MessageRow's docstring.
+    """
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT * FROM messages WHERE id = ?", (msg_id,)))
-        return dict(rows[0]) if rows else None
+        return cast(MessageRow, dict(rows[0])) if rows else None
 
 
 async def set_active_leaf(cid: str, leaf_id: int | None):

--- a/backend/database/queries/messages.py
+++ b/backend/database/queries/messages.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import datetime, timezone
-from typing import List, Optional, cast
+from typing import Any, List, Mapping, Optional, Sequence, cast
 
 from ..connection import get_db
-from ..models import MessageRow, MessageWithAttachments
+from ..models import (
+    MessageRow,
+    MessageWithAttachments,
+    UserAttachmentRow,
+    WorkflowAttachmentRowBase,
+)
 from .conversations import get_conversation
 
 
@@ -161,7 +166,7 @@ async def add_message(
     content: str,
     turn_index: int,
     parent_id: int | None = None,
-    attachments: Optional[List[dict]] = None,
+    attachments: Optional[Sequence[Mapping[str, Any]]] = None,
     progressive_fields: dict | None = None,
 ) -> tuple[int, list[dict]]:
     """Add a message. Returns ``(message_id, rejected_workflow_atts)``.
@@ -187,12 +192,15 @@ async def add_message(
       'seed', and 'generation_metadata'. Lands in `workflow_attachments`
       through the cache module's batch entry point.
     """
+    # workflow atts are materialized into a fresh list[dict] the cache writer
+    # owns and mutates (it tags rejects with a 'reason' and shallow-copies); the
+    # read-only user atts stay as the caller's mappings.
     workflow_atts: list[dict] = []
-    user_atts: list[dict] = []
+    user_atts: list[Mapping[str, Any]] = []
     for att in attachments or []:
         src = att.get("source")
         if isinstance(src, str) and src.startswith("workflow:"):
-            workflow_atts.append(att)
+            workflow_atts.append(dict(att))
         else:
             user_atts.append(att)
 
@@ -247,7 +255,7 @@ async def add_message(
     return message_id, rejected_workflow_atts
 
 
-async def get_user_attachments_for_message(message_id: int) -> List[dict]:
+async def get_user_attachments_for_message(message_id: int) -> List[UserAttachmentRow]:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
@@ -256,10 +264,10 @@ async def get_user_attachments_for_message(message_id: int) -> List[dict]:
                 (message_id,),
             )
         )
-        return [dict(r) for r in rows]
+        return [cast(UserAttachmentRow, dict(r)) for r in rows]
 
 
-async def get_workflow_attachments_for_message(message_id: int) -> List[dict]:
+async def get_workflow_attachments_for_message(message_id: int) -> List[WorkflowAttachmentRowBase]:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
@@ -270,7 +278,7 @@ async def get_workflow_attachments_for_message(message_id: int) -> List[dict]:
                 (message_id,),
             )
         )
-        return [dict(r) for r in rows]
+        return [cast(WorkflowAttachmentRowBase, dict(r)) for r in rows]
 
 
 async def update_message_content(msg_id: int, content: str) -> None:

--- a/backend/database/queries/mood_fragments.py
+++ b/backend/database/queries/mood_fragments.py
@@ -1,21 +1,24 @@
 from __future__ import annotations
 
+from typing import cast
+
 from ..connection import _build_set_clause, get_db
+from ..models import MoodFragmentRow
 
 
-async def get_mood_fragments() -> list[dict]:
+async def get_mood_fragments() -> list[MoodFragmentRow]:
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT * FROM mood_fragments ORDER BY label ASC"))
-        return [dict(r) for r in rows]
+        return [cast(MoodFragmentRow, dict(r)) for r in rows]
 
 
-async def get_mood_fragment(fid: str) -> dict | None:
+async def get_mood_fragment(fid: str) -> MoodFragmentRow | None:
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT * FROM mood_fragments WHERE id = ?", (fid,)))
-        return dict(rows[0]) if rows else None
+        return cast(MoodFragmentRow, dict(rows[0])) if rows else None
 
 
-async def create_mood_fragment(data: dict) -> dict:
+async def create_mood_fragment(data: dict) -> MoodFragmentRow:
     async with get_db() as db:
         enabled = data.get("enabled", 1)
         await db.execute(
@@ -35,7 +38,7 @@ async def create_mood_fragment(data: dict) -> dict:
         return result
 
 
-async def update_mood_fragment(fid: str, data: dict) -> dict | None:
+async def update_mood_fragment(fid: str, data: dict) -> MoodFragmentRow | None:
     async with get_db() as db:
         allowed = ["label", "description", "prompt_text", "negative_prompt", "enabled"]
         sets, vals = _build_set_clause(allowed, data)

--- a/backend/database/queries/phrase_bank.py
+++ b/backend/database/queries/phrase_bank.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
+from typing import cast
 
 from ..connection import get_db
-from ..models import PhraseGroup
+from ..models import PhraseBankRow, PhraseGroup
 
 
 def _row_to_group(row) -> PhraseGroup:
@@ -20,17 +21,20 @@ async def get_phrase_bank() -> list[PhraseGroup]:
         return [_row_to_group(r) for r in rows]
 
 
-async def get_phrase_bank_rows() -> list[dict]:
+async def get_phrase_bank_rows() -> list[PhraseBankRow]:
     """Return phrase bank rows with ids for UI management."""
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT id, variants, kind, pattern FROM phrase_bank ORDER BY id ASC"))
         return [
-            {
-                "id": r["id"],
-                "kind": r["kind"] or "literal",
-                "variants": json.loads(r["variants"]),
-                "pattern": r["pattern"] or "",
-            }
+            cast(
+                PhraseBankRow,
+                {
+                    "id": r["id"],
+                    "kind": r["kind"] or "literal",
+                    "variants": json.loads(r["variants"]),
+                    "pattern": r["pattern"] or "",
+                },
+            )
             for r in rows
         ]
 

--- a/backend/database/queries/phrase_bank.py
+++ b/backend/database/queries/phrase_bank.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 
 from ..connection import get_db
-from ...passes.editor.slop_detector import PhraseGroup
+from ..models import PhraseGroup
 
 
 def _row_to_group(row) -> PhraseGroup:

--- a/backend/database/queries/phrase_bank.py
+++ b/backend/database/queries/phrase_bank.py
@@ -3,16 +3,17 @@ from __future__ import annotations
 import json
 
 from ..connection import get_db
+from ...passes.editor.slop_detector import PhraseGroup
 
 
-def _row_to_group(row) -> dict:
+def _row_to_group(row) -> PhraseGroup:
     """Normalise a DB row into a phrase-bank group dict for the detector."""
     if (row["kind"] or "literal") == "regex":
         return {"kind": "regex", "pattern": row["pattern"] or ""}
     return {"kind": "literal", "variants": json.loads(row["variants"])}
 
 
-async def get_phrase_bank() -> list[dict]:
+async def get_phrase_bank() -> list[PhraseGroup]:
     """Return phrase bank groups (literal or regex) for the slop detector."""
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT variants, kind, pattern FROM phrase_bank ORDER BY id ASC"))

--- a/backend/database/queries/settings.py
+++ b/backend/database/queries/settings.py
@@ -4,7 +4,6 @@ import json
 
 from ..connection import _build_set_clause, get_db
 from ..seeds import DEFAULT_SETTINGS
-from ...tool_defs import TOOLS
 
 
 async def get_settings() -> dict:
@@ -169,13 +168,6 @@ async def set_workflow_config(workflow_id: str, payload: dict) -> None:
 
 
 async def update_settings(data: dict) -> dict:
-    # enabled_tools holds only model-callable tools. Drop any key that is not a
-    # registered tool so non-tool feature flags (e.g. the former length_guard*
-    # keys) can never be persisted back into it. Feature flags get their own
-    # columns; see migration 0023.
-    if isinstance(data.get("enabled_tools"), dict):
-        data = {**data, "enabled_tools": {k: v for k, v in data["enabled_tools"].items() if k in TOOLS}}
-
     async with get_db() as db:
         allowed = [
             "endpoint_url",

--- a/backend/database/queries/settings.py
+++ b/backend/database/queries/settings.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import json
+from typing import cast
 
 from ..connection import _build_set_clause, get_db
+from ..models import SettingsRow
 from ..seeds import DEFAULT_SETTINGS
 
 
-async def get_settings() -> dict:
+async def get_settings() -> SettingsRow:
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT * FROM settings WHERE id = 1"))
         if not rows:
-            return DEFAULT_SETTINGS
+            return cast(SettingsRow, DEFAULT_SETTINGS)
         s = dict(rows[0])
         s["enabled_tools"] = json.loads(s.get("enabled_tools") or "{}")
         s["reasoning_enabled_passes"] = json.loads(
@@ -111,7 +113,7 @@ async def get_settings() -> dict:
                                 s[f"agent_{field}"] = amc[field]
                         if amc.get("system_prompt") is not None:
                             s["agent_system_prompt"] = amc["system_prompt"]
-        return s
+        return cast(SettingsRow, s)
 
 
 # Empty slot returns {} here; per-workflow default fallback lives in the
@@ -167,7 +169,7 @@ async def set_workflow_config(workflow_id: str, payload: dict) -> None:
         await db.commit()
 
 
-async def update_settings(data: dict) -> dict:
+async def update_settings(data: dict) -> SettingsRow:
     async with get_db() as db:
         allowed = [
             "endpoint_url",

--- a/backend/database/queries/user_personas.py
+++ b/backend/database/queries/user_personas.py
@@ -1,21 +1,23 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import cast
 
 from ..connection import _build_set_clause, get_db
+from ..models import UserPersonaRow
 
 
-async def get_user_personas() -> list[dict]:
+async def get_user_personas() -> list[UserPersonaRow]:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
                 "SELECT id, name, description, avatar_color, created_at, updated_at FROM user_personas ORDER BY name ASC"
             )
         )
-        return [dict(r) for r in rows]
+        return [cast(UserPersonaRow, dict(r)) for r in rows]
 
 
-async def get_user_persona(persona_id: int) -> dict | None:
+async def get_user_persona(persona_id: int) -> UserPersonaRow | None:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
@@ -23,10 +25,10 @@ async def get_user_persona(persona_id: int) -> dict | None:
                 (persona_id,),
             )
         )
-        return dict(rows[0]) if rows else None
+        return cast(UserPersonaRow, dict(rows[0])) if rows else None
 
 
-async def create_user_persona(data: dict) -> dict:
+async def create_user_persona(data: dict) -> UserPersonaRow:
     async with get_db() as db:
         now = datetime.now(timezone.utc).isoformat()
         cur = await db.execute(
@@ -47,7 +49,7 @@ async def create_user_persona(data: dict) -> dict:
         return result
 
 
-async def update_user_persona(persona_id: int, data: dict) -> dict | None:
+async def update_user_persona(persona_id: int, data: dict) -> UserPersonaRow | None:
     async with get_db() as db:
         allowed = ["name", "description", "avatar_color"]
         sets, vals = _build_set_clause(allowed, data)

--- a/backend/database/queries/workflow_attachments.py
+++ b/backend/database/queries/workflow_attachments.py
@@ -18,8 +18,10 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
+from typing import cast
 
 from ..connection import get_db
+from ..models import WorkflowAttachmentRow
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +49,7 @@ def _encode_metadata_field(value: object, field_name: str, workflow_id: str, fil
         return None
 
 
-async def get_workflow_attachment_by_id(att_id: int) -> dict | None:
+async def get_workflow_attachment_by_id(att_id: int) -> WorkflowAttachmentRow | None:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
@@ -58,7 +60,7 @@ async def get_workflow_attachment_by_id(att_id: int) -> dict | None:
                 (att_id,),
             )
         )
-        return dict(rows[0]) if rows else None
+        return cast(WorkflowAttachmentRow, dict(rows[0])) if rows else None
 
 
 async def insert_workflow_attachment_row(

--- a/backend/database/queries/worlds.py
+++ b/backend/database/queries/worlds.py
@@ -3,29 +3,31 @@ from __future__ import annotations
 import json
 import uuid
 from datetime import datetime, timezone
+from typing import cast
 
 from ..connection import _build_set_clause, get_db
+from ..models import LorebookEntryRow, WorldRow
 
 
-async def get_worlds() -> list[dict]:
+async def get_worlds() -> list[WorldRow]:
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT * FROM worlds ORDER BY created_at ASC"))
-        return [dict(r) for r in rows]
+        return [cast(WorldRow, dict(r)) for r in rows]
 
 
-async def get_world(world_id: str) -> dict | None:
+async def get_world(world_id: str) -> WorldRow | None:
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT * FROM worlds WHERE id = ?", (world_id,)))
-        return dict(rows[0]) if rows else None
+        return cast(WorldRow, dict(rows[0])) if rows else None
 
 
-async def get_world_by_name(name: str) -> dict | None:
+async def get_world_by_name(name: str) -> WorldRow | None:
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT * FROM worlds WHERE name = ? LIMIT 1", (name,)))
-        return dict(rows[0]) if rows else None
+        return cast(WorldRow, dict(rows[0])) if rows else None
 
 
-async def create_world(data: dict) -> dict:
+async def create_world(data: dict) -> WorldRow:
     async with get_db() as db:
         now = datetime.now(timezone.utc).isoformat()
         world_id = data.get("id") or str(uuid.uuid4())
@@ -45,7 +47,7 @@ async def create_world(data: dict) -> dict:
         return result
 
 
-async def update_world(world_id: str, data: dict) -> dict | None:
+async def update_world(world_id: str, data: dict) -> WorldRow | None:
     async with get_db() as db:
         allowed = ["name", "enabled"]
         sets, vals = _build_set_clause(allowed, data)
@@ -68,13 +70,13 @@ async def delete_world(world_id: str) -> bool:
         return cur.rowcount > 0
 
 
-def _parse_lorebook_entry(row) -> dict:
+def _parse_lorebook_entry(row) -> LorebookEntryRow:
     d = dict(row)
     d["keywords"] = json.loads(d["keywords"]) if d.get("keywords") else []
-    return d
+    return cast(LorebookEntryRow, d)
 
 
-async def get_lorebook_entries(world_id: str) -> list[dict]:
+async def get_lorebook_entries(world_id: str) -> list[LorebookEntryRow]:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
@@ -85,13 +87,13 @@ async def get_lorebook_entries(world_id: str) -> list[dict]:
         return [_parse_lorebook_entry(r) for r in rows]
 
 
-async def get_lorebook_entry(entry_id: int) -> dict | None:
+async def get_lorebook_entry(entry_id: int) -> LorebookEntryRow | None:
     async with get_db() as db:
         rows = list(await db.execute_fetchall("SELECT * FROM lorebook_entries WHERE id = ?", (entry_id,)))
         return _parse_lorebook_entry(rows[0]) if rows else None
 
 
-async def create_lorebook_entry(world_id: str, data: dict) -> dict:
+async def create_lorebook_entry(world_id: str, data: dict) -> LorebookEntryRow:
     async with get_db() as db:
         now = datetime.now(timezone.utc).isoformat()
         cur = await db.execute(
@@ -117,7 +119,7 @@ async def create_lorebook_entry(world_id: str, data: dict) -> dict:
         return result
 
 
-async def update_lorebook_entry(entry_id: int, data: dict) -> dict | None:
+async def update_lorebook_entry(entry_id: int, data: dict) -> LorebookEntryRow | None:
     async with get_db() as db:
         allowed = [
             "name",
@@ -149,7 +151,7 @@ async def delete_lorebook_entry(entry_id: int) -> bool:
         return cur.rowcount > 0
 
 
-async def get_active_lorebook_entries() -> list[dict]:
+async def get_active_lorebook_entries() -> list[LorebookEntryRow]:
     """Return all enabled entries from enabled worlds, ordered by priority DESC, sort_order ASC."""
     async with get_db() as db:
         rows = list(
@@ -162,9 +164,4 @@ async def get_active_lorebook_entries() -> list[dict]:
             """
             )
         )
-        result = []
-        for r in rows:
-            d = dict(r)
-            d["keywords"] = json.loads(d["keywords"]) if d.get("keywords") else []
-            result.append(d)
-        return result
+        return [_parse_lorebook_entry(r) for r in rows]

--- a/backend/kv_tracker.py
+++ b/backend/kv_tracker.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 from typing import Any, AsyncIterator, Mapping, Sequence
 
 logger = logging.getLogger(__name__)
@@ -269,3 +270,59 @@ async def cached_complete(
         if event["type"] == "done" and kv_tracker is not None:
             kv_tracker.record_usage(label, event.get("usage"))
         yield event
+
+
+@dataclass(frozen=True)
+class CachedBase:
+    """The byte-identical bottom of the prompt stack for one turn on one
+    inference server: the system+history *prefix*, the *tools* blob, and the
+    *model*. Built once per server per turn and shared by every pass that runs
+    on that server, so the cache-relevant bytes are computed in exactly one
+    place and can never be reconstructed — and so silently diverge — per pass.
+
+    Passes EXTEND this base via :meth:`complete`; they never rebuild it. The
+    fields are frozen and stored as tuples so the shared instance cannot have
+    its prefix or tool list mutated, reordered, or swapped out mid-turn — the
+    failure mode the invariants in docs/architecture/kv-cache.md and
+    tests/unit/test_kv_cache_invariants.py exist to catch.
+
+    In dual-model turns there are two bases: one for the writer's server and one
+    for the agent (director + editor) server. Invariant 5 — "the writer drops
+    tools when it runs on a different server than the agent" — is then just a
+    property of how the writer's base is built (empty ``tools``), not a flag
+    threaded through the writer pass.
+    """
+
+    prefix: tuple[Mapping[str, Any], ...]
+    tools: tuple[dict, ...]
+    model: str
+
+    def complete(
+        self,
+        client: Any,
+        *,
+        label: str,
+        trailing: Sequence[Mapping[str, Any]],
+        tool_choice: "dict | str | None" = None,
+        kv_tracker: "_KVCacheTracker | None" = None,
+        record: bool = True,
+        **params: Any,
+    ) -> AsyncIterator[dict]:
+        """Issue one completion that extends this base with *trailing* (the
+        per-pass top of the stack). The cached bottom — prefix + tools + model —
+        comes solely from ``self``; only *trailing* and *tool_choice* vary.
+
+        Delegates to :func:`cached_complete` so the tracker snapshot is taken
+        from the exact bytes sent.
+        """
+        return cached_complete(
+            client,
+            label=label,
+            messages=[*self.prefix, *trailing],
+            model=self.model,
+            tools=list(self.tools) or None,
+            tool_choice=tool_choice,
+            kv_tracker=kv_tracker,
+            record=record,
+            **params,
+        )

--- a/backend/kv_tracker.py
+++ b/backend/kv_tracker.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Any, AsyncIterator, Mapping, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ logger = logging.getLogger(__name__)
 _prev_turn_entries: dict[str, list[dict]] = {}
 
 
-def _serialize_messages(messages: list[dict]) -> str:
+def _serialize_messages(messages: Sequence[Mapping[str, Any]]) -> str:
     """Compact JSON serialization of a messages list; sort_keys for byte-stable output regardless of dict construction order."""
     return "\n".join(json.dumps(m, separators=(",", ":"), sort_keys=True) for m in messages)
 
@@ -127,7 +128,7 @@ class _KVCacheTracker:
     def record(
         self,
         label: str,
-        messages: list[dict],
+        messages: Sequence[Mapping[str, Any]],
         tools: list[dict] | None,
         model: str = "",
     ) -> None:
@@ -225,3 +226,46 @@ class _KVCacheTracker:
 
         if self._conversation_id:
             _prev_turn_entries[self._conversation_id] = list(self._entries)
+
+
+async def cached_complete(
+    client: Any,
+    *,
+    label: str,
+    messages: Sequence[Mapping[str, Any]],
+    model: str,
+    tools: list[dict] | None = None,
+    tool_choice: "dict | str | None" = None,
+    kv_tracker: "_KVCacheTracker | None" = None,
+    record: bool = True,
+    **params: Any,
+) -> AsyncIterator[dict]:
+    """Run ``client.complete`` and snapshot the KV-cache view from the *same*
+    arguments it is called with, so the tracker can never drift from what was
+    actually sent to the model.
+
+    This is the single chokepoint every pipeline pass funnels its completions
+    through. ``record()`` (the prompt snapshot) and ``record_usage()`` (provider
+    truth) are bound to the one ``client.complete`` call here, eliminating the
+    old failure mode where a pass recorded one ``messages``/``tools`` blob and
+    then sent a different one.
+
+    ``record=True`` (default) snapshots the prompt before issuing the call, so
+    each call appends one tracker entry. A multi-call loop (the editor's ReAct
+    iterations) therefore shows *every* iteration — surfacing any mid-loop change
+    to the tools blob that would otherwise be invisible. Provider ``usage`` from
+    the terminal ``done`` event is attached to the latest entry for *label*. All
+    events from ``client.complete`` are yielded through unchanged.
+    """
+    if kv_tracker is not None and record:
+        kv_tracker.record(label, messages, tools, model=model)
+    async for event in client.complete(
+        messages=messages,
+        model=model,
+        tools=tools,
+        tool_choice=tool_choice,
+        **params,
+    ):
+        if event["type"] == "done" and kv_tracker is not None:
+            kv_tracker.record_usage(label, event.get("usage"))
+        yield event

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -11,6 +11,29 @@ from .endpoint_profiles import ModelProfile
 logger = logging.getLogger(__name__)
 
 
+class AbortToken:
+    """A single stop signal shared by every LLMClient in one turn.
+
+    A turn may spin up several physical clients (writer, separate agent, and
+    their macro-resolving wrappers). They all hold a reference to the same
+    token, so ``abort()`` is signalled once and ``is_aborted`` reads the same
+    state everywhere — no per-client fan-out, no list bookkeeping.
+    """
+
+    def __init__(self) -> None:
+        self._event = asyncio.Event()
+
+    def abort(self) -> None:
+        self._event.set()
+
+    @property
+    def is_aborted(self) -> bool:
+        return self._event.is_set()
+
+    async def wait(self) -> None:
+        await self._event.wait()
+
+
 def reasoning_cfg(on: bool) -> dict:
     """Complete reasoning params for a client.complete() call, spread with **.
 
@@ -40,21 +63,23 @@ class LLMClient:
         api_key: str = "",
         timeout: float = 120.0,
         profile: ModelProfile | None = None,
+        abort_token: AbortToken | None = None,
     ):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.timeout = timeout
         self.profile = profile
-        self._abort: asyncio.Event = asyncio.Event()
+        # Shared across the turn's clients when passed in; otherwise a private
+        # token so a standalone client (e.g. a workflow hook) is still abortable.
+        self.abort_token = abort_token or AbortToken()
 
     def abort(self) -> None:
         """Signal all ongoing complete() calls to stop and close their connections."""
-        logger.info("Stop Generation button clicked — abort signal sent to LLM client")
-        self._abort.set()
+        self.abort_token.abort()
 
     @property
     def is_aborted(self) -> bool:
-        return self._abort.is_set()
+        return self.abort_token.is_aborted
 
     def _headers(self) -> dict:
         if self.api_key:
@@ -136,7 +161,7 @@ class LLMClient:
                 # server. (Using asyncio task cancellation instead would leave the
                 # connection open under Python 3.11+ strict cancellation semantics.)
                 aiter = resp.aiter_lines().__aiter__()
-                abort_wait = asyncio.create_task(self._abort.wait())
+                abort_wait = asyncio.create_task(self.abort_token.wait())
                 try:
                     while True:
                         line_task = asyncio.ensure_future(aiter.__anext__())

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -4,7 +4,7 @@ import httpx
 import json
 import logging
 import re
-from typing import AsyncIterator
+from typing import Any, AsyncIterator, Mapping, Sequence
 
 from .endpoint_profiles import ModelProfile
 
@@ -66,7 +66,7 @@ class LLMClient:
 
     async def complete(
         self,
-        messages: list[dict],
+        messages: Sequence[Mapping[str, Any]],
         model: str,
         tools: list[dict] | None = None,
         tool_choice: dict | str | None = None,

--- a/backend/llm_types.py
+++ b/backend/llm_types.py
@@ -12,7 +12,9 @@ catch-all.
 
 from __future__ import annotations
 
-from typing import Literal, TypedDict, Union
+from typing import Any, Literal, TypedDict, Union
+
+from typing_extensions import NotRequired
 
 
 class TextPart(TypedDict):
@@ -47,10 +49,45 @@ class ChatMessage(TypedDict):
 
     A closed shape: a prefix only ever holds these three roles with text or
     multimodal content. The broader wire messages a pass *appends* before a
-    call -- assistant turns carrying ``tool_calls``, ``tool``-role results --
-    are deliberately left as free-form ``dict`` (see the editor pass), mirroring
-    the model layer's rule that only fixed-schema shapes get a contract.
+    call -- assistant turns carrying ``tool_calls`` / ``reasoning_content`` and
+    ``tool``-role results -- are the other members of :data:`WireMessage`.
     """
 
     role: Literal["system", "user", "assistant"]
     content: str | list[ContentPart]
+
+
+class ToolCall(TypedDict):
+    """An OpenAI-format tool call carried on an assistant wire message."""
+
+    id: str
+    type: Literal["function"]
+    function: dict[str, Any]
+
+
+class AssistantToolMessage(TypedDict):
+    """An assistant turn that carries tool calls (and optional reasoning),
+    appended by the ReAct loops when ``reasoning_on`` is set."""
+
+    role: Literal["assistant"]
+    content: str | list[ContentPart]
+    tool_calls: list[ToolCall]
+    reasoning_content: NotRequired[str]
+
+
+class ToolResultMessage(TypedDict):
+    """A ``tool``-role result turn answering a prior :class:`ToolCall`."""
+
+    role: Literal["tool"]
+    tool_call_id: str
+    content: str
+
+
+# The full mutable wire buffer a pass ships to the model: a ``ChatMessage``
+# prefix plus the turns the ReAct loops append. Modelled as a union (not a
+# single open TypedDict) because adding optional keys would make a superset
+# TypedDict a *subtype* of ``ChatMessage`` -- the wrong direction -- so a
+# ``ChatMessage`` could not flow into it. As a union member it flows in
+# directly, letting a buffer be built ``[*prefix, ...]`` and typed
+# ``list[WireMessage]`` with no cast.
+WireMessage = Union[ChatMessage, AssistantToolMessage, ToolResultMessage]

--- a/backend/llm_types.py
+++ b/backend/llm_types.py
@@ -1,0 +1,56 @@
+"""LLM wire-format contracts: the shape of the OpenAI-style chat messages the
+pipeline assembles and ships to the model.
+
+Like ``backend/database/models.py`` (the data layer's contracts) and
+``backend/workflows/contracts.py`` (the workflow layer's), this module is a
+dependency-free leaf -- it describes a *shape* and imports nothing else in the
+codebase, so every layer that builds or consumes messages (the prompt builder,
+the three passes, the orchestrator, the summarizer) can point its dependency
+inward at the contract rather than at the client implementation or the ``utils``
+catch-all.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict, Union
+
+
+class TextPart(TypedDict):
+    """A text content part in a multimodal message body."""
+
+    type: Literal["text"]
+    text: str
+
+
+class ImageURLSpec(TypedDict):
+    """The ``image_url`` payload of an :class:`ImagePart` (a ``data:`` URL)."""
+
+    url: str
+
+
+class ImagePart(TypedDict):
+    """An image content part in a multimodal message body."""
+
+    type: Literal["image_url"]
+    image_url: ImageURLSpec
+
+
+# A message body is either a plain string or, for vision-capable turns, a list
+# of typed parts. ``build_multimodal_content`` and
+# ``format_message_with_attachments`` emit the list form.
+ContentPart = Union[TextPart, ImagePart]
+
+
+class ChatMessage(TypedDict):
+    """One OpenAI-format chat message in a pipeline *prefix* (the system prompt
+    plus chat history that every pass shares byte-for-byte for KV-cache reuse).
+
+    A closed shape: a prefix only ever holds these three roles with text or
+    multimodal content. The broader wire messages a pass *appends* before a
+    call -- assistant turns carrying ``tool_calls``, ``tool``-role results --
+    are deliberately left as free-form ``dict`` (see the editor pass), mirroring
+    the model layer's rule that only fixed-schema shapes get a contract.
+    """
+
+    role: Literal["system", "user", "assistant"]
+    content: str | list[ContentPart]

--- a/backend/macros.py
+++ b/backend/macros.py
@@ -146,13 +146,11 @@ class _PlaceholderClient(LLMClient):
         self._inner = inner
         self._user_name = user_name
         self._char_name = char_name
-
-    def abort(self) -> None:
-        self._inner.abort()
-
-    @property
-    def is_aborted(self) -> bool:
-        return self._inner.is_aborted
+        # Share the inner client's abort token so the inherited abort()/
+        # is_aborted reflect the same turn-wide stop signal — no delegation
+        # overrides needed. Transport config (base_url/profile/…) is left unset
+        # since complete() delegates to the inner client rather than using it.
+        self.abort_token = inner.abort_token
 
     async def complete(
         self,

--- a/backend/macros.py
+++ b/backend/macros.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import random
 import re
-from typing import Any, Mapping, NamedTuple
+from typing import Any, Mapping, NamedTuple, Sequence
 
 from .llm_client import LLMClient
 
@@ -156,7 +156,7 @@ class _PlaceholderClient(LLMClient):
 
     async def complete(
         self,
-        messages: list[dict],
+        messages: Sequence[Mapping[str, Any]],
         model: str,
         tools: list[dict] | None = None,
         tool_choice: dict | str | None = None,

--- a/backend/macros.py
+++ b/backend/macros.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import random
 import re
-from typing import NamedTuple
+from typing import Any, Mapping, NamedTuple
 
 from .llm_client import LLMClient
 
@@ -105,9 +105,9 @@ class Macros(NamedTuple):
     @classmethod
     def from_settings(
         cls,
-        settings: dict,
+        settings: Mapping[str, Any],
         char_name: str,
-        active_persona: dict | None = None,
+        active_persona: Mapping[str, Any] | None = None,
     ) -> "Macros":
         user = active_persona.get("name", "User") if active_persona else settings.get("user_name", "User")
         return cls(user=user, char=char_name)

--- a/backend/main.py
+++ b/backend/main.py
@@ -128,6 +128,7 @@ from .orchestrator import (
     handle_magic_rewrite,
 )
 from .llm_client import LLMClient
+from .tool_defs import TOOLS
 from .macros import Macros
 from . import tavern_cards
 from . import card_downloader
@@ -542,7 +543,12 @@ async def api_get_settings():
 
 @app.put("/api/settings")
 async def api_update_settings(data: SettingsUpdate):
-    return await update_settings(data.model_dump(exclude_unset=True))
+    payload = data.model_dump(exclude_unset=True)
+    # enabled_tools holds only model-callable tools. Drop any key that is not a
+    # registered tool so non-tool feature flags can never be persisted into it.
+    if isinstance(payload.get("enabled_tools"), dict):
+        payload["enabled_tools"] = {k: v for k, v in payload["enabled_tools"].items() if k in TOOLS}
+    return await update_settings(payload)
 
 
 # Endpoints ──

--- a/backend/main.py
+++ b/backend/main.py
@@ -127,7 +127,7 @@ from .orchestrator import (
     handle_super_regenerate,
     handle_magic_rewrite,
 )
-from .llm_client import LLMClient
+from .llm_client import AbortToken, LLMClient
 from .tool_defs import TOOLS
 from .macros import Macros
 from . import tavern_cards
@@ -193,9 +193,10 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Orb", lifespan=lifespan)
 
-# Active LLM generations keyed by conversation ID.
-# Populated when streaming starts; cleared when it ends or is aborted.
-_active_clients: dict[str, list[LLMClient]] = {}
+# Per-conversation abort token for the active LLM generation. Set when streaming
+# starts; cleared when it ends or is aborted. One token covers every client in
+# the turn (writer + optional agent), so /stop signals them all at once.
+_active_aborts: dict[str, AbortToken] = {}
 
 
 @app.middleware("http")
@@ -1028,10 +1029,12 @@ async def api_summarize_conversation(cid: str, data: SummarizeRequest, request: 
     macros = Macros.from_settings(settings, char_name, active_persona)
     user_description = active_persona.get("description", "") if active_persona else settings.get("user_description", "")
 
+    abort_token = AbortToken()
     client = LLMClient(
         settings["endpoint_url"],
         api_key=settings.get("api_key", ""),
         profile=profile_for(settings["endpoint_url"], settings.get("model_name", "")),
+        abort_token=abort_token,
     )
     summarizer = ConversationSummarizer(client, settings)
     llm_messages = summarizer.build_messages(
@@ -1056,7 +1059,7 @@ async def api_summarize_conversation(cid: str, data: SummarizeRequest, request: 
             yield {"event": "error", "data": str(e)}
 
     return _CleanupStreamingResponse(
-        _sse_stream(_gen(), request, client_ref=[client], cid=cid),
+        _sse_stream(_gen(), request, abort_token=abort_token, cid=cid),
         media_type="text/event-stream",
     )
 
@@ -1322,6 +1325,20 @@ async def api_export_character(card_id: str):
     )
 
 
+async def _safe_aclose(gen: AsyncGenerator[Any, None]) -> None:
+    """Close *gen*, shielding the close from cancellation so the generator's own
+    finally blocks (e.g. the orchestrator's fallback persistence of incomplete
+    messages) always run to completion. If the shield itself is cancelled, retry
+    the close once unshielded and swallow any error."""
+    try:
+        await asyncio.shield(gen.aclose())
+    except asyncio.CancelledError:
+        try:
+            await gen.aclose()
+        except Exception:
+            pass
+
+
 class _CleanupStreamingResponse(StreamingResponse):
     """StreamingResponse that guarantees the body async generator is closed
     even when the client disconnects mid-stream.
@@ -1340,30 +1357,22 @@ class _CleanupStreamingResponse(StreamingResponse):
             # (e.g. client disconnected). This ensures the orchestrator's
             # finally block runs and saves any incomplete message.
             if hasattr(self.body_iterator, "aclose"):
-                gen = cast(AsyncGenerator[Any, None], self.body_iterator)
-                try:
-                    await asyncio.shield(gen.aclose())
-                except asyncio.CancelledError:
-                    # Shield was cancelled; try once more
-                    try:
-                        await gen.aclose()
-                    except Exception:
-                        pass
+                await _safe_aclose(cast(AsyncGenerator[Any, None], self.body_iterator))
 
 
 async def _sse_stream(
     gen,
     request: Request,
     *,
-    client_ref: list[LLMClient] | None = None,
+    abort_token: AbortToken | None = None,
     cid: str | None = None,
 ):
     """Wrap an event-dict async generator as SSE, stopping cleanly on client disconnect.
 
-    The primary stop path is the explicit POST /stop endpoint, which calls
-    LLMClient.abort() directly. That in turn breaks out of the asyncio.wait()
-    loop in complete() and lets the async-with block close the TCP connection
-    to the LLM server normally — no task cancellation needed.
+    The primary stop path is the explicit POST /stop endpoint, which signals
+    *abort_token*. That breaks out of the asyncio.wait() loop in complete() and
+    lets the async-with block close the TCP connection to the LLM server
+    normally — no task cancellation needed.
 
     A background watcher also polls request.is_disconnected() as a fallback
     for cases like the user closing the browser tab without clicking Stop.
@@ -1373,9 +1382,8 @@ async def _sse_stream(
         try:
             while True:
                 if await request.is_disconnected():
-                    if client_ref:
-                        for c in client_ref:
-                            c.abort()
+                    if abort_token is not None:
+                        abort_token.abort()
                     return
                 await asyncio.sleep(0.5)
         except asyncio.CancelledError:
@@ -1397,12 +1405,13 @@ async def _sse_stream(
                 return
             await candidate.acquire()
             lock = candidate
+            # Register only after winning the lock, so a rejected loser never
+            # clobbers the winner's entry. `lock is not None` in the finally
+            # gates the matching pop to the same winner.
+            if abort_token is not None:
+                _active_aborts[cid] = abort_token
         watcher = asyncio.create_task(_watch_disconnect())
         async for event in gen:
-            # Register client in _active_clients on the first event (by which
-            # point handle_turn has already populated client_ref).
-            if cid and client_ref and cid not in _active_clients:
-                _active_clients[cid] = list(client_ref)
             evt_type = event["event"]
             evt_data = event.get("data", "")
             if isinstance(evt_data, dict):
@@ -1415,34 +1424,23 @@ async def _sse_stream(
             watcher.cancel()
         if cid and lock is not None:
             # `lock is not None` implies this coroutine won the acquire race and
-            # therefore owns whatever was lazy-registered into _active_clients.
-            # Gating the pop on the same sentinel keeps the rejected-loser path
-            # from deleting the winner's entry and silently no-opping /stop.
-            _active_clients.pop(cid, None)
+            # therefore owns the _active_aborts entry it registered above.
+            _active_aborts.pop(cid, None)
         if lock is not None:
             # Release before gen.aclose() so a queued /edit, /delete, or
             # /switch-branch can proceed in parallel with the inner generator's
             # cleanup rather than waiting on it.
             lock.release()
-        # Shield aclose() from CancelledError so the orchestrator's finally
-        # block (fallback persistence of incomplete messages) always runs.
-        try:
-            await asyncio.shield(gen.aclose())
-        except asyncio.CancelledError:
-            try:
-                await gen.aclose()
-            except Exception:
-                pass
+        await _safe_aclose(gen)
 
 
 @app.post("/api/conversations/{cid}/stop")
 async def api_stop_generation(cid: str):
     """Abort the active LLM generation for this conversation, if any."""
-    clients = _active_clients.get(cid)
-    if clients:
-        for c in clients:
-            c.abort()
-        logger.info("Stop requested for conversation %s — aborted", cid)
+    token = _active_aborts.get(cid)
+    if token is not None:
+        token.abort()
+        logger.info("Stop Generation requested for conversation %s — abort signalled", cid)
     return {"ok": True}
 
 
@@ -1480,12 +1478,12 @@ async def api_fork_edit_message(cid: str, msg_id: int, data: EditMessage, reques
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    client_ref: list[LLMClient] = []
+    abort_token = AbortToken()
     return _CleanupStreamingResponse(
         _sse_stream(
-            handle_fork_edit(cid, msg_id, data.content, client_ref=client_ref),
+            handle_fork_edit(cid, msg_id, data.content, abort_token=abort_token),
             request,
-            client_ref=client_ref,
+            abort_token=abort_token,
             cid=cid,
         ),
         media_type="text/event-stream",
@@ -1531,12 +1529,12 @@ async def api_regenerate_msg(cid: str, msg_id: int, request: Request, data: Opti
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    client_ref: list[LLMClient] = []
+    abort_token = AbortToken()
     return _CleanupStreamingResponse(
         _sse_stream(
-            handle_regenerate(cid, msg_id, client_ref=client_ref),
+            handle_regenerate(cid, msg_id, abort_token=abort_token),
             request,
-            client_ref=client_ref,
+            abort_token=abort_token,
             cid=cid,
         ),
         media_type="text/event-stream",
@@ -1550,12 +1548,12 @@ async def api_super_regenerate_msg(cid: str, msg_id: int, request: Request, data
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    client_ref: list[LLMClient] = []
+    abort_token = AbortToken()
     return _CleanupStreamingResponse(
         _sse_stream(
-            handle_super_regenerate(cid, msg_id, client_ref=client_ref),
+            handle_super_regenerate(cid, msg_id, abort_token=abort_token),
             request,
-            client_ref=client_ref,
+            abort_token=abort_token,
             cid=cid,
         ),
         media_type="text/event-stream",
@@ -1569,12 +1567,12 @@ async def api_magic_rewrite_msg(cid: str, msg_id: int, request: Request, data: M
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    client_ref: list[LLMClient] = []
+    abort_token = AbortToken()
     return _CleanupStreamingResponse(
         _sse_stream(
-            handle_magic_rewrite(cid, msg_id, data.direction, client_ref=client_ref),
+            handle_magic_rewrite(cid, msg_id, data.direction, abort_token=abort_token),
             request,
-            client_ref=client_ref,
+            abort_token=abort_token,
             cid=cid,
         ),
         media_type="text/event-stream",
@@ -1712,12 +1710,12 @@ async def api_send_message(cid: str, data: SendMessage, request: Request):
         raise HTTPException(status_code=404, detail="Conversation not found")
 
     attachments = [a.dict() for a in data.attachments]
-    client_ref: list[LLMClient] = []
+    abort_token = AbortToken()
     return _CleanupStreamingResponse(
         _sse_stream(
-            handle_turn(cid, data.content, attachments=attachments, client_ref=client_ref),
+            handle_turn(cid, data.content, attachments=attachments, abort_token=abort_token),
             request,
-            client_ref=client_ref,
+            abort_token=abort_token,
             cid=cid,
         ),
         media_type="text/event-stream",
@@ -1734,12 +1732,12 @@ async def api_continue_from_user(cid: str, request: Request, data: Optional[Rege
     if not messages or messages[-1]["role"] != "user":
         raise HTTPException(status_code=400, detail="Last message is not a user message")
     user_content = messages[-1]["content"]
-    client_ref: list[LLMClient] = []
+    abort_token = AbortToken()
     return _CleanupStreamingResponse(
         _sse_stream(
-            handle_turn(cid, user_content, skip_user_persist=True, client_ref=client_ref),
+            handle_turn(cid, user_content, skip_user_persist=True, abort_token=abort_token),
             request,
-            client_ref=client_ref,
+            abort_token=abort_token,
             cid=cid,
         ),
         media_type="text/event-stream",

--- a/backend/main.py
+++ b/backend/main.py
@@ -1355,7 +1355,7 @@ async def _sse_stream(
     gen,
     request: Request,
     *,
-    client_ref: list | None = None,
+    client_ref: list[LLMClient] | None = None,
     cid: str | None = None,
 ):
     """Wrap an event-dict async generator as SSE, stopping cleanly on client disconnect.
@@ -1480,7 +1480,7 @@ async def api_fork_edit_message(cid: str, msg_id: int, data: EditMessage, reques
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    client_ref: list = []
+    client_ref: list[LLMClient] = []
     return _CleanupStreamingResponse(
         _sse_stream(
             handle_fork_edit(cid, msg_id, data.content, client_ref=client_ref),
@@ -1531,7 +1531,7 @@ async def api_regenerate_msg(cid: str, msg_id: int, request: Request, data: Opti
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    client_ref: list = []
+    client_ref: list[LLMClient] = []
     return _CleanupStreamingResponse(
         _sse_stream(
             handle_regenerate(cid, msg_id, client_ref=client_ref),
@@ -1550,7 +1550,7 @@ async def api_super_regenerate_msg(cid: str, msg_id: int, request: Request, data
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    client_ref: list = []
+    client_ref: list[LLMClient] = []
     return _CleanupStreamingResponse(
         _sse_stream(
             handle_super_regenerate(cid, msg_id, client_ref=client_ref),
@@ -1569,7 +1569,7 @@ async def api_magic_rewrite_msg(cid: str, msg_id: int, request: Request, data: M
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    client_ref: list = []
+    client_ref: list[LLMClient] = []
     return _CleanupStreamingResponse(
         _sse_stream(
             handle_magic_rewrite(cid, msg_id, data.direction, client_ref=client_ref),
@@ -1712,7 +1712,7 @@ async def api_send_message(cid: str, data: SendMessage, request: Request):
         raise HTTPException(status_code=404, detail="Conversation not found")
 
     attachments = [a.dict() for a in data.attachments]
-    client_ref: list = []
+    client_ref: list[LLMClient] = []
     return _CleanupStreamingResponse(
         _sse_stream(
             handle_turn(cid, data.content, attachments=attachments, client_ref=client_ref),
@@ -1734,7 +1734,7 @@ async def api_continue_from_user(cid: str, request: Request, data: Optional[Rege
     if not messages or messages[-1]["role"] != "user":
         raise HTTPException(status_code=400, detail="Last message is not a user message")
     user_content = messages[-1]["content"]
-    client_ref: list = []
+    client_ref: list[LLMClient] = []
     return _CleanupStreamingResponse(
         _sse_stream(
             handle_turn(cid, user_content, skip_user_persist=True, client_ref=client_ref),

--- a/backend/main.py
+++ b/backend/main.py
@@ -224,7 +224,7 @@ class SettingsUpdate(BaseModel):
     system_prompt: Optional[str] = None
     user_name: Optional[str] = None
     user_description: Optional[str] = None
-    enabled_tools: Optional[dict] = None
+    enabled_tools: Optional[dict[str, bool]] = None
     enable_agent: Optional[bool] = None
     length_guard_enabled: Optional[bool] = None
     length_guard_enforce: Optional[bool] = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,12 @@
+# pyright: reportArgumentType=false, reportReturnType=false, reportGeneralTypeIssues=false, reportTypedDictNotRequiredAccess=false
+# TODO(typing): the four rules above are the *only* standard-mode checks this
+# module does not yet pass; every other check is active. They fire because this
+# module forwards the database row TypedDicts (SettingsRow, ConversationRow,
+# CharacterCardRow, ...) into helpers still annotated as bare `dict`/`list[dict]`
+# and reads `total=False` settings keys by subscript. The fix is to widen those
+# consumer signatures (dict -> Mapping, list[dict] -> Sequence[Mapping]) and
+# firm up SettingsRow's always-present columns; doing so lets these suppressions
+# be removed one rule at a time. Dedicated follow-up; see REFACTOR_model_layer.md.
 from __future__ import annotations
 import asyncio
 import hashlib

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,3 @@
-# pyright: reportArgumentType=false, reportReturnType=false, reportGeneralTypeIssues=false, reportTypedDictNotRequiredAccess=false
-# TODO(typing): the four rules above are the *only* standard-mode checks this
-# module does not yet pass; every other check is active. They fire because this
-# module forwards the database row TypedDicts (SettingsRow, ConversationRow,
-# CharacterCardRow, ...) into helpers still annotated as bare `dict`/`list[dict]`
-# and reads `total=False` settings keys by subscript. The fix is to widen those
-# consumer signatures (dict -> Mapping, list[dict] -> Sequence[Mapping]) and
-# firm up SettingsRow's always-present columns; doing so lets these suppressions
-# be removed one rule at a time. Dedicated follow-up; see REFACTOR_model_layer.md.
 from __future__ import annotations
 import asyncio
 import hashlib
@@ -19,7 +10,7 @@ import tempfile
 
 from contextlib import asynccontextmanager
 
-from typing import Annotated, Any, AsyncGenerator, Optional, List, cast
+from typing import Annotated, Any, AsyncGenerator, Mapping, Optional, List, Sequence, cast
 from fastapi import Body, Depends, FastAPI, HTTPException, Request, UploadFile, File
 from fastapi.responses import StreamingResponse, FileResponse, Response
 from fastapi.staticfiles import StaticFiles
@@ -722,14 +713,14 @@ async def api_delete_world(world_id: str):
 # Lorebook Entries ──
 
 
-async def require_world(world_id: str) -> dict:
+async def require_world(world_id: str) -> Mapping[str, Any]:
     world = await get_world(world_id)
     if not world:
         raise HTTPException(status_code=404, detail="World not found")
     return world
 
 
-async def require_lorebook_entry(entry_id: int, world: dict = Depends(require_world)) -> dict:  # noqa: B008
+async def require_lorebook_entry(entry_id: int, world: dict = Depends(require_world)) -> Mapping[str, Any]:  # noqa: B008
     entry = await get_lorebook_entry(entry_id)
     if not entry or entry.get("world_id") != world["id"]:
         raise HTTPException(status_code=404, detail="Entry not found")
@@ -957,7 +948,7 @@ async def api_create_conversation(data: ConversationCreate):
         card = await get_character_card(card_id)
         if not card:
             raise HTTPException(status_code=404, detail="Character card not found")
-        char_name = card["name"]
+        char_name = card.get("name", "")
         char_scenario = card.get("scenario", "")
         first_mes = card.get("first_mes", "")
         post_hist = card.get("post_history_instructions", "")
@@ -1108,8 +1099,8 @@ async def api_compress_conversation(cid: str, data: CompressRequest):
         att_list = (
             [
                 {
-                    "mime_type": a["mime_type"],
-                    "data_b64": a["data_b64"],
+                    "mime_type": a.get("mime_type"),
+                    "data_b64": a.get("data_b64"),
                     "filename": a.get("filename"),
                     "size": a.get("size"),
                 }
@@ -1252,7 +1243,7 @@ async def api_update_character(card_id: str, data: CharacterCardUpdate):
     result = await update_character_card(card_id, update_data)
     if not result:
         raise HTTPException(status_code=404, detail="Character card not found")
-    old_name = old_card["name"] if old_card and "name" in update_data else None
+    old_name = old_card.get("name") if old_card and "name" in update_data else None
     await sync_conversations_for_card(card_id, result, old_name=old_name)
     return result
 
@@ -1280,21 +1271,28 @@ async def api_export_character(card_id: str):
     if not card:
         raise HTTPException(status_code=404, detail="Character not found")
 
+    # Materialize a mutable working copy: the export augments the row with fields
+    # that are not card columns (a forced ``id`` and an embedded ``character_book``),
+    # so it is a free-form dict here rather than a CharacterCardRow.
+    export_card: dict[str, Any] = dict(card)
+
     avatar_bytes: bytes | None = None
-    if card.get("avatar_b64"):
+    avatar_b64 = export_card.get("avatar_b64")
+    if avatar_b64:
         try:
-            avatar_bytes = base64.b64decode(card["avatar_b64"])
+            avatar_bytes = base64.b64decode(avatar_b64)
         except Exception:
             logger.warning("Avatar data for card %s is corrupt; exporting without avatar", card_id)
             avatar_bytes = None
 
-    card["id"] = card_id
+    export_card["id"] = card_id
 
     # If the character is linked to a lorebook, embed it as character_book
-    if card.get("world_id") and not card.get("character_book"):
-        world = await get_world(card["world_id"])
-        entries = await get_lorebook_entries(card["world_id"])
-        card["character_book"] = {
+    world_id = export_card.get("world_id")
+    if world_id and not export_card.get("character_book"):
+        world = await get_world(world_id)
+        entries = await get_lorebook_entries(world_id)
+        export_card["character_book"] = {
             "name": world["name"] if world else "",
             "extensions": {},
             "entries": [
@@ -1314,9 +1312,11 @@ async def api_export_character(card_id: str):
             ],
         }
 
-    png_bytes = tavern_cards.to_png(card, avatar_bytes)
+    png_bytes = tavern_cards.to_png(export_card, avatar_bytes)
 
-    safe_name = "".join(c for c in card.get("name", "character") if c.isalnum() or c in " _-").strip() or "character"
+    safe_name = (
+        "".join(c for c in export_card.get("name", "character") if c.isalnum() or c in " _-").strip() or "character"
+    )
     return Response(
         content=png_bytes,
         media_type="image/png",
@@ -1986,7 +1986,7 @@ def _split_reroll_gen_result(result, workflow_id: str | None) -> tuple[object, d
     return result, None
 
 
-def _build_reroll_gen_ctx(cid: str, mid: int, aid: int, att: dict, settings: dict, client) -> RerollGenCtx:
+def _build_reroll_gen_ctx(cid: str, mid: int, aid: int, att: dict, settings: Mapping[str, Any], client) -> RerollGenCtx:
     prior_cm = _decode_stored_consumption_metadata(att)
     return RerollGenCtx(
         conversation_id=cid,

--- a/backend/main.py
+++ b/backend/main.py
@@ -1947,7 +1947,7 @@ async def api_regenerate_attachment(cid: str, mid: int, aid: int, body: dict = B
         }
 
 
-def _decode_stored_consumption_metadata(att: dict) -> dict | None:
+def _decode_stored_consumption_metadata(att: Mapping[str, Any]) -> dict | None:
     """Parse the parent attachment's stored consumption_metadata JSON.
 
     Returns the decoded dict, or ``None`` for any malformed or non-dict value.
@@ -1984,7 +1984,9 @@ def _split_reroll_gen_result(result, workflow_id: str | None) -> tuple[object, d
     return result, None
 
 
-def _build_reroll_gen_ctx(cid: str, mid: int, aid: int, att: dict, settings: Mapping[str, Any], client) -> RerollGenCtx:
+def _build_reroll_gen_ctx(
+    cid: str, mid: int, aid: int, att: Mapping[str, Any], settings: Mapping[str, Any], client
+) -> RerollGenCtx:
     prior_cm = _decode_stored_consumption_metadata(att)
     return RerollGenCtx(
         conversation_id=cid,

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,7 @@ import tempfile
 
 from contextlib import asynccontextmanager
 
-from typing import Annotated, Any, AsyncGenerator, Mapping, Optional, List, Sequence, cast
+from typing import Annotated, Any, AsyncGenerator, Mapping, Optional, List, cast
 from fastapi import Body, Depends, FastAPI, HTTPException, Request, UploadFile, File
 from fastapi.responses import StreamingResponse, FileResponse, Response
 from fastapi.staticfiles import StaticFiles
@@ -1314,9 +1314,7 @@ async def api_export_character(card_id: str):
 
     png_bytes = tavern_cards.to_png(export_card, avatar_bytes)
 
-    safe_name = (
-        "".join(c for c in export_card.get("name", "character") if c.isalnum() or c in " _-").strip() or "character"
-    )
+    safe_name = "".join(c for c in export_card.get("name", "character") if c.isalnum() or c in " _-").strip() or "character"
     return Response(
         content=png_bytes,
         media_type="image/png",

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -1,12 +1,3 @@
-# pyright: reportArgumentType=false, reportReturnType=false, reportGeneralTypeIssues=false, reportTypedDictNotRequiredAccess=false
-# TODO(typing): the four rules above are the *only* standard-mode checks this
-# module does not yet pass; every other check is active. They fire because the
-# pipeline coordinator forwards the database row TypedDicts (ConversationRow,
-# SettingsRow, DirectorStateRow, the message rows, ...) into prompt-building
-# helpers still annotated as bare `dict`/`list[dict]`. The fix is to widen those
-# consumer signatures (dict -> Mapping, list[dict] -> Sequence[Mapping]); doing
-# so lets these suppressions be removed one rule at a time. Dedicated follow-up;
-# see REFACTOR_model_layer.md.
 """
 orchestrator.py — Pipeline coordinator: director → writer → editor,
 plus the public entry points handle_turn() and handle_regenerate().
@@ -17,7 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field, fields
-from typing import AsyncIterator, List, Optional
+from typing import Any, AsyncIterator, List, Mapping, Optional, Sequence
 
 from . import database as db
 from .llm_client import LLMClient, reasoning_cfg
@@ -44,7 +35,17 @@ from .utils import extract_hyperparams
 from .passes.director import DirectorResult, _director_pass
 from .passes.writer import _writer_pass, build_writer_content
 from .passes.editor import editor_pass
-from .database.models import PhraseGroup
+from .database.models import (
+    CharacterCardRow,
+    ConversationRow,
+    DirectorFragmentRow,
+    DirectorStateRow,
+    LorebookEntryRow,
+    MoodFragmentRow,
+    PhraseGroup,
+    SettingsRow,
+    UserPersonaRow,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ class _PipelineConfig:
 
 
 def _resolve_pipeline_config(
-    settings: dict,
+    settings: Mapping[str, Any],
     enabled_tools: dict,
     *,
     macros: Macros,
@@ -184,10 +185,10 @@ class _PipelineResult:
 
 async def _run_pipeline(
     client: LLMClient,
-    settings: dict,
-    director: dict,
-    mood_fragments: list[dict],
-    director_fragments: list[dict],
+    settings: Mapping[str, Any],
+    director: Mapping[str, Any],
+    mood_fragments: Sequence[Mapping[str, Any]],
+    director_fragments: Sequence[Mapping[str, Any]],
     user_message: str,
     attachments: Optional[List[dict]] = None,
     phrase_bank: list[PhraseGroup] | None = None,
@@ -198,14 +199,14 @@ async def _run_pipeline(
     macros: Macros | None = None,
     conversation_id: str | None = None,
     character_id: str | None = None,
-    card: dict | None = None,
+    card: Mapping[str, Any] | None = None,
     *,
     prefix: list[dict],
     enabled_tools: dict,
     turn_scratch: dict,
     kv_tracker: _KVCacheTracker,
     schema_overrides: dict,
-    history: list[dict] | None = None,
+    history: Sequence[Mapping[str, Any]] | None = None,
 ) -> AsyncIterator[dict]:
     """Three-pass pipeline: director → writer → editor, plus a post-pipeline
     workflow iteration before persistence.
@@ -515,11 +516,11 @@ async def _run_post_pipeline(
     draft: str,
     conversation_id: str | None,
     character_id: str | None,
-    card: dict | None,
-    history: list[dict] | None,
+    card: Mapping[str, Any] | None,
+    history: Sequence[Mapping[str, Any]] | None,
     effective_msg: str,
     director_output: dict,
-    settings: dict,
+    settings: Mapping[str, Any],
     prefix: list[dict],
     enabled_tools: dict,
     turn_scratch: dict,
@@ -736,10 +737,10 @@ async def _iterate_pre_pipeline_hooks(
     *,
     conversation_id: str,
     character_id: str | None = None,
-    card: dict | None = None,
-    history: list[dict],
+    card: Mapping[str, Any] | None = None,
+    history: Sequence[Mapping[str, Any]],
     last_user_message: str,
-    settings: dict,
+    settings: Mapping[str, Any],
     prefix_base: list[dict],
     enabled_tools_pre_merge: dict,
     turn_scratch: dict,
@@ -865,19 +866,19 @@ class PipelineContext:
     not mutating the dict it points at).
     """
 
-    settings: dict
-    conv: dict
-    card: Optional[dict]
-    director: dict
-    mood_fragments: list[dict]
-    director_fragments: list[dict]
+    settings: SettingsRow
+    conv: ConversationRow
+    card: Optional[CharacterCardRow]
+    director: DirectorStateRow
+    mood_fragments: list[MoodFragmentRow]
+    director_fragments: list[DirectorFragmentRow]
     phrase_bank: list[PhraseGroup]
-    lorebook_entries: list[dict]
+    lorebook_entries: list[LorebookEntryRow]
     client: LLMClient
     system_prompt: str
     char_persona: str
     mes_example: str
-    active_persona: Optional[dict]
+    active_persona: Optional[UserPersonaRow]
     agent_client: Optional[LLMClient]
     agent_system_prompt: Optional[str]
 
@@ -962,7 +963,7 @@ async def _load_pipeline_context(conversation_id: str) -> PipelineContext | None
 
 def _build_prefix_from_ctx(
     ctx: PipelineContext,
-    history: list[dict],
+    history: Sequence[Mapping[str, Any]],
     *,
     system_prompt: str | None = None,
     extra_system_blocks: list[str] | None = None,
@@ -994,7 +995,7 @@ def _build_prefix_from_ctx(
 
 def _build_prefixes(
     ctx: PipelineContext,
-    history: list[dict],
+    history: Sequence[Mapping[str, Any]],
     *,
     extra_system_blocks: list[str] | None = None,
 ) -> tuple[list[dict], list[dict] | None]:
@@ -1014,7 +1015,7 @@ def _build_prefixes(
     return prefix, agent_prefix
 
 
-def _compute_lorebook(macros: Macros, ctx: PipelineContext, messages: list[dict]) -> str:
+def _compute_lorebook(macros: Macros, ctx: PipelineContext, messages: Sequence[Mapping[str, Any]]) -> str:
     """Compute the lorebook injection block for a sequence of *messages*."""
     return compute_lorebook_injection_block(
         messages,
@@ -1048,10 +1049,10 @@ async def _prepare_turn(
     ctx: PipelineContext,
     conversation_id: str,
     *,
-    history: list[dict],
-    settings: dict,
+    history: Sequence[Mapping[str, Any]],
+    settings: Mapping[str, Any],
     last_user_message: str,
-    lorebook_messages: list[dict],
+    lorebook_messages: Sequence[Mapping[str, Any]],
 ) -> AsyncIterator[dict | _TurnSetup]:
     """Run the turn-setup sequence shared by every entry point and stream its
     pre-pipeline SSE events, then yield one terminal :class:`_TurnSetup`.
@@ -1162,7 +1163,9 @@ def _conversation_log_writer(conversation_id: str, log_turn_index: int):
     return _on_result
 
 
-async def _resolve_target_and_parent(conversation_id: str, assistant_msg_id: int) -> tuple[dict, dict] | str:
+async def _resolve_target_and_parent(
+    conversation_id: str, assistant_msg_id: int
+) -> tuple[Mapping[str, Any], Mapping[str, Any]] | str:
     """Validate *assistant_msg_id* and load its parent user message.
 
     Returns ``(target, user_msg)`` on success, or an error string on failure.
@@ -1178,8 +1181,8 @@ async def _resolve_target_and_parent(conversation_id: str, assistant_msg_id: int
 
 
 async def _prepare_regen_context(
-    ctx: PipelineContext, conversation_id: str, target: dict, user_msg: dict
-) -> tuple[list[dict], list[dict]]:
+    ctx: PipelineContext, conversation_id: str, target: Mapping[str, Any], user_msg: Mapping[str, Any]
+) -> tuple[Sequence[Mapping[str, Any]], list[dict]]:
     """Prepare history and attachments for a regeneration pass.
 
     Also resets director moods to the pre-turn baseline.
@@ -1199,7 +1202,7 @@ async def _prepare_regen_context(
 async def _persist_result(
     conversation_id: str,
     res: _PipelineResult,
-    settings: dict,
+    settings: Mapping[str, Any],
     user_msg_id: int | None,
     turn_index: int,
 ) -> tuple[int | None, list[dict]]:
@@ -1266,7 +1269,7 @@ async def _persist_result(
 async def _fallback_persist(
     conversation_id: str,
     res: _PipelineResult,
-    settings: dict,
+    settings: Mapping[str, Any],
     user_msg_id: int | None,
     turn_index: int,
     accumulated_text: str,
@@ -1313,7 +1316,7 @@ async def _fallback_persist(
 async def _shielded_fallback(
     conversation_id: str,
     res: _PipelineResult,
-    settings: dict,
+    settings: Mapping[str, Any],
     user_msg_id: int | None,
     turn_index: int,
     accumulated_text: str,
@@ -1372,7 +1375,7 @@ async def _shielded_log_save(extra_on_result, res: _PipelineResult, asst_id: int
 async def _consume_pipeline(
     pipeline: AsyncIterator[dict],
     conversation_id: str,
-    settings: dict,
+    settings: Mapping[str, Any],
     user_msg_id: int | None,
     turn_index: int,
     *,
@@ -1464,17 +1467,17 @@ async def _generate_reply(
     ctx: PipelineContext,
     conversation_id: str,
     *,
-    history: list[dict],
-    pipeline_settings: dict,
+    history: Sequence[Mapping[str, Any]],
+    pipeline_settings: Mapping[str, Any],
     last_user_message: str,
-    lorebook_messages: list[dict],
+    lorebook_messages: Sequence[Mapping[str, Any]],
     user_message: str,
     attachments: list[dict],
     user_msg_id: int | None,
     asst_turn_index: int,
     log_turn_index: int,
     editor_audit_msgs: list[str] | None = None,
-    consume_settings: dict | None = None,
+    consume_settings: Mapping[str, Any] | None = None,
 ) -> AsyncIterator[dict]:
     """Shared tail for every generating entry point: run the pre-pipeline setup,
     the three-pass pipeline, and result consumption, streaming all SSE events
@@ -1748,7 +1751,7 @@ async def handle_regenerate(
             history=history,
             pipeline_settings=settings,
             last_user_message=user_msg["content"],
-            lorebook_messages=history + [{"role": "user", "content": user_msg["content"]}],
+            lorebook_messages=[*history, {"role": "user", "content": user_msg["content"]}],
             user_message=user_msg["content"],
             attachments=attachments,
             user_msg_id=user_msg_id,
@@ -1790,7 +1793,8 @@ async def handle_super_regenerate(
 
         # Extend history to include the original user+assistant exchange so the
         # model sees what it wrote before being asked to go a different direction.
-        extended_history = history + [
+        extended_history = [
+            *history,
             {"role": "user", "content": user_msg["content"]},
             {"role": "assistant", "content": target["content"]},
         ]
@@ -1859,7 +1863,8 @@ async def handle_magic_rewrite(
         parent_id: int | None = user_msg.get("parent_id")
         history = await db.get_path_to_leaf(conversation_id, parent_id) if parent_id is not None else []
 
-        extended_history = history + [
+        extended_history = [
+            *history,
             {"role": "user", "content": user_msg["content"]},
             {"role": "assistant", "content": target["content"]},
         ]

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -190,7 +190,7 @@ async def _run_pipeline(
     mood_fragments: Sequence[Mapping[str, Any]],
     director_fragments: Sequence[Mapping[str, Any]],
     user_message: str,
-    attachments: Optional[List[dict]] = None,
+    attachments: Optional[Sequence[Mapping[str, Any]]] = None,
     phrase_bank: list[PhraseGroup] | None = None,
     lorebook_block: str = "",
     editor_audit_msgs: list[str] | None = None,
@@ -1182,7 +1182,7 @@ async def _resolve_target_and_parent(
 
 async def _prepare_regen_context(
     ctx: PipelineContext, conversation_id: str, target: Mapping[str, Any], user_msg: Mapping[str, Any]
-) -> tuple[Sequence[Mapping[str, Any]], list[dict]]:
+) -> tuple[Sequence[Mapping[str, Any]], Sequence[Mapping[str, Any]]]:
     """Prepare history and attachments for a regeneration pass.
 
     Also resets director moods to the pre-turn baseline.
@@ -1472,7 +1472,7 @@ async def _generate_reply(
     last_user_message: str,
     lorebook_messages: Sequence[Mapping[str, Any]],
     user_message: str,
-    attachments: list[dict],
+    attachments: Sequence[Mapping[str, Any]],
     user_msg_id: int | None,
     asst_turn_index: int,
     log_turn_index: int,

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -31,7 +31,7 @@ from .workflows import (
     iter_subscriptions,
 )
 from .workflows.attachment_cache import OVERSIZE_NO_METADATA_REASON
-from .utils import extract_hyperparams
+from .utils import LengthGuard, extract_hyperparams
 from .passes.director import DirectorResult, _director_pass
 from .passes.writer import _writer_pass, build_writer_content
 from .passes.editor import editor_pass
@@ -72,7 +72,7 @@ class _PipelineConfig:
     audit_enabled: bool
     length_guard_enabled: bool
     length_guard_enforce: bool
-    length_guard: dict | None
+    length_guard: LengthGuard | None
     do_edit: bool
     writer_enabled_tools: Mapping[str, bool]
     director_client: LLMClient
@@ -111,7 +111,7 @@ def _resolve_pipeline_config(
 
     # length_guard_enabled already folds in agent_on (it is False whenever the
     # agent is off), so no extra `and agent_on` guard is needed below.
-    length_guard = (
+    length_guard: LengthGuard | None = (
         {
             "enabled": length_guard_enabled,
             "max_words": int(settings.get("length_guard_max_words", 240)),

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -1,3 +1,12 @@
+# pyright: reportArgumentType=false, reportReturnType=false, reportGeneralTypeIssues=false, reportTypedDictNotRequiredAccess=false
+# TODO(typing): the four rules above are the *only* standard-mode checks this
+# module does not yet pass; every other check is active. They fire because the
+# pipeline coordinator forwards the database row TypedDicts (ConversationRow,
+# SettingsRow, DirectorStateRow, the message rows, ...) into prompt-building
+# helpers still annotated as bare `dict`/`list[dict]`. The fix is to widen those
+# consumer signatures (dict -> Mapping, list[dict] -> Sequence[Mapping]); doing
+# so lets these suppressions be removed one rule at a time. Dedicated follow-up;
+# see REFACTOR_model_layer.md.
 """
 orchestrator.py — Pipeline coordinator: director → writer → editor,
 plus the public entry points handle_turn() and handle_regenerate().

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field, fields
+from types import MappingProxyType
 from typing import Any, AsyncIterator, List, Mapping, Optional, Sequence
 
 from . import database as db
@@ -206,7 +207,7 @@ async def _run_pipeline(
     enabled_tools: Mapping[str, bool],
     turn_scratch: dict,
     kv_tracker: _KVCacheTracker,
-    schema_overrides: dict,
+    schema_overrides: Mapping[str, dict],
     history: Sequence[Mapping[str, Any]] | None = None,
 ) -> AsyncIterator[dict]:
     """Three-pass pipeline: director → writer → editor, plus a post-pipeline
@@ -527,7 +528,7 @@ async def _run_post_pipeline(
     turn_scratch: dict,
     client: LLMClient,
     kv_tracker: _KVCacheTracker,
-    schema_overrides: dict,
+    schema_overrides: Mapping[str, dict],
 ) -> AsyncIterator[dict | _PostPipelineResult]:
     """Drive each POST_PIPELINE subscription over the finished *draft*, streaming
     pass-through SSE events and yielding one terminal :class:`_PostPipelineResult`.
@@ -747,7 +748,7 @@ async def _iterate_pre_pipeline_hooks(
     turn_scratch: dict,
     client,
     kv_tracker,
-    schema_overrides: dict,
+    schema_overrides: Mapping[str, dict],
     accumulators: dict,
 ) -> AsyncIterator[dict]:
     """Drive each pre_pipeline subscription in priority-ascending order,
@@ -1043,7 +1044,7 @@ class _TurnSetup:
     lorebook_block: str
     turn_scratch: dict
     kv_tracker: _KVCacheTracker
-    schema_overrides: dict
+    schema_overrides: Mapping[str, dict]
 
 
 async def _prepare_turn(
@@ -1085,7 +1086,10 @@ async def _prepare_turn(
     # Per-turn shared identities — ref-shared across the hooks and every pass.
     turn_scratch: dict = {}
     kv_tracker = _KVCacheTracker(conversation_id=conversation_id)
-    schema_overrides = {"direct_scene": build_direct_scene_tool(ctx.director_fragments)}
+    # Built once and never mutated for the rest of the turn -- frozen here so the
+    # ref shared across every pass and hook cannot have entries added/swapped/dropped.
+    # Values stay plain dicts so they remain json-serializable into the tools blob.
+    schema_overrides = MappingProxyType({"direct_scene": build_direct_scene_tool(ctx.director_fragments)})
 
     enabled_tools_setting = settings.get("enabled_tools") or {}
     if settings.get("enable_agent", 1):

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -35,7 +35,7 @@ from .utils import extract_hyperparams
 from .passes.director import DirectorResult, _director_pass
 from .passes.writer import _writer_pass, build_writer_content
 from .passes.editor import editor_pass
-from .passes.editor.slop_detector import PhraseGroup
+from .database.models import PhraseGroup
 
 logger = logging.getLogger(__name__)
 

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -162,9 +162,9 @@ class _PipelineResult:
     instance via the bare ``_PipelineResult()`` seed in :func:`_consume_pipeline`.
     """
 
-    active_moods: list = field(default_factory=list)
+    active_moods: list[str] = field(default_factory=list)
     agent_raw: str = ""
-    calls: list = field(default_factory=list)
+    calls: list[dict] = field(default_factory=list)
     latency: int = 0
     rewritten_msg: str | None = None
     effective_msg: str = ""
@@ -175,7 +175,7 @@ class _PipelineResult:
     reasoning_director: str = ""
     reasoning_writer: str = ""
     reasoning_editor: str = ""
-    staged_attachments: list = field(default_factory=list)
+    staged_attachments: list[dict] = field(default_factory=list)
     staged_message_state: dict = field(default_factory=dict)
 
     def as_event_data(self) -> dict:

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -31,6 +31,7 @@ from .workflows import (
     iter_subscriptions,
 )
 from .workflows.attachment_cache import OVERSIZE_NO_METADATA_REASON
+from .llm_types import ChatMessage
 from .utils import LengthGuard, extract_hyperparams
 from .passes.director import DirectorResult, _director_pass
 from .passes.writer import _writer_pass, build_writer_content
@@ -78,8 +79,8 @@ class _PipelineConfig:
     director_client: LLMClient
     writer_client: LLMClient
     editor_client: LLMClient
-    director_prefix: list[dict]
-    editor_prefix: list[dict]
+    director_prefix: list[ChatMessage]
+    editor_prefix: list[ChatMessage]
     agent_model: str
 
 
@@ -90,8 +91,8 @@ def _resolve_pipeline_config(
     macros: Macros,
     client: LLMClient,
     agent_client: LLMClient | None,
-    agent_prefix: list[dict] | None,
-    prefix: list[dict],
+    agent_prefix: list[ChatMessage] | None,
+    prefix: list[ChatMessage],
     phrase_bank: list[PhraseGroup] | None,
 ) -> _PipelineConfig:
     """Derive the per-turn pipeline configuration (see :class:`_PipelineConfig`)."""
@@ -195,13 +196,13 @@ async def _run_pipeline(
     lorebook_block: str = "",
     editor_audit_msgs: list[str] | None = None,
     agent_client: LLMClient | None = None,
-    agent_prefix: list[dict] | None = None,
+    agent_prefix: list[ChatMessage] | None = None,
     macros: Macros | None = None,
     conversation_id: str | None = None,
     character_id: str | None = None,
     card: Mapping[str, Any] | None = None,
     *,
-    prefix: list[dict],
+    prefix: list[ChatMessage],
     enabled_tools: Mapping[str, bool],
     turn_scratch: dict,
     kv_tracker: _KVCacheTracker,
@@ -521,7 +522,7 @@ async def _run_post_pipeline(
     effective_msg: str,
     director_output: dict,
     settings: Mapping[str, Any],
-    prefix: list[dict],
+    prefix: list[ChatMessage],
     enabled_tools: Mapping[str, bool],
     turn_scratch: dict,
     client: LLMClient,
@@ -741,7 +742,7 @@ async def _iterate_pre_pipeline_hooks(
     history: Sequence[Mapping[str, Any]],
     last_user_message: str,
     settings: Mapping[str, Any],
-    prefix_base: list[dict],
+    prefix_base: list[ChatMessage],
     enabled_tools_pre_merge: Mapping[str, bool],
     turn_scratch: dict,
     client,
@@ -967,7 +968,7 @@ def _build_prefix_from_ctx(
     *,
     system_prompt: str | None = None,
     extra_system_blocks: list[str] | None = None,
-) -> list[dict]:
+) -> list[ChatMessage]:
     """Build the LLM prefix from a :class:`PipelineContext`.
 
     When *system_prompt* is provided it overrides ``ctx.system_prompt``
@@ -998,7 +999,7 @@ def _build_prefixes(
     history: Sequence[Mapping[str, Any]],
     *,
     extra_system_blocks: list[str] | None = None,
-) -> tuple[list[dict], list[dict] | None]:
+) -> tuple[list[ChatMessage], list[ChatMessage] | None]:
     """Build (prefix, agent_prefix) from *ctx* and *history*.
 
     *agent_prefix* is ``None`` when no separate agent system prompt is
@@ -1035,8 +1036,8 @@ class _TurnSetup:
     block, scratch dict, KV tracker, dynamic-schema map).
     """
 
-    prefix: list[dict]
-    agent_prefix: list[dict] | None
+    prefix: list[ChatMessage]
+    agent_prefix: list[ChatMessage] | None
     merged_enabled_tools: dict[str, bool]
     macros: Macros
     lorebook_block: str

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -55,16 +55,42 @@ logger = logging.getLogger(__name__)
 # ── Core pipeline ─────────────────────────────────────────────────────────────
 
 
+@dataclass(frozen=True)
+class ModelLane:
+    """One model's call surface for the turn: a macro-wrapped client paired with
+    its byte-identical cached bottom (prefix + tools + model).
+
+    A turn has two lanes — ``writer`` and ``agent`` (director + editor). In
+    single-model mode they are the *same object* (the writer's lane is reused for
+    the agent), so the byte-identity invariant "director + editor + writer ride
+    the same base" is structural, not a convention each call site must honour. In
+    dual-model mode they are distinct: the agent lane carries the agent server's
+    client, its own prefix + tool blob, and the agent model; the writer lane
+    carries the writer client with an empty tools blob (Invariant 5).
+
+    ``reasoning`` stays per-pass (director and editor share the agent lane but
+    toggle reasoning independently), so it is not part of the lane.
+    """
+
+    client: LLMClient
+    base: CachedBase
+
+
+def is_dual_model(agent_client: LLMClient | None) -> bool:
+    """The pipeline runs in one of two modes:
+
+    * **single-model** — the writer and the agent (director + editor) share one
+      endpoint, prefix, tool blob, and KV cache; both lanes are the *same*
+      :class:`ModelLane` object.
+    * **dual-model** — a separate agent endpoint is configured, so the agent
+      runs on its own client/prefix/tools/model with a disjoint KV cache.
+    """
+    return agent_client is not None
+
+
 @dataclass
 class _PipelineConfig:
-    """Resolved per-turn flags, clients, and prefixes for :func:`_run_pipeline`.
-
-    A pure derivation from *settings* plus the (possibly agent-zeroed)
-    enabled-tools map; it holds no mutable turn state. ``enabled_tools`` is the
-    final map with ``editor_rewrite`` folded in whenever the length guard is
-    active, so ``enabled_schemas()`` ships an identical tool blob across all
-    three passes (the KV-cache invariant).
-    """
+    """Resolved per-turn flags, lanes, and prefixes for :func:`_run_pipeline`."""
 
     agent_on: bool
     enabled_tools: Mapping[str, bool]
@@ -77,16 +103,11 @@ class _PipelineConfig:
     length_guard: LengthGuard | None
     do_edit: bool
     writer_enabled_tools: Mapping[str, bool]
-    director_client: LLMClient
-    writer_client: LLMClient
-    editor_client: LLMClient
-    # The byte-identical cached bottoms, built once per server per turn. The
-    # director and editor share ``agent_base`` (same server, same prefix + tools
-    # + model); the writer rides ``writer_base``. In single-model mode the two
-    # are identical by construction; in dual-model the writer_base carries the
-    # writer's prefix and an empty tools blob (Invariant 5).
-    agent_base: CachedBase
-    writer_base: CachedBase
+    # The two call surfaces for the turn. ``writer_lane`` runs the writer pass;
+    # ``agent_lane`` runs director + editor. In single-model mode they are the
+    # same object by construction (see :class:`ModelLane`).
+    writer_lane: ModelLane
+    agent_lane: ModelLane
 
 
 def _resolve_pipeline_config(
@@ -128,27 +149,42 @@ def _resolve_pipeline_config(
         else None
     )
 
-    # When the agent runs on a separate model/endpoint its KV cache is disjoint
-    # from the writer's; skip tool schemas and the OOC "no tools" notice from the
-    # writer call — neither is useful and both add unnecessary tokens.
-    writer_enabled_tools = {} if agent_client is not None else enabled_tools
+    # In dual-model mode the agent's KV cache is disjoint from the writer's; skip
+    # tool schemas and the OOC "no tools" notice from the writer call — neither is
+    # useful and both add unnecessary tokens.
+    dual_model = is_dual_model(agent_client)
+    writer_enabled_tools = {} if dual_model else enabled_tools
 
-    # The two cached bottoms, computed once here. The director + editor share the
-    # agent base (same server, same prefix/tools/model); the writer has its own.
+    # The two lanes, computed once here. The writer lane carries the writer's
+    # client + base. The agent lane (director + editor) is the *same object* in
+    # single-model mode and a distinct one only when a separate agent endpoint is
+    # configured — so the byte-identity "director + editor + writer ride the same
+    # base" is structural, not a convention each pass must independently honour.
     # The tool blobs are built via enabled_schemas exactly once each so no pass
-    # can rebuild them differently — the byte-identity is structural, not a
-    # convention each pass must independently honour.
-    agent_model = settings.get("agent_model_name", settings["model_name"]) if agent_client else settings["model_name"]
-    agent_base = CachedBase(
-        prefix=tuple(agent_prefix or prefix),
-        tools=tuple(enabled_schemas(enabled_tools, schema_overrides)),
-        model=agent_model,
+    # can rebuild them differently.
+    writer_lane = ModelLane(
+        client=macros.wrap_client(client),
+        base=CachedBase(
+            prefix=tuple(prefix),
+            tools=tuple(enabled_schemas(writer_enabled_tools, schema_overrides)),
+            model=settings["model_name"],
+        ),
     )
-    writer_base = CachedBase(
-        prefix=tuple(prefix),
-        tools=tuple(enabled_schemas(writer_enabled_tools, schema_overrides)),
-        model=settings["model_name"],
-    )
+    if dual_model:
+        assert agent_client is not None  # dual_model is True iff agent_client was resolved
+        agent_lane = ModelLane(
+            client=macros.wrap_client(agent_client),
+            base=CachedBase(
+                prefix=tuple(agent_prefix or prefix),
+                tools=tuple(enabled_schemas(enabled_tools, schema_overrides)),
+                model=settings.get("agent_model_name", settings["model_name"]),
+            ),
+        )
+    else:
+        # Single-model mode: agent rides the writer's lane verbatim. In this mode
+        # agent_prefix is None and writer_enabled_tools == enabled_tools, so the
+        # writer base already carries exactly the bytes the agent needs.
+        agent_lane = writer_lane
 
     return _PipelineConfig(
         agent_on=agent_on,
@@ -162,11 +198,8 @@ def _resolve_pipeline_config(
         length_guard=length_guard,
         do_edit=audit_enabled or length_guard_enabled,
         writer_enabled_tools=writer_enabled_tools,
-        director_client=macros.wrap_client(agent_client or client),
-        writer_client=macros.wrap_client(client),
-        editor_client=macros.wrap_client(agent_client or client),
-        agent_base=agent_base,
-        writer_base=writer_base,
+        writer_lane=writer_lane,
+        agent_lane=agent_lane,
     )
 
 
@@ -302,8 +335,8 @@ async def _run_pipeline(
     if cfg.agent_on and has_pre_writer_tools:
         yield {"event": "director_start"}
         async for event in _director_pass(
-            cfg.director_client,
-            cfg.agent_base,
+            cfg.agent_lane.client,
+            cfg.agent_lane.base,
             user_message,
             settings,
             director,
@@ -380,8 +413,8 @@ async def _run_pipeline(
     )
     resp_text = ""
     async for item in _writer_pass(
-        cfg.writer_client,
-        cfg.writer_base,
+        cfg.writer_lane.client,
+        cfg.writer_lane.base,
         settings,
         cfg.writer_enabled_tools,
         inj_block=inj_block,
@@ -442,8 +475,8 @@ async def _run_pipeline(
         )
         try:
             async for event in editor_pass(
-                cfg.editor_client,
-                cfg.agent_base,
+                cfg.agent_lane.client,
+                cfg.agent_lane.base,
                 effective_msg,
                 resp_text,
                 settings,

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -12,7 +12,7 @@ from types import MappingProxyType
 from typing import Any, AsyncIterator, List, Mapping, Optional, Sequence
 
 from . import database as db
-from .llm_client import LLMClient, reasoning_cfg
+from .llm_client import AbortToken, LLMClient, reasoning_cfg
 from .endpoint_profiles import profile_for
 from .tool_defs import TOOLS, POST_WRITER_TOOLS, build_direct_scene_tool, enabled_schemas
 from .prompt_builder import (
@@ -338,8 +338,9 @@ async def _run_pipeline(
                 "data": {"refined_message": rewritten_msg},
             }
 
-    # Bail out if stop was clicked during the director pass
-    if client.is_aborted or (agent_client is not None and agent_client.is_aborted):
+    # Bail out if stop was clicked during the director pass. The writer and
+    # agent clients share one abort token, so checking either is equivalent.
+    if client.is_aborted:
         return
 
     # Style injection
@@ -427,7 +428,7 @@ async def _run_pipeline(
     # If the turn was aborted during writer, persist what streamed so far and
     # skip the editor + post-pipeline iteration. The single _result still
     # fires so the persistence path stays uniform.
-    if client.is_aborted or (agent_client is not None and agent_client.is_aborted):
+    if client.is_aborted:
         yield _make_result(resp_text, [])
         kv_tracker.log_summary()
         return
@@ -901,12 +902,17 @@ class PipelineContext:
     agent_system_prompt: Optional[str]
 
 
-async def _load_pipeline_context(conversation_id: str) -> PipelineContext | None:
+async def _load_pipeline_context(conversation_id: str, *, abort_token: AbortToken | None = None) -> PipelineContext | None:
     """Load everything the pipeline needs: settings, conversation, director,
     mood_fragments, phrase_bank, and an LLMClient.
 
+    *abort_token* is the turn-wide stop signal; both the writer and (optional)
+    agent clients share it so a single ``/stop`` aborts every pass. A private
+    token is created when the caller does not supply one.
+
     Returns a :class:`PipelineContext`, or None if the conversation was not found.
     """
+    abort_token = abort_token or AbortToken()
     settings = await db.get_settings()
     conv = await db.get_conversation(conversation_id)
     if not conv:
@@ -931,6 +937,7 @@ async def _load_pipeline_context(conversation_id: str) -> PipelineContext | None
             settings["endpoint_url"],
             settings.get("model_name", ""),
         ),
+        abort_token=abort_token,
     )
 
     card_id = conv.get("character_card_id")
@@ -955,6 +962,7 @@ async def _load_pipeline_context(conversation_id: str) -> PipelineContext | None
             agent_url,
             api_key=agent_api_key,
             profile=profile_for(agent_url, agent_model),
+            abort_token=abort_token,
         )
         agent_system_prompt, _, _ = await db.resolve_char_context(
             conv, settings, shared_key="agent_shared_system_prompt", card=card
@@ -1472,18 +1480,6 @@ async def _consume_pipeline(
     yield {"event": "done"}
 
 
-def _register_clients(ctx: PipelineContext, client_ref: list[LLMClient] | None, *, include_agent: bool = True) -> None:
-    """Expose the turn's LLM client(s) on *client_ref* so a /stop can abort them.
-
-    *include_agent* is False for magic-rewrite, which never spins up the agent.
-    """
-    if client_ref is None:
-        return
-    client_ref.append(ctx.client)
-    if include_agent and ctx.agent_client:
-        client_ref.append(ctx.agent_client)
-
-
 async def _generate_reply(
     ctx: PipelineContext,
     conversation_id: str,
@@ -1573,17 +1569,15 @@ async def handle_turn(
     user_message: str,
     skip_user_persist: bool = False,
     attachments: Optional[List[dict]] = None,
-    client_ref: list[LLMClient] | None = None,
+    abort_token: AbortToken | None = None,
 ) -> AsyncIterator[dict]:
     try:
         if attachments is None:
             attachments = []
-        ctx = await _load_pipeline_context(conversation_id)
+        ctx = await _load_pipeline_context(conversation_id, abort_token=abort_token)
         if ctx is None:
             yield {"event": "error", "data": "Conversation not found"}
             return
-
-        _register_clients(ctx, client_ref)
 
         settings = ctx.settings
         messages = await db.get_messages(conversation_id)
@@ -1662,7 +1656,7 @@ async def handle_fork_edit(
     conversation_id: str,
     user_msg_id: int,
     new_content: str,
-    client_ref: list[LLMClient] | None = None,
+    abort_token: AbortToken | None = None,
 ) -> AsyncIterator[dict]:
     """Fork the conversation at a user message.
 
@@ -1680,12 +1674,10 @@ async def handle_fork_edit(
     distinguishable from the original turn's log at the user turn.
     """
     try:
-        ctx = await _load_pipeline_context(conversation_id)
+        ctx = await _load_pipeline_context(conversation_id, abort_token=abort_token)
         if ctx is None:
             yield {"event": "error", "data": "Conversation not found"}
             return
-
-        _register_clients(ctx, client_ref)
 
         settings = ctx.settings
         original = await db.get_message_by_id(user_msg_id)
@@ -1746,15 +1738,13 @@ async def handle_fork_edit(
 async def handle_regenerate(
     conversation_id: str,
     assistant_msg_id: int,
-    client_ref: list[LLMClient] | None = None,
+    abort_token: AbortToken | None = None,
 ) -> AsyncIterator[dict]:
     try:
-        ctx = await _load_pipeline_context(conversation_id)
+        ctx = await _load_pipeline_context(conversation_id, abort_token=abort_token)
         if ctx is None:
             yield {"event": "error", "data": "Conversation not found"}
             return
-
-        _register_clients(ctx, client_ref)
 
         settings = ctx.settings
         result = await _resolve_target_and_parent(conversation_id, assistant_msg_id)
@@ -1792,15 +1782,13 @@ _SUPER_REGEN_MSG = "[OOC: Your response was kind of meh, rewrite it in a slightl
 async def handle_super_regenerate(
     conversation_id: str,
     assistant_msg_id: int,
-    client_ref: list[LLMClient] | None = None,
+    abort_token: AbortToken | None = None,
 ) -> AsyncIterator[dict]:
     try:
-        ctx = await _load_pipeline_context(conversation_id)
+        ctx = await _load_pipeline_context(conversation_id, abort_token=abort_token)
         if ctx is None:
             yield {"event": "error", "data": "Conversation not found"}
             return
-
-        _register_clients(ctx, client_ref)
 
         settings = ctx.settings
         result = await _resolve_target_and_parent(conversation_id, assistant_msg_id)
@@ -1864,15 +1852,13 @@ async def handle_magic_rewrite(
     conversation_id: str,
     assistant_msg_id: int,
     direction: str,
-    client_ref: list[LLMClient] | None = None,
+    abort_token: AbortToken | None = None,
 ) -> AsyncIterator[dict]:
     try:
-        ctx = await _load_pipeline_context(conversation_id)
+        ctx = await _load_pipeline_context(conversation_id, abort_token=abort_token)
         if ctx is None:
             yield {"event": "error", "data": "Conversation not found"}
             return
-
-        _register_clients(ctx, client_ref, include_agent=False)
 
         settings = ctx.settings
         result = await _resolve_target_and_parent(conversation_id, assistant_msg_id)

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -32,7 +32,7 @@ from .workflows import (
 )
 from .workflows.attachment_cache import OVERSIZE_NO_METADATA_REASON
 from .utils import extract_hyperparams
-from .passes.director import _director_pass
+from .passes.director import DirectorResult, _director_pass
 from .passes.writer import _writer_pass, build_writer_content
 from .passes.editor import editor_pass
 from .passes.editor.slop_detector import PhraseGroup
@@ -291,14 +291,13 @@ async def _run_pipeline(
                     "data": {"pass": "director", "delta": event["delta"]},
                 }
             elif event["type"] == "done":
-                (
-                    active_moods,
-                    agent_raw,
-                    calls,
-                    latency,
-                    rewritten_msg,
-                    extra_fields,
-                ) = event["result"]
+                result: DirectorResult = event["result"]
+                active_moods = result.active_moods
+                agent_raw = result.agent_raw
+                calls = result.calls
+                latency = result.latency
+                rewritten_msg = result.rewritten_msg
+                extra_fields = result.extra_fields
                 progressive_fields = {k: v for k, v in extra_fields.items() if k in _valid_progressive_ids}
         if rewritten_msg:
             effective_msg = rewritten_msg
@@ -452,9 +451,13 @@ async def _run_pipeline(
         logger.info("Editor pass skipped (do_edit=%s, draft=%d chars)", cfg.do_edit, len(resp_text))
 
     # --- Post-pipeline workflow iteration ---
+    # PostCtx.director_output is a read-only mapping (workflow contract), so this
+    # stays a dict rather than the DirectorResult dataclass. Keys mirror the
+    # dataclass field names — notably ``agent_raw`` (not ``raw``) — so a single
+    # name follows each value from the director pass through to every consumer.
     director_output = {
         "active_moods": active_moods,
-        "raw": agent_raw,
+        "agent_raw": agent_raw,
         "calls": calls,
         "latency": latency,
         "rewritten_msg": rewritten_msg,

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -862,7 +862,7 @@ class PipelineContext:
     director: dict
     mood_fragments: list[dict]
     director_fragments: list[dict]
-    phrase_bank: list[dict]
+    phrase_bank: list[PhraseGroup]
     lorebook_entries: list[dict]
     client: LLMClient
     system_prompt: str

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -839,11 +839,45 @@ async def _iterate_pre_pipeline_hooks(
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-async def _load_pipeline_context(conversation_id: str) -> dict | None:
+@dataclass(frozen=True)
+class PipelineContext:
+    """Resolved per-conversation inputs the pipeline needs, loaded once by
+    :func:`_load_pipeline_context` and threaded through every entry point.
+
+    Frozen so the *binding* of each field is immutable; the optional fields make
+    explicit what was previously only implied by the ``ctx[...]`` vs
+    ``ctx.get(...)`` split in readers. ``card`` / ``active_persona`` are None when
+    the conversation has no character card / no active user persona; ``agent_client``
+    and ``agent_system_prompt`` are None unless a separate agent endpoint is
+    configured (they travel together). ``director`` is a mutable dict held by
+    reference and deliberately mutated in place — the regenerate paths reset its
+    ``active_moods`` / ``progressive_fields`` to the branch baseline before a turn,
+    which the frozen dataclass does not prevent (it guards rebinding the field,
+    not mutating the dict it points at).
+    """
+
+    settings: dict
+    conv: dict
+    card: Optional[dict]
+    director: dict
+    mood_fragments: list[dict]
+    director_fragments: list[dict]
+    phrase_bank: list[dict]
+    lorebook_entries: list[dict]
+    client: LLMClient
+    system_prompt: str
+    char_persona: str
+    mes_example: str
+    active_persona: Optional[dict]
+    agent_client: Optional[LLMClient]
+    agent_system_prompt: Optional[str]
+
+
+async def _load_pipeline_context(conversation_id: str) -> PipelineContext | None:
     """Load everything the pipeline needs: settings, conversation, director,
     mood_fragments, phrase_bank, and an LLMClient.
 
-    Returns a dict of resolved objects, or None if the conversation was not found.
+    Returns a :class:`PipelineContext`, or None if the conversation was not found.
     """
     settings = await db.get_settings()
     conv = await db.get_conversation(conversation_id)
@@ -898,50 +932,50 @@ async def _load_pipeline_context(conversation_id: str) -> dict | None:
             conv, settings, shared_key="agent_shared_system_prompt", card=card
         )
 
-    return {
-        "settings": settings,
-        "conv": conv,
-        "card": card,
-        "director": director,
-        "mood_fragments": mood_fragments,
-        "director_fragments": director_fragments,
-        "phrase_bank": phrase_bank,
-        "lorebook_entries": lorebook_entries,
-        "client": client,
-        "system_prompt": system_prompt,
-        "char_persona": char_persona,
-        "mes_example": mes_example,
-        "active_persona": active_persona,
-        "agent_client": agent_client,
-        "agent_system_prompt": agent_system_prompt,
-    }
+    return PipelineContext(
+        settings=settings,
+        conv=conv,
+        card=card,
+        director=director,
+        mood_fragments=mood_fragments,
+        director_fragments=director_fragments,
+        phrase_bank=phrase_bank,
+        lorebook_entries=lorebook_entries,
+        client=client,
+        system_prompt=system_prompt,
+        char_persona=char_persona,
+        mes_example=mes_example,
+        active_persona=active_persona,
+        agent_client=agent_client,
+        agent_system_prompt=agent_system_prompt,
+    )
 
 
 def _build_prefix_from_ctx(
-    ctx: dict,
+    ctx: PipelineContext,
     history: list[dict],
     *,
     system_prompt: str | None = None,
     extra_system_blocks: list[str] | None = None,
 ) -> list[dict]:
-    """Build the LLM prefix from a pipeline-context dict.
+    """Build the LLM prefix from a :class:`PipelineContext`.
 
-    When *system_prompt* is provided it overrides ``ctx["system_prompt"]``
+    When *system_prompt* is provided it overrides ``ctx.system_prompt``
     (used for the agent prefix when it has its own system prompt).
     *extra_system_blocks* appends contributions from pre-pipeline hooks; None
     or an empty list preserves baseline byte parity.
     """
-    conv = ctx["conv"]
-    active_persona = ctx.get("active_persona")
-    macros = Macros.from_settings(ctx["settings"], conv["character_name"], active_persona)
-    user_description = active_persona.get("description", "") if active_persona else ctx["settings"].get("user_description", "")
+    conv = ctx.conv
+    active_persona = ctx.active_persona
+    macros = Macros.from_settings(ctx.settings, conv["character_name"], active_persona)
+    user_description = active_persona.get("description", "") if active_persona else ctx.settings.get("user_description", "")
 
     return build_prefix(
-        system_prompt if system_prompt is not None else ctx["system_prompt"],
-        ctx["char_persona"],
+        system_prompt if system_prompt is not None else ctx.system_prompt,
+        ctx.char_persona,
         conv["character_scenario"],
-        ctx["mes_example"],
-        ("" if ctx["settings"].get("prevent_prompt_overrides") else conv.get("post_history_instructions", "")),
+        ctx.mes_example,
+        ("" if ctx.settings.get("prevent_prompt_overrides") else conv.get("post_history_instructions", "")),
         history,
         macros,
         user_description,
@@ -950,7 +984,7 @@ def _build_prefix_from_ctx(
 
 
 def _build_prefixes(
-    ctx: dict,
+    ctx: PipelineContext,
     history: list[dict],
     *,
     extra_system_blocks: list[str] | None = None,
@@ -962,7 +996,7 @@ def _build_prefixes(
     system body stays identical across director / writer / editor.
     """
     prefix = _build_prefix_from_ctx(ctx, history, extra_system_blocks=extra_system_blocks)
-    agent_sp = ctx.get("agent_system_prompt")
+    agent_sp = ctx.agent_system_prompt
     agent_prefix = (
         _build_prefix_from_ctx(ctx, history, system_prompt=agent_sp, extra_system_blocks=extra_system_blocks)
         if agent_sp is not None
@@ -971,11 +1005,11 @@ def _build_prefixes(
     return prefix, agent_prefix
 
 
-def _compute_lorebook(macros: Macros, ctx: dict, messages: list[dict]) -> str:
+def _compute_lorebook(macros: Macros, ctx: PipelineContext, messages: list[dict]) -> str:
     """Compute the lorebook injection block for a sequence of *messages*."""
     return compute_lorebook_injection_block(
         messages,
-        ctx.get("lorebook_entries", []),
+        ctx.lorebook_entries,
         macros,
     )
 
@@ -1002,7 +1036,7 @@ class _TurnSetup:
 
 
 async def _prepare_turn(
-    ctx: dict,
+    ctx: PipelineContext,
     conversation_id: str,
     *,
     history: list[dict],
@@ -1029,10 +1063,10 @@ async def _prepare_turn(
     (super-regenerate passes its rewrite-disabled copy). *last_user_message* is
     handed to the hooks; *lorebook_messages* is the full message list (history
     plus the turn's probe message) scanned for lorebook keywords. Macros and
-    prefixes are always built from ``ctx["settings"]`` so the system body stays
+    prefixes are always built from ``ctx.settings`` so the system body stays
     byte-identical across passes regardless of per-call setting tweaks.
     """
-    macros = Macros.from_settings(ctx["settings"], ctx["conv"]["character_name"], ctx.get("active_persona"))
+    macros = Macros.from_settings(ctx.settings, ctx.conv["character_name"], ctx.active_persona)
     lorebook_block = _compute_lorebook(macros, ctx, lorebook_messages)
 
     prefix_base, agent_prefix_base = _build_prefixes(ctx, history)
@@ -1040,7 +1074,7 @@ async def _prepare_turn(
     # Per-turn shared identities — ref-shared across the hooks and every pass.
     turn_scratch: dict = {}
     kv_tracker = _KVCacheTracker(conversation_id=conversation_id)
-    schema_overrides = {"direct_scene": build_direct_scene_tool(ctx["director_fragments"])}
+    schema_overrides = {"direct_scene": build_direct_scene_tool(ctx.director_fragments)}
 
     enabled_tools_setting = settings.get("enabled_tools") or {}
     if settings.get("enable_agent", 1):
@@ -1057,15 +1091,15 @@ async def _prepare_turn(
     # system blocks below; any other yield passes through to the SSE stream.
     async for ev in _iterate_pre_pipeline_hooks(
         conversation_id=conversation_id,
-        character_id=ctx["conv"].get("character_card_id"),
-        card=ctx["card"],
+        character_id=ctx.conv.get("character_card_id"),
+        card=ctx.card,
         history=history,
         last_user_message=last_user_message,
         settings=settings,
         prefix_base=prefix_base,
         enabled_tools_pre_merge=enabled_tools_pre_merge,
         turn_scratch=turn_scratch,
-        client=ctx["client"],
+        client=ctx.client,
         kv_tracker=kv_tracker,
         schema_overrides=schema_overrides,
         accumulators=accumulators,
@@ -1135,7 +1169,7 @@ async def _resolve_target_and_parent(conversation_id: str, assistant_msg_id: int
 
 
 async def _prepare_regen_context(
-    ctx: dict, conversation_id: str, target: dict, user_msg: dict
+    ctx: PipelineContext, conversation_id: str, target: dict, user_msg: dict
 ) -> tuple[list[dict], list[dict]]:
     """Prepare history and attachments for a regeneration pass.
 
@@ -1145,9 +1179,9 @@ async def _prepare_regen_context(
     parent_id: int | None = user_msg.get("parent_id")
     history = await db.get_path_to_leaf(conversation_id, parent_id) if parent_id is not None else []
     moods_before = await db.get_moods_before_turn(conversation_id, target["turn_index"] - 1)
-    ctx["director"]["active_moods"] = moods_before
+    ctx.director["active_moods"] = moods_before
     grandparent = next((m for m in reversed(history) if m["role"] == "assistant"), None)
-    ctx["director"]["progressive_fields"] = grandparent.get("progressive_fields") or {} if grandparent else {}
+    ctx.director["progressive_fields"] = grandparent.get("progressive_fields") or {} if grandparent else {}
     user_msg_id = target["parent_id"]
     attachments = await db.get_user_attachments_for_message(user_msg_id) if user_msg_id else []
     return history, attachments
@@ -1405,20 +1439,20 @@ async def _consume_pipeline(
     yield {"event": "done"}
 
 
-def _register_clients(ctx: dict, client_ref: list | None, *, include_agent: bool = True) -> None:
+def _register_clients(ctx: PipelineContext, client_ref: list | None, *, include_agent: bool = True) -> None:
     """Expose the turn's LLM client(s) on *client_ref* so a /stop can abort them.
 
     *include_agent* is False for magic-rewrite, which never spins up the agent.
     """
     if client_ref is None:
         return
-    client_ref.append(ctx["client"])
-    if include_agent and ctx.get("agent_client"):
-        client_ref.append(ctx["agent_client"])
+    client_ref.append(ctx.client)
+    if include_agent and ctx.agent_client:
+        client_ref.append(ctx.agent_client)
 
 
 async def _generate_reply(
-    ctx: dict,
+    ctx: PipelineContext,
     conversation_id: str,
     *,
     history: list[dict],
@@ -1462,22 +1496,22 @@ async def _generate_reply(
     assert setup is not None
 
     pipeline = _run_pipeline(
-        ctx["client"],
+        ctx.client,
         pipeline_settings,
-        ctx["director"],
-        ctx["mood_fragments"],
-        ctx["director_fragments"],
+        ctx.director,
+        ctx.mood_fragments,
+        ctx.director_fragments,
         user_message,
         attachments=attachments,
-        phrase_bank=ctx["phrase_bank"],
+        phrase_bank=ctx.phrase_bank,
         lorebook_block=setup.lorebook_block,
         editor_audit_msgs=editor_audit_msgs,
-        agent_client=ctx.get("agent_client"),
+        agent_client=ctx.agent_client,
         agent_prefix=setup.agent_prefix,
         macros=setup.macros,
         conversation_id=conversation_id,
-        character_id=ctx["conv"].get("character_card_id"),
-        card=ctx["card"],
+        character_id=ctx.conv.get("character_card_id"),
+        card=ctx.card,
         prefix=setup.prefix,
         enabled_tools=setup.merged_enabled_tools,
         turn_scratch=setup.turn_scratch,
@@ -1518,9 +1552,9 @@ async def handle_turn(
 
         _register_clients(ctx, client_ref)
 
-        settings = ctx["settings"]
+        settings = ctx.settings
         messages = await db.get_messages(conversation_id)
-        conv = ctx["conv"]
+        conv = ctx.conv
 
         history, user_msg_id = messages, None
         user_parent_id = conv.get("active_leaf_id")
@@ -1541,7 +1575,7 @@ async def handle_turn(
         # rather than conversation_logs which are indexed by turn_index and can
         # return data from a different branch after a branch switch.
         grandparent = next((m for m in reversed(messages) if m["role"] == "assistant"), None)
-        ctx["director"]["progressive_fields"] = grandparent.get("progressive_fields") or {} if grandparent else {}
+        ctx.director["progressive_fields"] = grandparent.get("progressive_fields") or {} if grandparent else {}
 
         # Save user message BEFORE pipeline
         if not skip_user_persist:
@@ -1620,7 +1654,7 @@ async def handle_fork_edit(
 
         _register_clients(ctx, client_ref)
 
-        settings = ctx["settings"]
+        settings = ctx.settings
         original = await db.get_message_by_id(user_msg_id)
         if not original or original["conversation_id"] != conversation_id or original["role"] != "user":
             yield {"event": "error", "data": "Invalid target message"}
@@ -1635,9 +1669,9 @@ async def handle_fork_edit(
         # moods as of the branch point, and progressive_fields read branch-aware
         # from the grandparent assistant node (not conversation_logs, which are
         # turn-indexed and can leak across branches).
-        ctx["director"]["active_moods"] = await db.get_moods_before_turn(conversation_id, turn_index)
+        ctx.director["active_moods"] = await db.get_moods_before_turn(conversation_id, turn_index)
         grandparent = next((m for m in reversed(history) if m["role"] == "assistant"), None)
-        ctx["director"]["progressive_fields"] = grandparent.get("progressive_fields") or {} if grandparent else {}
+        ctx.director["progressive_fields"] = grandparent.get("progressive_fields") or {} if grandparent else {}
 
         # Carry the original message's user attachments onto the new sibling and
         # into the prompt. DB-format dicts (mime_type/data_b64) pass straight
@@ -1689,7 +1723,7 @@ async def handle_regenerate(
 
         _register_clients(ctx, client_ref)
 
-        settings = ctx["settings"]
+        settings = ctx.settings
         result = await _resolve_target_and_parent(conversation_id, assistant_msg_id)
         if isinstance(result, str):
             yield {"event": "error", "data": result}
@@ -1735,7 +1769,7 @@ async def handle_super_regenerate(
 
         _register_clients(ctx, client_ref)
 
-        settings = ctx["settings"]
+        settings = ctx.settings
         result = await _resolve_target_and_parent(conversation_id, assistant_msg_id)
         if isinstance(result, str):
             yield {"event": "error", "data": result}
@@ -1806,7 +1840,7 @@ async def handle_magic_rewrite(
 
         _register_clients(ctx, client_ref, include_agent=False)
 
-        settings = ctx["settings"]
+        settings = ctx.settings
         result = await _resolve_target_and_parent(conversation_id, assistant_msg_id)
         if isinstance(result, str):
             yield {"event": "error", "data": result}
@@ -1831,7 +1865,7 @@ async def handle_magic_rewrite(
         extra = reasoning_cfg(writer_reasoning_on)
 
         accumulated = ""
-        async for item in ctx["client"].complete(messages=msgs, model=settings["model_name"], **extra, **hyperparams):
+        async for item in ctx.client.complete(messages=msgs, model=settings["model_name"], **extra, **hyperparams):
             if item["type"] == "done":
                 break
             if item["type"] == "reasoning":
@@ -1845,7 +1879,7 @@ async def handle_magic_rewrite(
 
         # On abort, keep the original message intact rather than overwriting it
         # with the partial rewrite that streamed before the stop.
-        if accumulated.strip() and not ctx["client"].is_aborted:
+        if accumulated.strip() and not ctx.client.is_aborted:
             await db.update_message_content(assistant_msg_id, accumulated)
 
         # Emitted on the success path only — on error we yield "error" and stop,

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -65,7 +65,7 @@ class _PipelineConfig:
     """
 
     agent_on: bool
-    enabled_tools: dict
+    enabled_tools: Mapping[str, bool]
     director_reasoning_on: bool
     writer_reasoning_on: bool
     editor_reasoning_on: bool
@@ -74,7 +74,7 @@ class _PipelineConfig:
     length_guard_enforce: bool
     length_guard: dict | None
     do_edit: bool
-    writer_enabled_tools: dict
+    writer_enabled_tools: Mapping[str, bool]
     director_client: LLMClient
     writer_client: LLMClient
     editor_client: LLMClient
@@ -85,7 +85,7 @@ class _PipelineConfig:
 
 def _resolve_pipeline_config(
     settings: Mapping[str, Any],
-    enabled_tools: dict,
+    enabled_tools: Mapping[str, bool],
     *,
     macros: Macros,
     client: LLMClient,
@@ -202,7 +202,7 @@ async def _run_pipeline(
     card: Mapping[str, Any] | None = None,
     *,
     prefix: list[dict],
-    enabled_tools: dict,
+    enabled_tools: Mapping[str, bool],
     turn_scratch: dict,
     kv_tracker: _KVCacheTracker,
     schema_overrides: dict,
@@ -522,7 +522,7 @@ async def _run_post_pipeline(
     director_output: dict,
     settings: Mapping[str, Any],
     prefix: list[dict],
-    enabled_tools: dict,
+    enabled_tools: Mapping[str, bool],
     turn_scratch: dict,
     client: LLMClient,
     kv_tracker: _KVCacheTracker,
@@ -742,7 +742,7 @@ async def _iterate_pre_pipeline_hooks(
     last_user_message: str,
     settings: Mapping[str, Any],
     prefix_base: list[dict],
-    enabled_tools_pre_merge: dict,
+    enabled_tools_pre_merge: Mapping[str, bool],
     turn_scratch: dict,
     client,
     kv_tracker,
@@ -1037,7 +1037,7 @@ class _TurnSetup:
 
     prefix: list[dict]
     agent_prefix: list[dict] | None
-    merged_enabled_tools: dict
+    merged_enabled_tools: dict[str, bool]
     macros: Macros
     lorebook_block: str
     turn_scratch: dict

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -14,13 +14,13 @@ from typing import Any, AsyncIterator, List, Mapping, Optional, Sequence
 from . import database as db
 from .llm_client import LLMClient, reasoning_cfg
 from .endpoint_profiles import profile_for
-from .tool_defs import TOOLS, POST_WRITER_TOOLS, build_direct_scene_tool
+from .tool_defs import TOOLS, POST_WRITER_TOOLS, build_direct_scene_tool, enabled_schemas
 from .prompt_builder import (
     build_prefix,
     compute_style_injection_block,
     compute_lorebook_injection_block,
 )
-from .kv_tracker import _KVCacheTracker
+from .kv_tracker import _KVCacheTracker, CachedBase
 from .locks import workflow_character_state_lock, workflow_state_lock
 from .macros import Macros
 from .workflows import (
@@ -80,9 +80,13 @@ class _PipelineConfig:
     director_client: LLMClient
     writer_client: LLMClient
     editor_client: LLMClient
-    director_prefix: list[ChatMessage]
-    editor_prefix: list[ChatMessage]
-    agent_model: str
+    # The byte-identical cached bottoms, built once per server per turn. The
+    # director and editor share ``agent_base`` (same server, same prefix + tools
+    # + model); the writer rides ``writer_base``. In single-model mode the two
+    # are identical by construction; in dual-model the writer_base carries the
+    # writer's prefix and an empty tools blob (Invariant 5).
+    agent_base: CachedBase
+    writer_base: CachedBase
 
 
 def _resolve_pipeline_config(
@@ -95,6 +99,7 @@ def _resolve_pipeline_config(
     agent_prefix: list[ChatMessage] | None,
     prefix: list[ChatMessage],
     phrase_bank: list[PhraseGroup] | None,
+    schema_overrides: Mapping[str, dict],
 ) -> _PipelineConfig:
     """Derive the per-turn pipeline configuration (see :class:`_PipelineConfig`)."""
     agent_on = bool(settings.get("enable_agent", 1))
@@ -128,6 +133,23 @@ def _resolve_pipeline_config(
     # writer call — neither is useful and both add unnecessary tokens.
     writer_enabled_tools = {} if agent_client is not None else enabled_tools
 
+    # The two cached bottoms, computed once here. The director + editor share the
+    # agent base (same server, same prefix/tools/model); the writer has its own.
+    # The tool blobs are built via enabled_schemas exactly once each so no pass
+    # can rebuild them differently — the byte-identity is structural, not a
+    # convention each pass must independently honour.
+    agent_model = settings.get("agent_model_name", settings["model_name"]) if agent_client else settings["model_name"]
+    agent_base = CachedBase(
+        prefix=tuple(agent_prefix or prefix),
+        tools=tuple(enabled_schemas(enabled_tools, schema_overrides)),
+        model=agent_model,
+    )
+    writer_base = CachedBase(
+        prefix=tuple(prefix),
+        tools=tuple(enabled_schemas(writer_enabled_tools, schema_overrides)),
+        model=settings["model_name"],
+    )
+
     return _PipelineConfig(
         agent_on=agent_on,
         enabled_tools=enabled_tools,
@@ -143,9 +165,8 @@ def _resolve_pipeline_config(
         director_client=macros.wrap_client(agent_client or client),
         writer_client=macros.wrap_client(client),
         editor_client=macros.wrap_client(agent_client or client),
-        director_prefix=agent_prefix or prefix,
-        editor_prefix=agent_prefix or prefix,
-        agent_model=(settings.get("agent_model_name", settings["model_name"]) if agent_client else settings["model_name"]),
+        agent_base=agent_base,
+        writer_base=writer_base,
     )
 
 
@@ -260,6 +281,7 @@ async def _run_pipeline(
         agent_prefix=agent_prefix,
         prefix=prefix,
         phrase_bank=phrase_bank,
+        schema_overrides=schema_overrides,
     )
 
     # Mutable turn state, accumulated as the three passes run below.
@@ -281,7 +303,7 @@ async def _run_pipeline(
         yield {"event": "director_start"}
         async for event in _director_pass(
             cfg.director_client,
-            cfg.director_prefix,
+            cfg.agent_base,
             user_message,
             settings,
             director,
@@ -292,9 +314,7 @@ async def _run_pipeline(
             kv_tracker=kv_tracker,
             reasoning_on=cfg.director_reasoning_on,
             lorebook_block=lorebook_block,
-            model=cfg.agent_model,
             progressive_state=progressive_state,
-            schema_overrides=schema_overrides,
         ):
             if event["type"] == "reasoning":
                 reasoning_director_text += event["delta"]
@@ -360,7 +380,7 @@ async def _run_pipeline(
     resp_text = ""
     async for item in _writer_pass(
         cfg.writer_client,
-        prefix,
+        cfg.writer_base,
         settings,
         cfg.writer_enabled_tools,
         inj_block=inj_block,
@@ -371,7 +391,6 @@ async def _run_pipeline(
         length_guard=cfg.length_guard,
         kv_tracker=kv_tracker,
         reasoning_on=cfg.writer_reasoning_on,
-        schema_overrides=schema_overrides,
     ):
         if item["type"] == "reasoning":
             reasoning_writer_text += item["delta"]
@@ -423,20 +442,17 @@ async def _run_pipeline(
         try:
             async for event in editor_pass(
                 cfg.editor_client,
-                cfg.editor_prefix,
+                cfg.agent_base,
                 effective_msg,
                 resp_text,
                 settings,
                 phrase_bank or [],
-                cfg.enabled_tools,
                 cfg.audit_enabled,
                 cfg.length_guard,
                 kv_tracker=kv_tracker,
                 reasoning_on=cfg.editor_reasoning_on,
                 audit_context_msgs=editor_audit_msgs,
-                model=cfg.agent_model,
                 writer_user_msg=writer_content,
-                schema_overrides=schema_overrides,
             ):
                 if event["type"] == "reasoning":
                     reasoning_editor_text += event["delta"]

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -1456,7 +1456,7 @@ async def _consume_pipeline(
     yield {"event": "done"}
 
 
-def _register_clients(ctx: PipelineContext, client_ref: list | None, *, include_agent: bool = True) -> None:
+def _register_clients(ctx: PipelineContext, client_ref: list[LLMClient] | None, *, include_agent: bool = True) -> None:
     """Expose the turn's LLM client(s) on *client_ref* so a /stop can abort them.
 
     *include_agent* is False for magic-rewrite, which never spins up the agent.
@@ -1557,7 +1557,7 @@ async def handle_turn(
     user_message: str,
     skip_user_persist: bool = False,
     attachments: Optional[List[dict]] = None,
-    client_ref: list | None = None,
+    client_ref: list[LLMClient] | None = None,
 ) -> AsyncIterator[dict]:
     try:
         if attachments is None:
@@ -1646,7 +1646,7 @@ async def handle_fork_edit(
     conversation_id: str,
     user_msg_id: int,
     new_content: str,
-    client_ref: list | None = None,
+    client_ref: list[LLMClient] | None = None,
 ) -> AsyncIterator[dict]:
     """Fork the conversation at a user message.
 
@@ -1730,7 +1730,7 @@ async def handle_fork_edit(
 async def handle_regenerate(
     conversation_id: str,
     assistant_msg_id: int,
-    client_ref: list | None = None,
+    client_ref: list[LLMClient] | None = None,
 ) -> AsyncIterator[dict]:
     try:
         ctx = await _load_pipeline_context(conversation_id)
@@ -1776,7 +1776,7 @@ _SUPER_REGEN_MSG = "[OOC: Your response was kind of meh, rewrite it in a slightl
 async def handle_super_regenerate(
     conversation_id: str,
     assistant_msg_id: int,
-    client_ref: list | None = None,
+    client_ref: list[LLMClient] | None = None,
 ) -> AsyncIterator[dict]:
     try:
         ctx = await _load_pipeline_context(conversation_id)
@@ -1848,7 +1848,7 @@ async def handle_magic_rewrite(
     conversation_id: str,
     assistant_msg_id: int,
     direction: str,
-    client_ref: list | None = None,
+    client_ref: list[LLMClient] | None = None,
 ) -> AsyncIterator[dict]:
     try:
         ctx = await _load_pipeline_context(conversation_id)

--- a/backend/passes/director.py
+++ b/backend/passes/director.py
@@ -10,7 +10,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import AsyncIterator, List, Optional
+from typing import Any, AsyncIterator, List, Mapping, Optional, Sequence
 
 from ..llm_client import LLMClient, parse_tool_calls, reasoning_cfg
 from ..tool_defs import (
@@ -81,10 +81,10 @@ async def _director_pass(
     client: LLMClient,
     prefix: list[dict],
     user_message: str,
-    settings: dict,
-    director: dict,
-    mood_fragments: list[dict],
-    director_fragments: list[dict],
+    settings: Mapping[str, Any],
+    director: Mapping[str, Any],
+    mood_fragments: Sequence[Mapping[str, Any]],
+    director_fragments: Sequence[Mapping[str, Any]],
     enabled_tools: dict,
     attachments: Optional[List[dict]] = None,
     kv_tracker=None,

--- a/backend/passes/director.py
+++ b/backend/passes/director.py
@@ -19,6 +19,7 @@ from ..tool_defs import (
     enabled_schemas,
 )
 from ..prompt_builder import build_director_tool_prompt
+from ..llm_types import ChatMessage
 from ..utils import extract_hyperparams, build_multimodal_content
 
 logger = logging.getLogger(__name__)
@@ -79,7 +80,7 @@ def apply_tool_calls(
 
 async def _director_pass(
     client: LLMClient,
-    prefix: list[dict],
+    prefix: list[ChatMessage],
     user_message: str,
     settings: Mapping[str, Any],
     director: Mapping[str, Any],
@@ -148,7 +149,7 @@ async def _director_pass(
         )
         tail = ("___\n\n" + lorebook_block + "\n\n" if lorebook_block else "") + tool_tail
         content = build_multimodal_content(tail, attachments)
-        msgs = prefix + [{"role": "user", "content": content}]
+        msgs: list[ChatMessage] = [*prefix, {"role": "user", "content": content}]
         logger.info(
             "Agent tool=%s prompt:\n%s",
             name,

--- a/backend/passes/director.py
+++ b/backend/passes/director.py
@@ -40,9 +40,9 @@ class DirectorResult:
     fragment ids, which the director pass does not know about.
     """
 
-    active_moods: list = field(default_factory=list)
+    active_moods: list[str] = field(default_factory=list)
     agent_raw: str = ""
-    calls: list = field(default_factory=list)
+    calls: list[dict] = field(default_factory=list)
     latency: int = 0
     rewritten_msg: str | None = None
     extra_fields: dict = field(default_factory=dict)

--- a/backend/passes/director.py
+++ b/backend/passes/director.py
@@ -10,7 +10,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, List, Mapping, Optional, Sequence
+from typing import Any, AsyncIterator, Mapping, Optional, Sequence
 
 from ..llm_client import LLMClient, parse_tool_calls, reasoning_cfg
 from ..tool_defs import (
@@ -86,7 +86,7 @@ async def _director_pass(
     mood_fragments: Sequence[Mapping[str, Any]],
     director_fragments: Sequence[Mapping[str, Any]],
     enabled_tools: dict,
-    attachments: Optional[List[dict]] = None,
+    attachments: Optional[Sequence[Mapping[str, Any]]] = None,
     kv_tracker=None,
     reasoning_on: bool = True,
     lorebook_block: str = "",

--- a/backend/passes/director.py
+++ b/backend/passes/director.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+from dataclasses import dataclass, field
 from typing import AsyncIterator, List, Optional
 
 from ..llm_client import LLMClient, parse_tool_calls, reasoning_cfg
@@ -21,6 +22,29 @@ from ..prompt_builder import build_director_tool_prompt
 from ..utils import extract_hyperparams, build_multimodal_content
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DirectorResult:
+    """Typed payload of the director pass's terminal ``done`` event.
+
+    Field names match the orchestrator's turn-state locals and
+    :class:`~backend.orchestrator._PipelineResult` (notably ``agent_raw``,
+    ``rewritten_msg``) so a single name follows each value end to end. This
+    replaces the former 6-positional ``result`` tuple: adding or reordering a
+    field can no longer silently transpose values at the unpack site.
+
+    ``progressive_fields`` is intentionally absent — it is derived in the
+    orchestrator from ``extra_fields`` filtered against the valid progressive
+    fragment ids, which the director pass does not know about.
+    """
+
+    active_moods: list = field(default_factory=list)
+    agent_raw: str = ""
+    calls: list = field(default_factory=list)
+    latency: int = 0
+    rewritten_msg: str | None = None
+    extra_fields: dict = field(default_factory=dict)
 
 
 # ── Tool-call result unpacking ────────────────────────────────────────────────
@@ -73,8 +97,8 @@ async def _director_pass(
     """Yields reasoning dicts during each tool call, then a single done dict.
 
     Yields:
-        {"type": "reasoning", "delta": str}   — zero or more reasoning chunks
-        {"type": "done", "result": tuple}     — final (moods, raw, calls, latency, refined, extra_fields)
+        {"type": "reasoning", "delta": str}        — zero or more reasoning chunks
+        {"type": "done", "result": DirectorResult}  — terminal pass result
     """
     active_moods = director["active_moods"]
     if attachments is None:
@@ -96,7 +120,7 @@ async def _director_pass(
     if not tool_names:
         yield {
             "type": "done",
-            "result": (active_moods, "", [], 0, None, {}),
+            "result": DirectorResult(active_moods=active_moods),
         }
         return
 
@@ -172,12 +196,12 @@ async def _director_pass(
 
     yield {
         "type": "done",
-        "result": (
-            active_moods,
-            last_raw,
-            all_calls,
-            int((time.monotonic() - t0) * 1000),
-            refined_msg,
-            extra_fields,
+        "result": DirectorResult(
+            active_moods=active_moods,
+            agent_raw=last_raw,
+            calls=all_calls,
+            latency=int((time.monotonic() - t0) * 1000),
+            rewritten_msg=refined_msg,
+            extra_fields=extra_fields,
         ),
     }

--- a/backend/passes/director.py
+++ b/backend/passes/director.py
@@ -85,7 +85,7 @@ async def _director_pass(
     director: Mapping[str, Any],
     mood_fragments: Sequence[Mapping[str, Any]],
     director_fragments: Sequence[Mapping[str, Any]],
-    enabled_tools: dict,
+    enabled_tools: Mapping[str, bool],
     attachments: Optional[Sequence[Mapping[str, Any]]] = None,
     kv_tracker=None,
     reasoning_on: bool = True,

--- a/backend/passes/director.py
+++ b/backend/passes/director.py
@@ -93,7 +93,7 @@ async def _director_pass(
     lorebook_block: str = "",
     model: str | None = None,
     progressive_state: dict | None = None,
-    schema_overrides: dict | None = None,
+    schema_overrides: Mapping[str, dict] | None = None,
 ) -> AsyncIterator[dict]:
     """Yields reasoning dicts during each tool call, then a single done dict.
 

--- a/backend/passes/director.py
+++ b/backend/passes/director.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Mapping, Optional, Sequence
 
 from ..llm_client import LLMClient, parse_tool_calls, reasoning_cfg
+from ..kv_tracker import cached_complete
 from ..tool_defs import (
     TOOLS,
     POST_WRITER_TOOLS,
@@ -155,22 +156,18 @@ async def _director_pass(
             name,
             json.dumps(msgs, indent=2, ensure_ascii=False),
         )
-        if kv_tracker is not None:
-            kv_tracker.record(
-                f"director:{name}",
-                msgs,
-                tool_schemas,
-                model=model or settings["model_name"],
-            )
         resp: dict = {}
         try:
             reasoning_params = reasoning_cfg(reasoning_on and name != "rewrite_user_prompt")
             hyperparams = extract_hyperparams(settings, defaults={"temperature": 0.25, "max_tokens": 8192})
-            async for event in client.complete(
+            async for event in cached_complete(
+                client,
+                label=f"director:{name}",
                 messages=msgs,
                 model=model or settings["model_name"],
                 tools=tool_schemas,
                 tool_choice=TOOLS[name]["choice"],
+                kv_tracker=kv_tracker,
                 **hyperparams,
                 **reasoning_params,
             ):
@@ -178,8 +175,6 @@ async def _director_pass(
                     yield {"type": "reasoning", "delta": event["delta"]}
                 elif event["type"] == "done":
                     resp = event["message"]
-                    if kv_tracker is not None:
-                        kv_tracker.record_usage(f"director:{name}", event.get("usage"))
             last_raw = json.dumps(resp, default=str)
             logger.info("Agent tool=%s output:\n%s", name, last_raw)
             if parsed := parse_tool_calls(resp):

--- a/backend/passes/director.py
+++ b/backend/passes/director.py
@@ -13,11 +13,10 @@ from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Mapping, Optional, Sequence
 
 from ..llm_client import LLMClient, parse_tool_calls, reasoning_cfg
-from ..kv_tracker import cached_complete
+from ..kv_tracker import CachedBase
 from ..tool_defs import (
     TOOLS,
     POST_WRITER_TOOLS,
-    enabled_schemas,
 )
 from ..prompt_builder import build_director_tool_prompt
 from ..llm_types import ChatMessage
@@ -81,7 +80,7 @@ def apply_tool_calls(
 
 async def _director_pass(
     client: LLMClient,
-    prefix: list[ChatMessage],
+    base: CachedBase,
     user_message: str,
     settings: Mapping[str, Any],
     director: Mapping[str, Any],
@@ -92,9 +91,7 @@ async def _director_pass(
     kv_tracker=None,
     reasoning_on: bool = True,
     lorebook_block: str = "",
-    model: str | None = None,
     progressive_state: dict | None = None,
-    schema_overrides: Mapping[str, dict] | None = None,
 ) -> AsyncIterator[dict]:
     """Yields reasoning dicts during each tool call, then a single done dict.
 
@@ -126,7 +123,9 @@ async def _director_pass(
         }
         return
 
-    tool_schemas = enabled_schemas(enabled_tools, schema_overrides)
+    # The tools blob is resolved once into the shared base; the director reads it
+    # rather than rebuilding it, so it cannot drift from the writer/editor blobs.
+    tool_schemas = list(base.tools)
 
     logger.info(
         "Director pass: tools included=%s",
@@ -150,22 +149,20 @@ async def _director_pass(
         )
         tail = ("___\n\n" + lorebook_block + "\n\n" if lorebook_block else "") + tool_tail
         content = build_multimodal_content(tail, attachments)
-        msgs: list[ChatMessage] = [*prefix, {"role": "user", "content": content}]
+        trailing: list[ChatMessage] = [{"role": "user", "content": content}]
         logger.info(
             "Agent tool=%s prompt:\n%s",
             name,
-            json.dumps(msgs, indent=2, ensure_ascii=False),
+            json.dumps([*base.prefix, *trailing], indent=2, ensure_ascii=False),
         )
         resp: dict = {}
         try:
             reasoning_params = reasoning_cfg(reasoning_on and name != "rewrite_user_prompt")
             hyperparams = extract_hyperparams(settings, defaults={"temperature": 0.25, "max_tokens": 8192})
-            async for event in cached_complete(
+            async for event in base.complete(
                 client,
                 label=f"director:{name}",
-                messages=msgs,
-                model=model or settings["model_name"],
-                tools=tool_schemas,
+                trailing=trailing,
                 tool_choice=TOOLS[name]["choice"],
                 kv_tracker=kv_tracker,
                 **hyperparams,

--- a/backend/passes/editor/audit.py
+++ b/backend/passes/editor/audit.py
@@ -4,7 +4,12 @@ audit.py — Run all programmatic scanners and produce a consolidated AuditRepor
 
 from __future__ import annotations
 
-from .slop_detector import detect_cliches, DetectionResult, PhraseGroup
+from typing import TYPE_CHECKING
+
+from .slop_detector import detect_cliches, DetectionResult
+
+if TYPE_CHECKING:
+    from ...database.models import PhraseGroup
 from .opening_monotony import detect_opening_monotony, MonotonyResult
 from .template_repetition import detect_template_repetition, TemplateResult
 from .contrastive_negation import detect_contrastive_negation

--- a/backend/passes/editor/editor.py
+++ b/backend/passes/editor/editor.py
@@ -18,15 +18,14 @@ if TYPE_CHECKING:
 from .opening_monotony import FlaggedOpener, MonotonyResult, _split_sentences
 from .template_repetition import FlaggedTemplate, TemplateResult
 from ...llm_client import LLMClient, parse_tool_calls, reasoning_cfg
-from ...kv_tracker import cached_complete
+from ...kv_tracker import CachedBase
 from ...tool_defs import (
     TOOLS,
     LENGTH_GUARD_INSTRUCTIONS,
     MAX_EDITOR_ITERATIONS,
-    enabled_schemas,
 )
 from ...prompt_builder import build_editor_prompt
-from ...llm_types import AssistantToolMessage, ChatMessage, ContentPart, WireMessage
+from ...llm_types import AssistantToolMessage, ContentPart, WireMessage
 from ...utils import LengthGuard, extract_hyperparams
 
 logger = logging.getLogger(__name__)
@@ -302,22 +301,19 @@ def _editor_done_event(
 
 async def editor_pass(
     client: LLMClient,
-    prefix: list[ChatMessage],
+    base: CachedBase,
     effective_msg: str,
     draft: str,
     settings: Mapping[str, Any],
     phrase_bank: list[PhraseGroup],
-    enabled_tools: Mapping[str, bool],
     audit_enabled: bool = True,
     length_guard: LengthGuard | None = None,
     kv_tracker=None,
     reasoning_on: bool = False,  # If true, use structured tool-use message format (role=tool) for iteration feedback; non-thinking models get a synthetic recap instead
     audit_context_msgs: (
         list[str] | None
-    ) = None,  # explicit previous-assistant list for repetition scanning; if None, derived from prefix
-    model: str | None = None,
+    ) = None,  # explicit previous-assistant list for repetition scanning; if None, derived from base.prefix
     writer_user_msg: "str | list[ContentPart] | None" = None,  # writer's exact last user message; when provided replaces bare effective_msg so the editor extends the writer's KV-cached prefix
-    schema_overrides: Mapping[str, dict] | None = None,
 ) -> AsyncIterator[dict]:
     """ReAct-style editor loop with optional audit and/or length guard.
 
@@ -339,7 +335,7 @@ async def editor_pass(
         if audit_context_msgs is not None:
             assistant_messages = audit_context_msgs[:3]
         else:
-            for msg in reversed(prefix):
+            for msg in reversed(base.prefix):
                 if msg.get("role") == "assistant":
                     # Assistant history is always plain text; the multimodal
                     # list form only ever rides user messages, so a non-str
@@ -383,17 +379,12 @@ async def editor_pass(
     length_guard_instruction = ""
 
     # Uses the same enabled-tool set as director and writer for KV-cache
-    # alignment. The editor_apply_patch / editor_rewrite tools are folded into
-    # enabled_tools by the orchestrator before this pass runs.
-    #
-    # This blob is built ONCE and never reassigned for the life of the ReAct
-    # loop. Tool schemas live inside the cached prefix, so narrowing the list to
-    # a single tool mid-loop would bust the KV cache on every iteration. Which
-    # single tool the model must call is steered entirely by tool_choice (see
-    # _pick_tool_choice, recomputed each iteration) — it forces the right tool
-    # while the schema blob stays byte-identical across all iterations.
-    editor_tools: list[dict] = enabled_schemas(enabled_tools, schema_overrides)
-
+    # The tools blob lives on the shared ``base`` (built once by the orchestrator
+    # from the same enabled-tool set as the director and writer). The editor never
+    # rebuilds or narrows it: the schemas sit inside the cached prefix, so changing
+    # the list mid-loop would bust the KV cache every iteration. Which single tool
+    # the model must call is steered entirely by tool_choice (see _pick_tool_choice,
+    # recomputed each iteration) while base.tools stays byte-identical throughout.
     if length_guard and length_guard["enabled"]:
         word_count = len(draft.split())
         max_words = length_guard["max_words"]
@@ -420,7 +411,7 @@ async def editor_pass(
         yield _editor_done_event(None, debug_parts, t0)
         return
 
-    if not editor_tools:
+    if not base.tools:
         logger.info("Editor: no editor tools applicable, skipping LLM loop")
         yield _editor_done_event(None, debug_parts, t0)
         return
@@ -437,11 +428,11 @@ async def editor_pass(
 
     logger.info(final_prompt)
 
-    # The prefix is the closed ChatMessage shape; from here msgs is the broader
+    # base.prefix is the shared, frozen cached bottom; *trailing* is the broader
     # WireMessage buffer the ReAct loop mutates in place (assistant tool_calls,
-    # tool-role results). ChatMessage widens into WireMessage, so no cast.
-    msgs: list[WireMessage] = [
-        *prefix,
+    # tool-role results) and hands to base.complete() each iteration. Keeping the
+    # bottom on the base means the loop can only ever change the top of the stack.
+    trailing: list[WireMessage] = [
         {
             "role": "user",
             "content": (writer_user_msg if writer_user_msg is not None else effective_msg),
@@ -473,19 +464,17 @@ async def editor_pass(
             logger.debug(
                 "Editor iteration %d: sending %d messages to LLM:\n%s",
                 iteration + 1,
-                len(msgs),
-                json.dumps(msgs, default=str, indent=2),
+                len(base.prefix) + len(trailing),
+                json.dumps([*base.prefix, *trailing], default=str, indent=2),
             )
 
             resp: dict = {}
             try:
                 hyperparams = extract_hyperparams(settings, defaults={"temperature": 0.25, "max_tokens": 8192})
-                async for event in cached_complete(
+                async for event in base.complete(
                     client,
                     label="editor",
-                    messages=msgs,
-                    model=model or settings["model_name"],
-                    tools=editor_tools,
+                    trailing=trailing,
                     tool_choice=_pick_tool_choice(length_guard_triggered, report, audit_enabled),
                     kv_tracker=kv_tracker,
                     **hyperparams,
@@ -554,7 +543,7 @@ async def editor_pass(
                 if report.total_issues <= 1:
                     break
                 # Next iteration's tool_choice (via _pick_tool_choice) forces the
-                # right tool; editor_tools stays the full, byte-identical blob.
+                # right tool; base.tools stays the full, byte-identical blob.
                 prev_issues = report.total_issues
                 if reasoning_on:
                     rewrite_tool_calls = resp.get("tool_calls", [])
@@ -565,9 +554,9 @@ async def editor_pass(
                     }
                     if resp.get("reasoning_content"):
                         asst_msg["reasoning_content"] = resp["reasoning_content"]
-                    msgs.append(asst_msg)
+                    trailing.append(asst_msg)
                     if rewrite_tool_calls:
-                        msgs.append(
+                        trailing.append(
                             {
                                 "role": "tool",
                                 "tool_call_id": rewrite_tool_calls[0].get("id", ""),
@@ -575,8 +564,8 @@ async def editor_pass(
                             }
                         )
                 else:
-                    msgs[-2] = {"role": "assistant", "content": current_draft}
-                    msgs[-1] = {
+                    trailing[-2] = {"role": "assistant", "content": current_draft}
+                    trailing[-1] = {
                         "role": "user",
                         "content": build_editor_prompt(
                             audit_enabled and not report.is_clean,
@@ -646,10 +635,10 @@ async def editor_pass(
             # reasoning_on=False: replace the draft + prompt in-place (same as
             # the rewrite path) so the message list stays flat.
             if reasoning_on:
-                _append_iteration_context(msgs, resp, patches, errors, report_text, reasoning_on=True)
+                _append_iteration_context(trailing, resp, patches, errors, report_text, reasoning_on=True)
             else:
-                msgs[-2] = {"role": "assistant", "content": current_draft}
-                msgs[-1] = {
+                trailing[-2] = {"role": "assistant", "content": current_draft}
+                trailing[-1] = {
                     "role": "user",
                     "content": build_editor_prompt(
                         audit_enabled and not report.is_clean,

--- a/backend/passes/editor/editor.py
+++ b/backend/passes/editor/editor.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from typing import Any, AsyncIterator, Mapping, TYPE_CHECKING, cast
+from typing import Any, AsyncIterator, Mapping, TYPE_CHECKING
 
 from .audit import run_audit, format_report, AuditReport
 from .slop_detector import DetectionResult
@@ -27,7 +27,7 @@ from ...tool_defs import (
     enabled_schemas,
 )
 from ...prompt_builder import build_editor_prompt
-from ...llm_types import ChatMessage, ContentPart
+from ...llm_types import AssistantToolMessage, ChatMessage, ContentPart, WireMessage
 from ...utils import LengthGuard, extract_hyperparams
 
 logger = logging.getLogger(__name__)
@@ -431,11 +431,11 @@ async def editor_pass(
 
     logger.info(final_prompt)
 
-    # The prefix is the closed ChatMessage shape; from here msgs becomes the
-    # broader wire buffer the ReAct loop mutates in place (assistant tool_calls,
-    # tool-role results), so it crosses into free-form dict at this boundary.
-    msgs: list[dict[str, Any]] = [
-        *cast("list[dict[str, Any]]", prefix),
+    # The prefix is the closed ChatMessage shape; from here msgs is the broader
+    # WireMessage buffer the ReAct loop mutates in place (assistant tool_calls,
+    # tool-role results). ChatMessage widens into WireMessage, so no cast.
+    msgs: list[WireMessage] = [
+        *prefix,
         {
             "role": "user",
             "content": (writer_user_msg if writer_user_msg is not None else effective_msg),
@@ -557,7 +557,7 @@ async def editor_pass(
                 prev_issues = report.total_issues
                 if reasoning_on:
                     rewrite_tool_calls = resp.get("tool_calls", [])
-                    asst_msg = {
+                    asst_msg: AssistantToolMessage = {
                         "role": "assistant",
                         "content": resp.get("content") or "",
                         "tool_calls": rewrite_tool_calls,
@@ -701,7 +701,7 @@ def _pick_tool_choice(length_guard_triggered: bool, report: AuditReport, audit_e
 
 
 def _append_iteration_context(
-    msgs: list[dict],
+    msgs: list[WireMessage],
     resp: dict,
     patches: list[dict],
     errors: list[str],
@@ -719,7 +719,7 @@ def _append_iteration_context(
     tool_response = ("\n".join(errors) + "\n\n" if errors else "") + report_text
     if reasoning_on:
         tool_calls = resp.get("tool_calls", [])
-        asst_msg: dict = {
+        asst_msg: AssistantToolMessage = {
             "role": "assistant",
             "content": resp.get("content") or "",
             "tool_calls": tool_calls,

--- a/backend/passes/editor/editor.py
+++ b/backend/passes/editor/editor.py
@@ -307,7 +307,7 @@ async def editor_pass(
     draft: str,
     settings: Mapping[str, Any],
     phrase_bank: list[PhraseGroup],
-    enabled_tools: dict,
+    enabled_tools: Mapping[str, bool],
     audit_enabled: bool = True,
     length_guard: dict | None = None,
     kv_tracker=None,

--- a/backend/passes/editor/editor.py
+++ b/backend/passes/editor/editor.py
@@ -21,8 +21,6 @@ from ...llm_client import LLMClient, parse_tool_calls, reasoning_cfg
 from ...kv_tracker import cached_complete
 from ...tool_defs import (
     TOOLS,
-    EDITOR_APPLY_PATCH_TOOL,
-    EDITOR_REWRITE_TOOL,
     LENGTH_GUARD_INSTRUCTIONS,
     MAX_EDITOR_ITERATIONS,
     enabled_schemas,
@@ -385,8 +383,15 @@ async def editor_pass(
     length_guard_instruction = ""
 
     # Uses the same enabled-tool set as director and writer for KV-cache
-    # alignment. EDITOR_APPLY_PATCH_TOOL and EDITOR_REWRITE_TOOL are injected
-    # into enabled_tools by the orchestrator before this pass runs.
+    # alignment. The editor_apply_patch / editor_rewrite tools are folded into
+    # enabled_tools by the orchestrator before this pass runs.
+    #
+    # This blob is built ONCE and never reassigned for the life of the ReAct
+    # loop. Tool schemas live inside the cached prefix, so narrowing the list to
+    # a single tool mid-loop would bust the KV cache on every iteration. Which
+    # single tool the model must call is steered entirely by tool_choice (see
+    # _pick_tool_choice, recomputed each iteration) — it forces the right tool
+    # while the schema blob stays byte-identical across all iterations.
     editor_tools: list[dict] = enabled_schemas(enabled_tools, schema_overrides)
 
     if length_guard and length_guard["enabled"]:
@@ -548,12 +553,8 @@ async def editor_pass(
 
                 if report.total_issues <= 1:
                     break
-                if _structural_rewrite_needed(report):
-                    editor_tools = [EDITOR_REWRITE_TOOL]
-                elif audit_enabled:
-                    editor_tools = [EDITOR_APPLY_PATCH_TOOL]
-                else:
-                    editor_tools = []
+                # Next iteration's tool_choice (via _pick_tool_choice) forces the
+                # right tool; editor_tools stays the full, byte-identical blob.
                 prev_issues = report.total_issues
                 if reasoning_on:
                     rewrite_tool_calls = resp.get("tool_calls", [])
@@ -625,8 +626,11 @@ async def editor_pass(
             if report.total_issues <= 1:
                 if not length_guard_triggered:
                     break
+                # Audit clean but length guard still pending: next iteration's
+                # tool_choice forces editor_rewrite (length_guard_triggered is
+                # still True). The schema blob is left untouched so the KV cache
+                # survives the hand-off.
                 logger.info("Editor: audit within threshold, length guard still pending — queuing rewrite")
-                editor_tools = [EDITOR_REWRITE_TOOL]
 
             if report.total_issues >= prev_issues:
                 logger.info(

--- a/backend/passes/editor/editor.py
+++ b/backend/passes/editor/editor.py
@@ -27,7 +27,7 @@ from ...tool_defs import (
     enabled_schemas,
 )
 from ...prompt_builder import build_editor_prompt
-from ...utils import extract_hyperparams
+from ...utils import LengthGuard, extract_hyperparams
 
 logger = logging.getLogger(__name__)
 
@@ -309,7 +309,7 @@ async def editor_pass(
     phrase_bank: list[PhraseGroup],
     enabled_tools: Mapping[str, bool],
     audit_enabled: bool = True,
-    length_guard: dict | None = None,
+    length_guard: LengthGuard | None = None,
     kv_tracker=None,
     reasoning_on: bool = False,  # If true, use structured tool-use message format (role=tool) for iteration feedback; non-thinking models get a synthetic recap instead
     audit_context_msgs: (
@@ -382,10 +382,10 @@ async def editor_pass(
     # into enabled_tools by the orchestrator before this pass runs.
     editor_tools: list[dict] = enabled_schemas(enabled_tools, schema_overrides)
 
-    if length_guard and length_guard.get("enabled"):
+    if length_guard and length_guard["enabled"]:
         word_count = len(draft.split())
-        max_words = length_guard.get("max_words", 280)
-        max_paragraphs = length_guard.get("max_paragraphs", 3)
+        max_words = length_guard["max_words"]
+        max_paragraphs = length_guard["max_paragraphs"]
         if word_count > max_words:
             length_guard_triggered = True
             length_guard_instruction = LENGTH_GUARD_INSTRUCTIONS.format(

--- a/backend/passes/editor/editor.py
+++ b/backend/passes/editor/editor.py
@@ -318,7 +318,7 @@ async def editor_pass(
     ) = None,  # explicit previous-assistant list for repetition scanning; if None, derived from prefix
     model: str | None = None,
     writer_user_msg: "str | list[ContentPart] | None" = None,  # writer's exact last user message; when provided replaces bare effective_msg so the editor extends the writer's KV-cached prefix
-    schema_overrides: dict | None = None,
+    schema_overrides: Mapping[str, dict] | None = None,
 ) -> AsyncIterator[dict]:
     """ReAct-style editor loop with optional audit and/or length guard.
 

--- a/backend/passes/editor/editor.py
+++ b/backend/passes/editor/editor.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from typing import AsyncIterator, TYPE_CHECKING
+from typing import Any, AsyncIterator, Mapping, TYPE_CHECKING
 
 from .audit import run_audit, format_report, AuditReport
 from .slop_detector import DetectionResult
@@ -305,7 +305,7 @@ async def editor_pass(
     prefix: list[dict],
     effective_msg: str,
     draft: str,
-    settings: dict,
+    settings: Mapping[str, Any],
     phrase_bank: list[PhraseGroup],
     enabled_tools: dict,
     audit_enabled: bool = True,

--- a/backend/passes/editor/editor.py
+++ b/backend/passes/editor/editor.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from typing import Any, AsyncIterator, Mapping, TYPE_CHECKING
+from typing import Any, AsyncIterator, Mapping, TYPE_CHECKING, cast
 
 from .audit import run_audit, format_report, AuditReport
 from .slop_detector import DetectionResult
@@ -27,6 +27,7 @@ from ...tool_defs import (
     enabled_schemas,
 )
 from ...prompt_builder import build_editor_prompt
+from ...llm_types import ChatMessage, ContentPart
 from ...utils import LengthGuard, extract_hyperparams
 
 logger = logging.getLogger(__name__)
@@ -302,7 +303,7 @@ def _editor_done_event(
 
 async def editor_pass(
     client: LLMClient,
-    prefix: list[dict],
+    prefix: list[ChatMessage],
     effective_msg: str,
     draft: str,
     settings: Mapping[str, Any],
@@ -316,7 +317,7 @@ async def editor_pass(
         list[str] | None
     ) = None,  # explicit previous-assistant list for repetition scanning; if None, derived from prefix
     model: str | None = None,
-    writer_user_msg: "str | list | None" = None,  # writer's exact last user message; when provided replaces bare effective_msg so the editor extends the writer's KV-cached prefix
+    writer_user_msg: "str | list[ContentPart] | None" = None,  # writer's exact last user message; when provided replaces bare effective_msg so the editor extends the writer's KV-cached prefix
     schema_overrides: dict | None = None,
 ) -> AsyncIterator[dict]:
     """ReAct-style editor loop with optional audit and/or length guard.
@@ -341,7 +342,12 @@ async def editor_pass(
         else:
             for msg in reversed(prefix):
                 if msg.get("role") == "assistant":
-                    assistant_messages.append(msg.get("content", ""))
+                    # Assistant history is always plain text; the multimodal
+                    # list form only ever rides user messages, so a non-str
+                    # body has nothing to contribute to the repetition window.
+                    content = msg.get("content", "")
+                    if isinstance(content, str):
+                        assistant_messages.append(content)
                     if len(assistant_messages) >= 3:
                         break
 
@@ -425,7 +431,11 @@ async def editor_pass(
 
     logger.info(final_prompt)
 
-    msgs = prefix + [
+    # The prefix is the closed ChatMessage shape; from here msgs becomes the
+    # broader wire buffer the ReAct loop mutates in place (assistant tool_calls,
+    # tool-role results), so it crosses into free-form dict at this boundary.
+    msgs: list[dict[str, Any]] = [
+        *cast("list[dict[str, Any]]", prefix),
         {
             "role": "user",
             "content": (writer_user_msg if writer_user_msg is not None else effective_msg),

--- a/backend/passes/editor/editor.py
+++ b/backend/passes/editor/editor.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 from .opening_monotony import FlaggedOpener, MonotonyResult, _split_sentences
 from .template_repetition import FlaggedTemplate, TemplateResult
 from ...llm_client import LLMClient, parse_tool_calls, reasoning_cfg
+from ...kv_tracker import cached_complete
 from ...tool_defs import (
     TOOLS,
     EDITOR_APPLY_PATCH_TOOL,
@@ -459,8 +460,6 @@ async def editor_pass(
             MAX_EDITOR_ITERATIONS,
             report.total_issues,
         )
-        if kv_tracker is not None and iteration == 0:
-            kv_tracker.record("editor", msgs, editor_tools, model=model or settings["model_name"])
         try:
             reasoning_params = reasoning_cfg(reasoning_on)
             if not reasoning_params["reasoning"].get("enabled", True):
@@ -476,11 +475,14 @@ async def editor_pass(
             resp: dict = {}
             try:
                 hyperparams = extract_hyperparams(settings, defaults={"temperature": 0.25, "max_tokens": 8192})
-                async for event in client.complete(
+                async for event in cached_complete(
+                    client,
+                    label="editor",
                     messages=msgs,
                     model=model or settings["model_name"],
                     tools=editor_tools,
                     tool_choice=_pick_tool_choice(length_guard_triggered, report, audit_enabled),
+                    kv_tracker=kv_tracker,
                     **hyperparams,
                     **reasoning_params,
                 ):
@@ -488,8 +490,6 @@ async def editor_pass(
                         yield {"type": "reasoning", "delta": event["delta"]}
                     elif event["type"] == "done":
                         resp = event["message"]
-                        if kv_tracker is not None and iteration == 0:
-                            kv_tracker.record_usage("editor", event.get("usage"))
             except Exception as llm_err:
                 logger.error(
                     "Editor iteration %d: client.complete() raised %s: %s",

--- a/backend/passes/editor/editor.py
+++ b/backend/passes/editor/editor.py
@@ -8,10 +8,13 @@ from __future__ import annotations
 import json
 import logging
 import time
-from typing import AsyncIterator
+from typing import AsyncIterator, TYPE_CHECKING
 
 from .audit import run_audit, format_report, AuditReport
-from .slop_detector import DetectionResult, PhraseGroup
+from .slop_detector import DetectionResult
+
+if TYPE_CHECKING:
+    from ...database.models import PhraseGroup
 from .opening_monotony import FlaggedOpener, MonotonyResult, _split_sentences
 from .template_repetition import FlaggedTemplate, TemplateResult
 from ...llm_client import LLMClient, parse_tool_calls, reasoning_cfg

--- a/backend/passes/editor/slop_detector.py
+++ b/backend/passes/editor/slop_detector.py
@@ -28,12 +28,12 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from typing import Union
+from typing import TYPE_CHECKING
 
 from .text_segmentation import split_sentences
 
-# A group is either a list of literal variants or a {kind, ...} dict.
-PhraseGroup = Union[list[str], dict]
+if TYPE_CHECKING:
+    from ...database.models import PhraseGroup
 
 _N = 3
 _EXACT_MATCH_MAX_LEN = 3

--- a/backend/passes/writer.py
+++ b/backend/passes/writer.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, AsyncIterator, List, Mapping, Optional
+from typing import Any, AsyncIterator, Mapping, Optional, Sequence
 
 from ..llm_client import LLMClient, reasoning_cfg
 from ..tool_defs import enabled_schemas
@@ -20,7 +20,7 @@ def build_writer_content(
     inj_block: str,
     enabled_tools: dict,
     effective_msg: str,
-    attachments: list[dict] | None,
+    attachments: Sequence[Mapping[str, Any]] | None,
     length_guard_enforce: bool,
     length_guard: dict | None,
 ) -> "str | list":
@@ -54,7 +54,7 @@ async def _writer_pass(
     inj_block: str = "",
     lorebook_block: str = "",
     effective_msg: str,
-    attachments: Optional[List[dict]] = None,
+    attachments: Optional[Sequence[Mapping[str, Any]]] = None,
     length_guard_enforce: bool = False,
     length_guard: dict | None = None,
     kv_tracker=None,

--- a/backend/passes/writer.py
+++ b/backend/passes/writer.py
@@ -60,7 +60,7 @@ async def _writer_pass(
     length_guard: LengthGuard | None = None,
     kv_tracker=None,
     reasoning_on: bool = True,
-    schema_overrides: dict | None = None,
+    schema_overrides: Mapping[str, dict] | None = None,
 ) -> AsyncIterator[dict]:
     """Yields {"type": "content"|"reasoning", "delta": str} dicts."""
     content = build_writer_content(

--- a/backend/passes/writer.py
+++ b/backend/passes/writer.py
@@ -9,8 +9,7 @@ import logging
 from typing import Any, AsyncIterator, Mapping, Optional, Sequence
 
 from ..llm_client import LLMClient, reasoning_cfg
-from ..kv_tracker import cached_complete
-from ..tool_defs import enabled_schemas
+from ..kv_tracker import CachedBase
 from ..llm_types import ChatMessage, ContentPart
 from ..utils import LengthGuard, extract_hyperparams, build_multimodal_content
 
@@ -49,7 +48,7 @@ def build_writer_content(
 
 async def _writer_pass(
     client: LLMClient,
-    prefix: list[ChatMessage],
+    base: CachedBase,
     settings: Mapping[str, Any],
     enabled_tools: Mapping[str, bool],
     *,
@@ -61,9 +60,13 @@ async def _writer_pass(
     length_guard: LengthGuard | None = None,
     kv_tracker=None,
     reasoning_on: bool = True,
-    schema_overrides: Mapping[str, dict] | None = None,
 ) -> AsyncIterator[dict]:
-    """Yields {"type": "content"|"reasoning", "delta": str} dicts."""
+    """Yields {"type": "content"|"reasoning", "delta": str} dicts.
+
+    *enabled_tools* still drives the in-prompt "do not use tools" notice; the
+    tool *schema* blob comes from ``base`` (built from the same enabled-tool set)
+    so it stays byte-identical with the director/editor passes.
+    """
     content = build_writer_content(
         lorebook_block,
         inj_block,
@@ -74,22 +77,22 @@ async def _writer_pass(
         length_guard,
     )
 
-    msgs: list[ChatMessage] = [*prefix, {"role": "user", "content": content}]
+    trailing: list[ChatMessage] = [{"role": "user", "content": content}]
 
     hyperparams = extract_hyperparams(settings)
-    schemas = enabled_schemas(enabled_tools, schema_overrides)
     logger.info(
         "Writer pass: tools included=%s",
-        json.dumps([s["function"]["name"] for s in schemas]) if schemas else "[]",
+        json.dumps([t["function"]["name"] for t in base.tools]) if base.tools else "[]",
     )
 
-    async for item in cached_complete(
+    async for item in base.complete(
         client,
         label="writer",
-        messages=msgs,
-        model=settings["model_name"],
-        tools=schemas or None,
-        tool_choice="none" if schemas else None,
+        trailing=trailing,
+        # base.tools is empty in dual-model (Invariant 5) → no tools, no
+        # tool_choice; otherwise the writer ships the shared blob but is barred
+        # from calling anything.
+        tool_choice="none" if base.tools else None,
         kv_tracker=kv_tracker,
         **reasoning_cfg(reasoning_on),
         **hyperparams,

--- a/backend/passes/writer.py
+++ b/backend/passes/writer.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 def build_writer_content(
     lorebook_block: str,
     inj_block: str,
-    enabled_tools: dict,
+    enabled_tools: Mapping[str, bool],
     effective_msg: str,
     attachments: Sequence[Mapping[str, Any]] | None,
     length_guard_enforce: bool,
@@ -49,7 +49,7 @@ async def _writer_pass(
     client: LLMClient,
     prefix: list[dict],
     settings: Mapping[str, Any],
-    enabled_tools: dict,
+    enabled_tools: Mapping[str, bool],
     *,
     inj_block: str = "",
     lorebook_block: str = "",

--- a/backend/passes/writer.py
+++ b/backend/passes/writer.py
@@ -10,6 +10,7 @@ from typing import Any, AsyncIterator, Mapping, Optional, Sequence
 
 from ..llm_client import LLMClient, reasoning_cfg
 from ..tool_defs import enabled_schemas
+from ..llm_types import ChatMessage, ContentPart
 from ..utils import LengthGuard, extract_hyperparams, build_multimodal_content
 
 logger = logging.getLogger(__name__)
@@ -23,7 +24,7 @@ def build_writer_content(
     attachments: Sequence[Mapping[str, Any]] | None,
     length_guard_enforce: bool,
     length_guard: LengthGuard | None,
-) -> "str | list":
+) -> "str | list[ContentPart]":
     """Build the writer's user-message content (string or multimodal list).
 
     Extracted so the orchestrator can pass the exact value to the editor,
@@ -47,7 +48,7 @@ def build_writer_content(
 
 async def _writer_pass(
     client: LLMClient,
-    prefix: list[dict],
+    prefix: list[ChatMessage],
     settings: Mapping[str, Any],
     enabled_tools: Mapping[str, bool],
     *,
@@ -72,7 +73,7 @@ async def _writer_pass(
         length_guard,
     )
 
-    msgs = prefix + [{"role": "user", "content": content}]
+    msgs: list[ChatMessage] = [*prefix, {"role": "user", "content": content}]
 
     hyperparams = extract_hyperparams(settings)
     schemas = enabled_schemas(enabled_tools, schema_overrides)

--- a/backend/passes/writer.py
+++ b/backend/passes/writer.py
@@ -10,7 +10,7 @@ from typing import Any, AsyncIterator, Mapping, Optional, Sequence
 
 from ..llm_client import LLMClient, reasoning_cfg
 from ..tool_defs import enabled_schemas
-from ..utils import extract_hyperparams, build_multimodal_content
+from ..utils import LengthGuard, extract_hyperparams, build_multimodal_content
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ def build_writer_content(
     effective_msg: str,
     attachments: Sequence[Mapping[str, Any]] | None,
     length_guard_enforce: bool,
-    length_guard: dict | None,
+    length_guard: LengthGuard | None,
 ) -> "str | list":
     """Build the writer's user-message content (string or multimodal list).
 
@@ -36,9 +36,9 @@ def build_writer_content(
         tail += "___\n\n" + inj_block + "\n\n"
     if enabled_tools:
         tail += "**Do not use tool or function calls this turn.**\n\n"
-    if length_guard_enforce and length_guard and length_guard.get("enabled"):
-        max_words = length_guard.get("max_words", 240)
-        max_paragraphs = length_guard.get("max_paragraphs", 4)
+    if length_guard_enforce and length_guard and length_guard["enabled"]:
+        max_words = length_guard["max_words"]
+        max_paragraphs = length_guard["max_paragraphs"]
         tail += f"**Keep your response under {max_words} words and {max_paragraphs} paragraphs.**\n\n"
     tail += "___\n\n" + effective_msg + "\n\n"
 
@@ -56,7 +56,7 @@ async def _writer_pass(
     effective_msg: str,
     attachments: Optional[Sequence[Mapping[str, Any]]] = None,
     length_guard_enforce: bool = False,
-    length_guard: dict | None = None,
+    length_guard: LengthGuard | None = None,
     kv_tracker=None,
     reasoning_on: bool = True,
     schema_overrides: dict | None = None,

--- a/backend/passes/writer.py
+++ b/backend/passes/writer.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import AsyncIterator, List, Optional
+from typing import Any, AsyncIterator, List, Mapping, Optional
 
 from ..llm_client import LLMClient, reasoning_cfg
 from ..tool_defs import enabled_schemas
@@ -48,7 +48,7 @@ def build_writer_content(
 async def _writer_pass(
     client: LLMClient,
     prefix: list[dict],
-    settings: dict,
+    settings: Mapping[str, Any],
     enabled_tools: dict,
     *,
     inj_block: str = "",

--- a/backend/passes/writer.py
+++ b/backend/passes/writer.py
@@ -9,6 +9,7 @@ import logging
 from typing import Any, AsyncIterator, Mapping, Optional, Sequence
 
 from ..llm_client import LLMClient, reasoning_cfg
+from ..kv_tracker import cached_complete
 from ..tool_defs import enabled_schemas
 from ..llm_types import ChatMessage, ContentPart
 from ..utils import LengthGuard, extract_hyperparams, build_multimodal_content
@@ -81,15 +82,18 @@ async def _writer_pass(
         "Writer pass: tools included=%s",
         json.dumps([s["function"]["name"] for s in schemas]) if schemas else "[]",
     )
-    extra: dict = {"tools": schemas, "tool_choice": "none"} if schemas else {}
-    extra.update(reasoning_cfg(reasoning_on))
 
-    if kv_tracker is not None:
-        kv_tracker.record("writer", msgs, schemas if schemas else None, model=settings["model_name"])
-
-    async for item in client.complete(messages=msgs, model=settings["model_name"], **extra, **hyperparams):
+    async for item in cached_complete(
+        client,
+        label="writer",
+        messages=msgs,
+        model=settings["model_name"],
+        tools=schemas or None,
+        tool_choice="none" if schemas else None,
+        kv_tracker=kv_tracker,
+        **reasoning_cfg(reasoning_on),
+        **hyperparams,
+    ):
         if item["type"] == "done":
-            if kv_tracker is not None:
-                kv_tracker.record_usage("writer", item.get("usage"))
             return
         yield item

--- a/backend/prompt_builder.py
+++ b/backend/prompt_builder.py
@@ -5,6 +5,8 @@ and tool-call prompts for the orchestrator pipeline.
 
 from __future__ import annotations
 
+from typing import Any, Mapping, Sequence
+
 from .macros import Macros
 from .tool_defs import (
     TOOLS,
@@ -20,7 +22,7 @@ from .tool_defs import (
 LOREBOOK_SCAN_DEPTH = 6
 
 
-def format_message_with_attachments(message: dict, macros: Macros | None) -> dict:
+def format_message_with_attachments(message: Mapping[str, Any], macros: Macros | None) -> dict:
     """Convert a message dict with optional attachments to OpenAI vision format.
 
     Two attachment lists travel on the message dict:
@@ -73,7 +75,7 @@ def build_prefix(
     char_scenario: str,
     mes_example: str = "",
     post_history_instructions: str = "",
-    messages: list[dict] | None = None,
+    messages: Sequence[Mapping[str, Any]] | None = None,
     macros: Macros | None = None,
     user_description: str = "",
     *,
@@ -127,9 +129,9 @@ def build_director_tool_prompt(
     tool_name: str,
     user_message: str,
     active_moods: list[str],
-    mood_fragments: list[dict],
+    mood_fragments: Sequence[Mapping[str, Any]],
     reasoning_on: bool = False,
-    director_fragments: list[dict] | None = None,
+    director_fragments: Sequence[Mapping[str, Any]] | None = None,
     progressive_state: dict | None = None,
     tool_schema: dict | None = None,
 ) -> str:
@@ -197,8 +199,8 @@ def build_editor_prompt(
 def compute_style_injection_block(
     active_moods: list[str],
     prior_moods: list[str],
-    mood_fragments: list[dict],
-    director_fragments: list[dict],
+    mood_fragments: Sequence[Mapping[str, Any]],
+    director_fragments: Sequence[Mapping[str, Any]],
     direct_scene_enabled: bool,
     extra_fields: dict | None = None,
     prior_progressive_state: dict | None = None,
@@ -234,9 +236,9 @@ def compute_style_injection_block(
 
 
 def build_style_injection(
-    active: list[dict],
-    deactivated: list[dict] | None = None,
-    director_fragments: list[dict] | None = None,
+    active: Sequence[Mapping[str, Any]],
+    deactivated: Sequence[Mapping[str, Any]] | None = None,
+    director_fragments: Sequence[Mapping[str, Any]] | None = None,
     extra_fields: dict | None = None,
     prior_progressive_state: dict | None = None,
 ) -> str:
@@ -274,8 +276,8 @@ def build_style_injection(
 
 
 def compute_lorebook_injection_block(
-    messages: list[dict],
-    entries: list[dict],
+    messages: Sequence[Mapping[str, Any]],
+    entries: Sequence[Mapping[str, Any]],
     macros: Macros | None = None,
 ) -> str:
     """Compute the lorebook injection block from active entries.

--- a/backend/prompt_builder.py
+++ b/backend/prompt_builder.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any, Mapping, Sequence
 
 from .macros import Macros
+from .llm_types import ChatMessage, ContentPart
 from .tool_defs import (
     TOOLS,
     DIRECTOR_PREAMBLE,
@@ -22,7 +23,7 @@ from .tool_defs import (
 LOREBOOK_SCAN_DEPTH = 6
 
 
-def format_message_with_attachments(message: Mapping[str, Any], macros: Macros | None) -> dict:
+def format_message_with_attachments(message: Mapping[str, Any], macros: Macros | None) -> ChatMessage:
     """Convert a message dict with optional attachments to OpenAI vision format.
 
     Two attachment lists travel on the message dict:
@@ -55,7 +56,7 @@ def format_message_with_attachments(message: Mapping[str, Any], macros: Macros |
     if not user_atts:
         return {"role": role, "content": combined_text}
 
-    parts: list[dict] = []
+    parts: list[ContentPart] = []
     if combined_text:
         parts.append({"type": "text", "text": combined_text})
     for att in user_atts:
@@ -80,7 +81,7 @@ def build_prefix(
     user_description: str = "",
     *,
     extra_system_blocks: list[str] | None = None,
-) -> list[dict]:
+) -> list[ChatMessage]:
     resolve = macros.resolve_message if macros else (lambda t: t)
     resolved = {
         key: resolve(val)
@@ -119,7 +120,8 @@ def build_prefix(
 
     processed_messages = [format_message_with_attachments(m, macros) for m in (messages or [])]
 
-    return [{"role": "system", "content": "".join(parts)}] + processed_messages
+    system_message: ChatMessage = {"role": "system", "content": "".join(parts)}
+    return [system_message] + processed_messages
 
 
 # ── Tool-call prompt

--- a/backend/summarizer.py
+++ b/backend/summarizer.py
@@ -4,6 +4,7 @@ from typing import Any, AsyncGenerator, Mapping, Sequence
 
 from .llm_client import LLMClient
 from .macros import Macros
+from .llm_types import ChatMessage
 from . import prompt_builder
 
 DEFAULT_SUMMARY_INSTRUCTIONS = (
@@ -39,7 +40,7 @@ class ConversationSummarizer:
         macros: Macros,
         user_description: str,
         custom_instructions: str | None = None,
-    ) -> list[dict]:
+    ) -> list[ChatMessage]:
         prefix = prompt_builder.build_prefix(
             system_prompt,
             char_persona,
@@ -55,7 +56,7 @@ class ConversationSummarizer:
             instructions += f"\n{custom_instructions}"
         return prefix + [{"role": "user", "content": instructions}]
 
-    async def stream(self, llm_messages: list[dict], model: str) -> AsyncGenerator[str, None]:
+    async def stream(self, llm_messages: Sequence[Mapping[str, Any]], model: str) -> AsyncGenerator[str, None]:
         params = {k: v for k in _LLM_PARAMS if (v := self.settings.get(k)) is not None}
         async for chunk in self.client.complete(llm_messages, model, **params):
             if chunk["type"] == "content":

--- a/backend/summarizer.py
+++ b/backend/summarizer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator, Mapping, Sequence
 
 from .llm_client import LLMClient
 from .macros import Macros
@@ -24,7 +24,7 @@ _LLM_PARAMS = (
 
 
 class ConversationSummarizer:
-    def __init__(self, client: LLMClient, settings: dict):
+    def __init__(self, client: LLMClient, settings: Mapping[str, Any]):
         self.client = client
         self.settings = settings
 
@@ -35,7 +35,7 @@ class ConversationSummarizer:
         char_scenario: str,
         mes_example: str,
         post_history_instructions: str,
-        history_slice: list[dict],
+        history_slice: Sequence[Mapping[str, Any]],
         macros: Macros,
         user_description: str,
         custom_instructions: str | None = None,

--- a/backend/tool_defs.py
+++ b/backend/tool_defs.py
@@ -4,6 +4,8 @@ tool_defs.py — Tool schemas, constants, and helper lookups for the orchestrato
 
 from __future__ import annotations
 
+from typing import Any, Mapping, Sequence
+
 
 # ── Agent tool definitions (OpenAI function-calling format)
 
@@ -25,7 +27,7 @@ _DIRECT_SCENE_DESCRIPTION = (
 )
 
 
-def build_direct_scene_tool(director_fragments: list[dict]) -> dict:
+def build_direct_scene_tool(director_fragments: Sequence[Mapping[str, Any]]) -> dict:
     """Build the direct_scene tool schema from enabled director fragments.
 
     Director fragments provide dynamic string/array parameters beyond the fixed

--- a/backend/tool_defs.py
+++ b/backend/tool_defs.py
@@ -257,7 +257,7 @@ def register_tool(name: str, schema: dict, choice: dict, *, standalone: bool = F
 
 def enabled_schemas(
     enabled_tools: Mapping[str, bool] | None,
-    overrides: dict[str, dict] | None = None,
+    overrides: Mapping[str, dict] | None = None,
 ) -> list[dict]:
     """Return tool schemas for enabled, non-standalone tools, in TOOLS registry order.
 

--- a/backend/tool_defs.py
+++ b/backend/tool_defs.py
@@ -256,7 +256,7 @@ def register_tool(name: str, schema: dict, choice: dict, *, standalone: bool = F
 
 
 def enabled_schemas(
-    enabled_tools: dict | None,
+    enabled_tools: Mapping[str, bool] | None,
     overrides: dict[str, dict] | None = None,
 ) -> list[dict]:
     """Return tool schemas for enabled, non-standalone tools, in TOOLS registry order.

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -4,7 +4,7 @@ utils.py — Shared helpers.
 
 from __future__ import annotations
 
-from typing import Any, List, Mapping, Optional
+from typing import Any, Mapping, Optional, Sequence
 
 
 def extract_hyperparams(settings: Mapping[str, Any], *, defaults: Mapping[str, Any] | None = None) -> dict:
@@ -28,7 +28,7 @@ def extract_hyperparams(settings: Mapping[str, Any], *, defaults: Mapping[str, A
     return params
 
 
-def build_multimodal_content(text: str, attachments: Optional[List[dict]] = None) -> str | list:
+def build_multimodal_content(text: str, attachments: Optional[Sequence[Mapping[str, Any]]] = None) -> str | list:
     """Wrap *text* (and optional image attachments) into a multimodal content list.
 
     Returns a plain string when there are no attachments, or a list of content

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, Sequence, TypedDict
 
+from .llm_types import ContentPart
+
 
 class LengthGuard(TypedDict):
     """Resolved length-guard limits threaded through the pipeline.
@@ -41,7 +43,7 @@ def extract_hyperparams(settings: Mapping[str, Any], *, defaults: Mapping[str, A
     return params
 
 
-def build_multimodal_content(text: str, attachments: Optional[Sequence[Mapping[str, Any]]] = None) -> str | list:
+def build_multimodal_content(text: str, attachments: Optional[Sequence[Mapping[str, Any]]] = None) -> str | list[ContentPart]:
     """Wrap *text* (and optional image attachments) into a multimodal content list.
 
     Returns a plain string when there are no attachments, or a list of content
@@ -49,7 +51,7 @@ def build_multimodal_content(text: str, attachments: Optional[Sequence[Mapping[s
     """
     if not attachments:
         return text
-    parts: list = [{"type": "text", "text": text}]
+    parts: list[ContentPart] = [{"type": "text", "text": text}]
     for att in attachments:
         mime = att.get("mime_type", att.get("mime", "image/jpeg"))
         b64 = att.get("data_b64", att.get("b64", ""))

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -4,7 +4,20 @@ utils.py — Shared helpers.
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence, TypedDict
+
+
+class LengthGuard(TypedDict):
+    """Resolved length-guard limits threaded through the pipeline.
+
+    Built by the orchestrator only when the length guard is enabled (``None``
+    otherwise) and consumed by the writer and editor passes. ``enabled`` mirrors
+    that on/off state so a hook receiving the dict need not re-derive it.
+    """
+
+    enabled: bool
+    max_words: int
+    max_paragraphs: int
 
 
 def extract_hyperparams(settings: Mapping[str, Any], *, defaults: Mapping[str, Any] | None = None) -> dict:

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -4,10 +4,10 @@ utils.py — Shared helpers.
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, List, Mapping, Optional
 
 
-def extract_hyperparams(settings: dict, *, defaults: dict | None = None) -> dict:
+def extract_hyperparams(settings: Mapping[str, Any], *, defaults: Mapping[str, Any] | None = None) -> dict:
     """Extract LLM hyperparameters from a settings dict.
 
     Optionally fills in *defaults* for any keys not present in settings.

--- a/backend/workflows/contracts.py
+++ b/backend/workflows/contracts.py
@@ -71,13 +71,16 @@ class PreCtx:
     """Inputs available to a workflow's pre-pipeline hook.
 
     Wrapped fields (``history``, ``settings``, ``prefix``,
-    ``enabled_tools_pre_merge``, ``schema_overrides``) are recursively
-    read-only at the point the orchestrator constructs this Ctx; mutation
-    attempts at any nesting depth raise immediately. ``turn_scratch``,
-    ``client``, and ``kv_tracker`` are intentionally not wrapped -- they
-    are the documented mutation channel, the per-turn LLM client, and the
-    per-turn cache aggregator respectively, ref-shared across every PreCtx
-    and PostCtx in the same turn.
+    ``enabled_tools_pre_merge``) are recursively read-only at the point the
+    orchestrator constructs this Ctx; mutation attempts at any nesting depth
+    raise immediately. ``schema_overrides`` is a ``MappingProxyType`` frozen
+    once at turn setup -- its top-level mapping cannot gain/lose/swap entries,
+    but its schema *values* stay plain dicts so they remain json-serializable
+    into the tools blob (only the values, never the container, are serialized).
+    ``turn_scratch``, ``client``, and ``kv_tracker`` are intentionally not
+    wrapped -- they are the documented mutation channel, the per-turn LLM
+    client, and the per-turn cache aggregator respectively, ref-shared across
+    every PreCtx and PostCtx in the same turn.
 
     ``prefix`` carries the pipeline prefix *before* extra system blocks
     contributed by pre-pipeline ``system_prompt`` yields have been

--- a/docs/architecture/kv-cache.md
+++ b/docs/architecture/kv-cache.md
@@ -102,6 +102,10 @@ The director picks moods, plot direction, progressive state, etc. None of that m
 
 If the director and editor are configured to run on a different model than the writer, the writer's KV cache lives on a different inference server and can't be shared with the agent passes. In that case, the writer sends no tools at all — including them would just waste tokens with no caching benefit. The agent passes still share a cache with each other on their own server.
 
+### How these invariants are enforced in code
+
+Invariants 1–3 and 5 are not left to each pass to honour by convention. The cached bottom — prefix + tools blob + model — is captured once per turn per server in a frozen `CachedBase` (`backend/kv_tracker.py`), built in `_resolve_pipeline_config`. A single-model turn has one base shared by all three passes; a dual-model turn has two (an agent base for director + editor, and a writer base whose tools blob is empty — that *is* Invariant 5). Passes never call `enabled_schemas` or assemble the prefix themselves; they call `base.complete(trailing=…, tool_choice=…)`, which extends the frozen bottom with only the per-pass top. Because the cache-relevant bytes are computed in exactly one place and the base is immutable, a pass cannot reconstruct them differently and so cannot silently diverge. `base.complete` routes through `cached_complete`, so the KV tracker always records the exact bytes that were sent (see §8).
+
 ---
 
 ## 5. Walk-through: one full turn

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,6 @@
+{
+  "include": ["backend"],
+  "typeCheckingMode": "standard",
+  "pythonVersion": "3.12",
+  "reportMissingImports": "warning"
+}

--- a/tests/integration/_llm_mock.py
+++ b/tests/integration/_llm_mock.py
@@ -20,6 +20,8 @@ import asyncio
 import copy
 from typing import Any, AsyncIterator
 
+from backend.llm_client import AbortToken
+
 
 _EDITOR_FUNCTION_NAMES = {"editor_apply_patch", "editor_rewrite"}
 _DIRECTOR_FUNCTION_NAMES = {"direct_scene", "rewrite_user_prompt"}
@@ -114,7 +116,9 @@ class FakeLLMClient:
     def __init__(self) -> None:
         self._queues: dict[str, list[dict]] = {"director": [], "writer": [], "editor": [], "workflow": []}
         self._gates: dict[str, list[PassGate]] = {"director": [], "writer": [], "editor": [], "workflow": []}
-        self._abort = asyncio.Event()
+        # Mirror LLMClient: a wrapping _PlaceholderClient shares this token, so
+        # an abort signalled on either is visible to both.
+        self.abort_token = AbortToken()
         # Public assertion surface: tests inspect ``calls`` directly for
         # dispatch order and invocation counts, so its shape is part of
         # the mock's contract -- do not rename or restructure.
@@ -168,11 +172,11 @@ class FakeLLMClient:
         """Mirror ``LLMClient.abort()``: makes in-flight ``complete()``
         calls exit at their next gate or yield boundary.
         """
-        self._abort.set()
+        self.abort_token.abort()
 
     @property
     def is_aborted(self) -> bool:
-        return self._abort.is_set()
+        return self.abort_token.is_aborted
 
     async def complete(
         self,
@@ -200,7 +204,7 @@ class FakeLLMClient:
             gate.reached.set()
             await gate.release.wait()
 
-        if self._abort.is_set():
+        if self.abort_token.is_aborted:
             return
 
         if pass_name == "writer":

--- a/tests/integration/workflows/test_reset_cache_bookkeeping.py
+++ b/tests/integration/workflows/test_reset_cache_bookkeeping.py
@@ -65,9 +65,7 @@ async def test_reset_preserves_access_counter_and_budget(client, db):
         await record_access([att_id])
 
     before = list(
-        await db.execute_fetchall(
-            "SELECT attachment_cache_budget_bytes, attachment_access_counter FROM settings WHERE id = 1"
-        )
+        await db.execute_fetchall("SELECT attachment_cache_budget_bytes, attachment_access_counter FROM settings WHERE id = 1")
     )[0]
     assert before["attachment_cache_budget_bytes"] == 12345
     assert before["attachment_access_counter"] == 5
@@ -75,9 +73,7 @@ async def test_reset_preserves_access_counter_and_budget(client, db):
     await reset_to_defaults()
 
     after = list(
-        await db.execute_fetchall(
-            "SELECT attachment_cache_budget_bytes, attachment_access_counter FROM settings WHERE id = 1"
-        )
+        await db.execute_fetchall("SELECT attachment_cache_budget_bytes, attachment_access_counter FROM settings WHERE id = 1")
     )[0]
     assert after["attachment_cache_budget_bytes"] == 12345
     assert after["attachment_access_counter"] == 5
@@ -95,9 +91,7 @@ async def test_reset_keeps_counter_above_retained_recent_accesses(client, db):
     counter = list(await db.execute_fetchall("SELECT attachment_access_counter FROM settings WHERE id = 1"))[0][
         "attachment_access_counter"
     ]
-    ra_row = list(
-        await db.execute_fetchall("SELECT recent_accesses FROM workflow_attachments WHERE id = ?", (att_id,))
-    )[0]
+    ra_row = list(await db.execute_fetchall("SELECT recent_accesses FROM workflow_attachments WHERE id = ?", (att_id,)))[0]
     assert ra_row["recent_accesses"] is not None
     retained_max = max(json.loads(ra_row["recent_accesses"]))
     assert counter >= retained_max

--- a/tests/unit/test_abort_pipeline.py
+++ b/tests/unit/test_abort_pipeline.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 from backend.kv_tracker import _KVCacheTracker
 from backend.llm_client import LLMClient
 from backend.orchestrator import _run_pipeline
+from backend.passes.director import DirectorResult
 
 
 _DIRECTOR_STATE = {"active_moods": []}
@@ -48,7 +49,7 @@ class TestAbortPropagation:
 
         async def mock_director(c, *args, **kwargs):
             c.abort()
-            yield {"type": "done", "result": ([], "", [], 0, None, {})}
+            yield {"type": "done", "result": DirectorResult()}
 
         async def mock_writer(*args, **kwargs):
             writer_calls[0] += 1

--- a/tests/unit/test_editor_abort.py
+++ b/tests/unit/test_editor_abort.py
@@ -11,9 +11,11 @@ from unittest.mock import patch
 
 import pytest
 
+from backend.kv_tracker import CachedBase
 from backend.llm_client import LLMClient
 from backend.passes.editor.audit import AuditReport
 from backend.passes.editor.editor import editor_pass
+from backend.tool_defs import enabled_schemas
 from backend.passes.editor.opening_monotony import MonotonyResult
 from backend.passes.editor.slop_detector import (
     DetectionResult,
@@ -122,18 +124,22 @@ async def test_editor_iteration_exception_propagates():
         "backend.passes.editor.editor._run_contextual_audit",
         new=fake_run_contextual_audit,
     ):
+        base = CachedBase(
+            prefix=({"role": "system", "content": "sys"},),
+            tools=tuple(enabled_schemas({"editor_apply_patch": True}, {})),
+            model="test-model",
+        )
         events = []
         with pytest.raises(RuntimeError, match="LLM API exploded"):
             async for event in editor_pass(
                 client,
-                prefix=[{"role": "system", "content": "sys"}],
+                base,
                 effective_msg="user msg",
                 draft="Sentence 0. Sentence 1.",
                 settings=settings,
                 phrase_bank=[[]],
                 audit_enabled=True,
                 length_guard=None,
-                enabled_tools={"editor_apply_patch": True},
             ):
                 events.append(event)
 

--- a/tests/unit/test_kv_cache_invariants.py
+++ b/tests/unit/test_kv_cache_invariants.py
@@ -43,6 +43,7 @@ from typing import Any
 
 import pytest
 
+from backend.llm_client import AbortToken
 from backend.kv_tracker import (
     CachedBase,
     _KVCacheTracker,
@@ -113,7 +114,8 @@ class CapturingClient:
     def __init__(self, model: str) -> None:
         self.model = model
         self.calls: list[dict] = []
-        self._abort = False
+        # Shared with a wrapping _PlaceholderClient, mirroring LLMClient.
+        self.abort_token = AbortToken()
         # FIFO of editor tool-call messages to return, one per ReAct iteration.
         # Empty → the editor returns no tool call and the loop stops.
         self._editor_queue: list[dict] = []
@@ -161,10 +163,10 @@ class CapturingClient:
 
     @property
     def is_aborted(self) -> bool:
-        return self._abort
+        return self.abort_token.is_aborted
 
     def abort(self) -> None:
-        self._abort = True
+        self.abort_token.abort()
 
     def _label(self, tool_choice: Any) -> str:
         if tool_choice in (None, "none"):

--- a/tests/unit/test_kv_cache_invariants.py
+++ b/tests/unit/test_kv_cache_invariants.py
@@ -44,6 +44,7 @@ from typing import Any
 import pytest
 
 from backend.kv_tracker import (
+    CachedBase,
     _KVCacheTracker,
     _common_prefix_len,
     _serialize_messages,
@@ -530,21 +531,24 @@ async def test_editor_react_iterations_preserve_cached_bottom(reasoning_on):
         client.enqueue_editor_patch(f"{lead} shiver ran down her spine.", f"{lead} hall stayed silent.")
 
     settings = {"model_name": "editor-model", "editor_audit_toggles": None}
+    base = CachedBase(
+        prefix=tuple(prefix),
+        tools=tuple(enabled_schemas({"editor_apply_patch": True}, {})),
+        model="editor-model",
+    )
     async for _ in editor_pass(
         client,
-        prefix,
+        base,
         "I strike the anvil.",
         draft,
         settings,
         phrase_bank,
-        {"editor_apply_patch": True},
         audit_enabled=True,
         length_guard=None,
         kv_tracker=None,
         reasoning_on=reasoning_on,
         audit_context_msgs=[],
         writer_user_msg=writer_user,
-        schema_overrides={},
     ):
         pass
 
@@ -617,22 +621,25 @@ async def test_editor_tools_blob_constant_across_tool_switch():
 
     settings = {"model_name": "editor-model", "editor_audit_toggles": None}
     length_guard = {"enabled": True, "max_words": 5, "max_paragraphs": 1}
+    # 3-tool enabled set so a narrow-to-one would be visible as a byte change.
+    base = CachedBase(
+        prefix=tuple(prefix),
+        tools=tuple(enabled_schemas({"direct_scene": True, "editor_apply_patch": True, "editor_rewrite": True}, {})),
+        model="editor-model",
+    )
     async for _ in editor_pass(
         client,
-        prefix,
+        base,
         writer_user,
         draft,
         settings,
         phrase_bank,
-        # 3-tool enabled set so a narrow-to-one would be visible as a byte change.
-        {"direct_scene": True, "editor_apply_patch": True, "editor_rewrite": True},
         audit_enabled=True,
         length_guard=length_guard,
         kv_tracker=None,
         reasoning_on=False,
         audit_context_msgs=[],
         writer_user_msg=writer_user,
-        schema_overrides={},
     ):
         pass
 

--- a/tests/unit/test_kv_cache_invariants.py
+++ b/tests/unit/test_kv_cache_invariants.py
@@ -51,7 +51,7 @@ from backend.kv_tracker import (
 )
 from backend.orchestrator import _run_pipeline
 from backend.passes.editor.editor import editor_pass
-from backend.tool_defs import build_direct_scene_tool
+from backend.tool_defs import build_direct_scene_tool, enabled_schemas
 
 
 def _wire_tools(tools: Any) -> str:
@@ -131,6 +131,27 @@ class CapturingClient:
                         "function": {
                             "name": "editor_apply_patch",
                             "arguments": json.dumps({"patches": [{"search": search, "replace": replace}]}),
+                        },
+                    }
+                ],
+            }
+        )
+
+    def enqueue_editor_rewrite(self, text: str) -> None:
+        """Queue an ``editor_rewrite`` call returning *text* as the new draft.
+        Used to drive the rewrite branch of the ReAct loop (length guard /
+        structural rewrite), which is where the tool list used to be narrowed."""
+        self._editor_queue.append(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": f"r{len(self._editor_queue)}",
+                        "type": "function",
+                        "function": {
+                            "name": "editor_rewrite",
+                            "arguments": json.dumps({"rewritten_text": text}),
                         },
                     }
                 ],
@@ -541,6 +562,16 @@ async def test_editor_react_iterations_preserve_cached_bottom(reasoning_on):
             "prefix is re-billed on every editor round."
         )
 
+    # Inv-3 across iterations — the tools blob must stay byte-identical every
+    # round. The schema list lives in the cached prefix; narrowing it mid-loop
+    # would re-bill the tools region each iteration. (This particular path never
+    # narrows, but the assertion documents the invariant cheaply; the rewrite
+    # path is covered by test_editor_tools_blob_constant_across_tool_switch.)
+    iter_blobs = {c["tools_wire"] for c in editor_calls}
+    assert len(iter_blobs) == 1, "CACHE BUST: editor tools blob changed between iterations. " + json.dumps(
+        sorted(len(b) for b in iter_blobs)
+    )
+
     if reasoning_on:
         # Append-only: every iteration extends the previous prompt verbatim, so
         # even the writer's draft pancake stays cached (the doc §7 ideal).
@@ -556,3 +587,65 @@ async def test_editor_react_iterations_preserve_cached_bottom(reasoning_on):
             "flat-mode editor changed its message count between iterations — it must "
             "rewrite the top two pancakes in place, not grow or rebuild the list."
         )
+
+
+async def test_editor_tools_blob_constant_across_tool_switch():
+    """Inv-3 regression: when the ReAct loop switches which tool it forces
+    (rewrite on one iteration, patch on the next), the tools *blob* must NOT
+    change — only ``tool_choice`` may. The loop used to narrow ``editor_tools``
+    to a single-tool list when changing tools mid-flight, shrinking the schema
+    blob (e.g. 3 tools → 1) and re-billing the tools region every iteration.
+
+    This drives that exact path: a 3-tool enabled set, a length-guard-forced
+    rewrite on iteration 1 whose result still carries a banned phrase, so the
+    loop continues to iteration 2 now forcing ``editor_apply_patch``. Before the
+    fix the two iterations shipped different-sized blobs; this asserts they don't.
+    """
+    prefix = _make_prefix("You are the editor's bench.", n_pairs=2)
+    writer_user = "I strike the anvil."
+    banned = "shiver ran down her spine"
+    # Long enough to trip the (tiny) length guard, and banned-phrase-laden so the
+    # initial audit has issues too.
+    draft = " ".join([f"The {banned}."] * 6)
+    phrase_bank = [[banned]]
+
+    client = CapturingClient("editor-model")
+    # Iteration 1 is force-rewrite (length guard). Return a rewrite that clears
+    # the word limit but still repeats the banned phrase, so audit issues remain
+    # and the loop advances to a patch-forced iteration 2 (queue then empty → stop).
+    client.enqueue_editor_rewrite(" ".join([f"A {banned}."] * 4))
+
+    settings = {"model_name": "editor-model", "editor_audit_toggles": None}
+    length_guard = {"enabled": True, "max_words": 5, "max_paragraphs": 1}
+    async for _ in editor_pass(
+        client,
+        prefix,
+        writer_user,
+        draft,
+        settings,
+        phrase_bank,
+        # 3-tool enabled set so a narrow-to-one would be visible as a byte change.
+        {"direct_scene": True, "editor_apply_patch": True, "editor_rewrite": True},
+        audit_enabled=True,
+        length_guard=length_guard,
+        kv_tracker=None,
+        reasoning_on=False,
+        audit_context_msgs=[],
+        writer_user_msg=writer_user,
+        schema_overrides={},
+    ):
+        pass
+
+    editor_calls = [c for c in client.calls if c["label"] == "editor"]
+    assert len(editor_calls) >= 2, f"expected ≥2 editor iterations (rewrite then patch), got {len(editor_calls)}"
+
+    # The forced tool changed across iterations — but the blob must be constant.
+    blobs = {c["tools_wire"] for c in editor_calls}
+    assert len(blobs) == 1, (
+        "CACHE BUST: the editor narrowed its tools blob when switching the forced "
+        "tool mid-loop. Tool selection must go through tool_choice alone; the "
+        "schema list must stay byte-identical. Distinct blob sizes: " + json.dumps(sorted(len(b) for b in blobs))
+    )
+    # And it must genuinely be the full 3-tool set, not a coincidental match.
+    full_blob = _wire_tools(enabled_schemas({"direct_scene": True, "editor_apply_patch": True, "editor_rewrite": True}, {}))
+    assert next(iter(blobs)) == full_blob, "editor shipped a tools blob that is not the full enabled set"

--- a/tests/unit/test_super_regen_audit_context.py
+++ b/tests/unit/test_super_regen_audit_context.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
+from backend.kv_tracker import CachedBase
 from backend.passes.editor.audit import AuditReport
 from backend.passes.editor.editor import editor_pass
 from backend.passes.editor.opening_monotony import MonotonyResult
@@ -21,6 +22,18 @@ from backend.passes.editor.slop_detector import DetectionResult
 from backend.passes.editor.structural_repetition import StructuralResult
 from backend.passes.editor.template_repetition import TemplateResult
 from backend.llm_client import LLMClient
+from backend.tool_defs import enabled_schemas
+
+
+def _editor_base(prefix: list[dict]) -> CachedBase:
+    """Build a CachedBase wrapping *prefix* with the patch tool enabled, as the
+    super-regen path does. These tests only exercise audit-context derivation
+    (which reads base.prefix), so the tool blob just needs to be non-empty."""
+    return CachedBase(
+        prefix=tuple(prefix),
+        tools=tuple(enabled_schemas({"editor_apply_patch": True}, {})),
+        model="test-model",
+    )
 
 
 def _clean_report() -> AuditReport:
@@ -71,14 +84,13 @@ async def test_audit_context_msgs_overrides_prefix():
         events = []
         async for event in editor_pass(
             client,
-            prefix=prefix,
+            _editor_base(prefix),
             effective_msg="user msg",
             draft="Some new draft text.",
             settings={"model_name": "test-model"},
             phrase_bank=[],
             audit_enabled=True,
             length_guard=None,
-            enabled_tools={"editor_apply_patch": True},
             audit_context_msgs=[],  # explicitly empty — no prior context
         ):
             events.append(event)
@@ -114,15 +126,14 @@ async def test_no_audit_context_msgs_falls_back_to_prefix():
     ):
         async for _ in editor_pass(
             client,
-            prefix=prefix,
+            _editor_base(prefix),
             effective_msg="user msg",
             draft="Some draft.",
             settings={"model_name": "test-model"},
             phrase_bank=[],
             audit_enabled=True,
             length_guard=None,
-            enabled_tools={"editor_apply_patch": True},
-            # audit_context_msgs omitted → derive from prefix
+            # audit_context_msgs omitted → derive from base.prefix
         ):
             pass
 
@@ -168,14 +179,13 @@ async def test_super_regen_prior_history_still_scanned():
     ):
         async for _ in editor_pass(
             client,
-            prefix=prefix,
+            _editor_base(prefix),
             effective_msg="[OOC: rewrite]",
             draft="Some new draft.",
             settings={"model_name": "test-model"},
             phrase_bank=[],
             audit_enabled=True,
             length_guard=None,
-            enabled_tools={"editor_apply_patch": True},
             audit_context_msgs=audit_context_msgs,
         ):
             pass
@@ -216,14 +226,13 @@ async def test_super_regen_does_not_flag_replaced_message():
         events = []
         async for event in editor_pass(
             client,
-            prefix=prefix,
+            _editor_base(prefix),
             effective_msg="[OOC: rewrite]",
             draft=new_draft,
             settings={"model_name": "test-model"},
             phrase_bank=[],
             audit_enabled=True,
             length_guard=None,
-            enabled_tools={"editor_apply_patch": True},
             audit_context_msgs=[],  # super-regen passes history-only context
         ):
             events.append(event)


### PR DESCRIPTION
Need to enforce data types to our best effort. The project is half vibecoded so this is needed for early warnings and for better understanding on grep (basically `active_persona: Optional[UserPersonaRow]` is better than `active_persona: Optional[dict]`), and for more immutability thus robustness.

Plan:
- Make shared datatype classes, coupled with database (sorta like Models in MVC)
- Existing dicts to use typed classes to best effort
- Bump pyright config from Basic (default) to Standard to catch weak, non-typed dicts