### PR TITLE
Stricter phrase repetition detection

### DIFF
--- a/backend/analysis/audit.py
+++ b/backend/analysis/audit.py
@@ -19,6 +19,7 @@ from .detectors.structural_repetition import (
     detect_structural_repetition,
 )
 from .detectors.template_repetition import TemplateResult, detect_template_repetition
+from .text.lexical import is_contiguous_subsequence
 
 # Audit toggles
 #
@@ -45,6 +46,30 @@ def _on(toggles: dict | None, key: str) -> bool:
     """Whether scanner *key* is enabled. Missing key / None toggles → enabled,
     so callers (and older databases) default to the prior all-on behaviour."""
     return True if toggles is None else bool(toggles.get(key, True))
+
+
+def _merge_phrase_results(short: PhraseResult, long: PhraseResult) -> PhraseResult:
+    """Combine the short-phrase (high-threshold) and long-phrase (low-threshold)
+    phrase-repetition passes into a single result.
+
+    A short phrase is dropped when it is a contiguous sub-phrase of a long phrase
+    covering the exact same messages. This mirrors the detector's own sub-gram
+    suppression across the two passes, so a longer phrase repeating often doesn't
+    also surface its 2-word fragment (e.g. "shadowed red" alongside
+    "shadowed red eyes")."""
+    long_signatures = [(tuple(p.phrase.split()), frozenset(p.message_indices)) for p in long.flagged_phrases]
+    merged = list(long.flagged_phrases)
+    for sp in short.flagged_phrases:
+        s_tokens = tuple(sp.phrase.split())
+        s_messages = frozenset(sp.message_indices)
+        if any(
+            s_messages == l_messages and is_contiguous_subsequence(s_tokens, l_tokens)
+            for l_tokens, l_messages in long_signatures
+        ):
+            continue
+        merged.append(sp)
+    merged.sort(key=lambda p: (-p.count, -len(p.phrase.split()), p.phrase))
+    return PhraseResult(flagged_phrases=merged, total_messages=short.total_messages)
 
 
 # Data container
@@ -139,6 +164,8 @@ def run_audit(
     phrase_min_n: int = 2,
     phrase_max_n: int = 5,
     phrase_min_messages: int = 3,
+    phrase_short_max_n: int = 2,
+    phrase_long_min_messages: int = 2,
     phrase_min_content_words: int = 2,
     assistant_messages: list[str] | None = None,
     structural_text: str | None = None,
@@ -181,14 +208,29 @@ def run_audit(
             )
         if _on(audit_toggles, "phrase_repetition"):
             # The draft must be last so require_last_message focuses flags on it.
-            phrase_result = detect_phrase_repetition(
-                assistant_messages + [current_msg],
+            phrase_messages = assistant_messages + [current_msg]
+            # Two universal passes with different thresholds by phrase length:
+            #  - short phrases (up to phrase_short_max_n words) need phrase_min_messages
+            #    repeats, since a 2-word match is easily a coincidence.
+            #  - longer phrases are distinctive enough that phrase_long_min_messages
+            #    (a lower threshold) repeats are damning.
+            short_phrases = detect_phrase_repetition(
+                phrase_messages,
                 min_n=phrase_min_n,
-                max_n=phrase_max_n,
+                max_n=phrase_short_max_n,
                 min_messages=phrase_min_messages,
                 min_content_words=phrase_min_content_words,
                 require_last_message=True,
             )
+            long_phrases = detect_phrase_repetition(
+                phrase_messages,
+                min_n=phrase_short_max_n + 1,
+                max_n=phrase_max_n,
+                min_messages=phrase_long_min_messages,
+                min_content_words=phrase_min_content_words,
+                require_last_message=True,
+            )
+            phrase_result = _merge_phrase_results(short_phrases, long_phrases)
 
     return AuditReport(
         cliche_result=(

--- a/backend/analysis/audit.py
+++ b/backend/analysis/audit.py
@@ -136,7 +136,7 @@ def run_audit(
     template_flag_threshold: int = 2,
     structural_similarity_threshold: float = 0.75,
     structural_min_complexity: int = 2,
-    phrase_min_n: int = 3,
+    phrase_min_n: int = 2,
     phrase_max_n: int = 5,
     phrase_min_messages: int = 3,
     phrase_min_content_words: int = 2,

--- a/backend/analysis/audit.py
+++ b/backend/analysis/audit.py
@@ -305,10 +305,18 @@ def format_report(report: AuditReport) -> str:
     # 5. Exact phrase repetition (echoed across messages)
     if report.phrase_result and report.phrase_result.flagged_phrases:
         lines = ["Repeated Phrases (echoed across messages)"]
+        # Group phrases that cite the same target sentence so it's shown once, not
+        # repeated under every phrase that happens to live in it.
+        groups: dict[str, list] = {}
         for fp in report.phrase_result.flagged_phrases:
-            lines.append(f'   - "{_strip_asterisks(fp.phrase)}" (in {fp.count} previous messages):')
-            if fp.example_sentences:
-                lines.append(f"     • {_strip_asterisks(fp.example_sentences[-1])}")
+            sentence = fp.example_sentences[-1] if fp.example_sentences else ""
+            groups.setdefault(sentence, []).append(fp)
+        for sentence, fps in groups.items():
+            for j, fp in enumerate(fps):
+                suffix = ":" if sentence and j == len(fps) - 1 else ""
+                lines.append(f'   - "{_strip_asterisks(fp.phrase)}" (in {fp.count} previous messages){suffix}')
+            if sentence:
+                lines.append(f"     • {_strip_asterisks(sentence)}")
         sections.append("\n".join(lines))
 
     # 6. Structural repetition

--- a/backend/analysis/audit.py
+++ b/backend/analysis/audit.py
@@ -13,13 +13,16 @@ if TYPE_CHECKING:
 from .detectors.anti_echo import EchoResult, detect_anti_echo
 from .detectors.contrastive_negation import detect_contrastive_negation
 from .detectors.opening_monotony import MonotonyResult, detect_opening_monotony
-from .detectors.phrase_repetition import PhraseResult, detect_phrase_repetition
+from .detectors.phrase_repetition import (
+    PhraseResult,
+    deduplicate_phrases,
+    detect_phrase_repetition,
+)
 from .detectors.structural_repetition import (
     StructuralResult,
     detect_structural_repetition,
 )
 from .detectors.template_repetition import TemplateResult, detect_template_repetition
-from .text.lexical import is_contiguous_subsequence
 
 # Audit toggles
 #
@@ -52,23 +55,12 @@ def _merge_phrase_results(short: PhraseResult, long: PhraseResult) -> PhraseResu
     """Combine the short-phrase (high-threshold) and long-phrase (low-threshold)
     phrase-repetition passes into a single result.
 
-    A short phrase is dropped when it is a contiguous sub-phrase of a long phrase
-    covering the exact same messages. This mirrors the detector's own sub-gram
-    suppression across the two passes, so a longer phrase repeating often doesn't
-    also surface its 2-word fragment (e.g. "shadowed red" alongside
-    "shadowed red eyes")."""
-    long_signatures = [(tuple(p.phrase.split()), frozenset(p.message_indices)) for p in long.flagged_phrases]
-    merged = list(long.flagged_phrases)
-    for sp in short.flagged_phrases:
-        s_tokens = tuple(sp.phrase.split())
-        s_messages = frozenset(sp.message_indices)
-        if any(
-            s_messages == l_messages and is_contiguous_subsequence(s_tokens, l_tokens)
-            for l_tokens, l_messages in long_signatures
-        ):
-            continue
-        merged.append(sp)
-    merged.sort(key=lambda p: (-p.count, -len(p.phrase.split()), p.phrase))
+    deduplicate_phrases drops any phrase that restates the same repeat as another
+    across the two passes — a sub-phrase of a longer one ("shadowed red" under
+    "shadowed red eyes"), a longer phrase that recurs less than its frequent core
+    ("for six centuries" under "six centuries"), or an overlapping fragment
+    ("the tight ring" beside "ring of muscle")."""
+    merged = deduplicate_phrases(long.flagged_phrases + short.flagged_phrases)
     return PhraseResult(flagged_phrases=merged, total_messages=short.total_messages)
 
 

--- a/backend/analysis/detectors/phrase_repetition.py
+++ b/backend/analysis/detectors/phrase_repetition.py
@@ -5,7 +5,7 @@ Catches stock phrases the model keeps reaching for across multiple turns, like
 a description that reappears word-for-word in three different messages.
 
 Public API:
-    detect_phrase_repetition(messages, min_n=3, max_n=5, min_messages=2,
+    detect_phrase_repetition(messages, min_n=2, max_n=5, min_messages=2,
                              min_content_words=2, require_last_message=True)
     PhraseResult, FlaggedPhrase  (dataclasses)
 
@@ -109,7 +109,7 @@ def _suppress_subgrams(
 
 def detect_phrase_repetition(
     messages: list[str],
-    min_n: int = 3,
+    min_n: int = 2,
     max_n: int = 5,
     min_messages: int = 2,
     min_content_words: int = 2,
@@ -125,6 +125,9 @@ def detect_phrase_repetition(
         min_messages: how many distinct messages a phrase must appear in to be flagged.
         min_content_words: minimum content words (non-stopwords) in a phrase.
             Filters out grammatical glue like "in the air" or "I don't know".
+            Load-bearing at min_n=2: a value of 2 forces both tokens of a 2-gram
+            to be content words, so 2-word flags can't degenerate into a
+            single-word match dressed up with a stopword ("the eyes", "his gaze").
         require_last_message: when True, only flag phrases that also appear in
             the last message. Set to False to flag any repeated phrase across the
             full list.

--- a/backend/analysis/detectors/phrase_repetition.py
+++ b/backend/analysis/detectors/phrase_repetition.py
@@ -48,6 +48,7 @@ DEBUG = "DEBUG_PHRASE_REPETITION" in os.environ
 
 __all__ = [
     "detect_phrase_repetition",
+    "deduplicate_phrases",
     "PhraseResult",
     "FlaggedPhrase",
 ]
@@ -77,31 +78,57 @@ class PhraseResult:
 _split_sentences = split_narration_sentences
 
 
-# ---------- n-gram suppression ----------
+# ---------- redundancy suppression ----------
 # n-gram extraction and the contiguous-containment test both live in lexical
 # (shared, were duplicated here); this module keeps only the suppression policy.
+# deduplicate_phrases is the single source of truth, used here and by audit's
+# two-pass merge so the same phrase can't surface twice across passes.
 
 
-def _suppress_subgrams(
-    candidates: dict[tuple[str, ...], dict[int, str]],
-) -> dict[tuple[str, ...], dict[int, str]]:
-    """Drop shorter n-grams that are fully contained in a longer n-gram appearing in the same set of messages."""
-    by_fingerprint: dict[frozenset[int], list[tuple[tuple[str, ...], dict[int, str]]]] = {}
-    for gram, docs in candidates.items():
-        fp = frozenset(docs.keys())
-        by_fingerprint.setdefault(fp, []).append((gram, docs))
+def _rank(p: FlaggedPhrase) -> tuple[int, int, str]:
+    """Best-first ordering: most frequent, then longest, then alphabetical."""
+    return (-p.count, -len(p.phrase.split()), p.phrase)
 
-    survivors: dict[tuple[str, ...], dict[int, str]] = {}
-    for items in by_fingerprint.values():
-        # Longest first; keep only ones not contained in something already kept.
-        items.sort(key=lambda x: len(x[0]), reverse=True)
-        kept: list[tuple[str, ...]] = []
-        for gram, docs in items:
-            if any(is_contiguous_subsequence(gram, k) for k in kept):
-                continue
-            kept.append(gram)
-            survivors[gram] = docs
-    return survivors
+
+def _overlap_chains(a: tuple[str, ...], b: tuple[str, ...]) -> bool:
+    """True when a and b tile a longer phrase head-to-tail — a suffix of one
+    equals a prefix of the other — and the shared run carries a content word.
+    Catches one long repeat surfacing as two overlapping fragments, e.g.
+    "the tight ring" + "ring of muscle" (overlap "ring"). The content-word
+    requirement stops stopword joints ("into the" + "the dark") from merging."""
+    for x, y in ((a, b), (b, a)):
+        for k in range(min(len(x), len(y)) - 1, 0, -1):  # k < len excludes containment
+            if x[-k:] == y[:k] and count_content_words(x[-k:]):
+                return True
+    return False
+
+
+def deduplicate_phrases(phrases: list[FlaggedPhrase]) -> list[FlaggedPhrase]:
+    """Drop phrases that restate the same underlying repeat as another.
+
+    A shorter phrase contiguously contained in a longer one always recurs in a
+    superset of the longer's messages, so for each containment pair keep:
+      - the longer phrase when both span the same messages (more specific), else
+      - the shorter phrase, which recurs more widely (the longer is a partial
+        coincidence: "six centuries" in 3 msgs subsumes "for six centuries" in 2).
+    For phrases that merely overlap head-to-tail across the same messages, keep
+    the higher-ranked one ("ring of muscle" / "the tight ring" -> one line).
+    Survivors are returned best-first (_rank order); callers need not re-sort.
+    """
+    grams = {id(p): tuple(p.phrase.split()) for p in phrases}
+    msgs = {id(p): frozenset(p.message_indices) for p in phrases}
+    suppressed: set[int] = set()
+    for i, a in enumerate(phrases):
+        for b in phrases[i + 1 :]:
+            ga, gb = grams[id(a)], grams[id(b)]
+            short, long = (a, b) if len(ga) <= len(gb) else (b, a)
+            sg, lg = grams[id(short)], grams[id(long)]
+            if len(sg) < len(lg) and is_contiguous_subsequence(sg, lg):
+                same = msgs[id(short)] == msgs[id(long)]
+                suppressed.add(id(short) if same else id(long))
+            elif msgs[id(a)] == msgs[id(b)] and _overlap_chains(ga, gb):
+                suppressed.add(id(max((a, b), key=_rank)))
+    return sorted((p for p in phrases if id(p) not in suppressed), key=_rank)
 
 
 # ---------- public API ----------
@@ -175,13 +202,8 @@ def detect_phrase_repetition(
     if DEBUG:
         sys.stderr.write(f"[phrase_repetition] {len(candidates)} candidates after filters\n")
 
-    survivors = _suppress_subgrams(candidates)
-
-    if DEBUG:
-        sys.stderr.write(f"[phrase_repetition] {len(survivors)} after sub-gram suppression\n")
-
     flagged: list[FlaggedPhrase] = []
-    for gram, docs in survivors.items():
+    for gram, docs in candidates.items():
         ordered = sorted(docs.keys())
         flagged.append(
             FlaggedPhrase(
@@ -192,5 +214,9 @@ def detect_phrase_repetition(
             )
         )
 
-    flagged.sort(key=lambda p: (-p.count, -len(p.phrase.split()), p.phrase))
+    flagged = deduplicate_phrases(flagged)
+
+    if DEBUG:
+        sys.stderr.write(f"[phrase_repetition] {len(flagged)} after redundancy suppression\n")
+
     return PhraseResult(flagged_phrases=flagged, total_messages=total)

--- a/tests/unit/test_phrase_repetition_integration.py
+++ b/tests/unit/test_phrase_repetition_integration.py
@@ -46,9 +46,29 @@ def test_phrase_repetition_no_false_positive_when_draft_is_distinct():
     )
 
 
-def test_phrase_repetition_below_threshold_not_flagged():
-    """An echo across only two messages (draft + one previous) must NOT be
-    flagged, since the default threshold is three messages."""
+def test_phrase_repetition_two_word_pair_below_threshold_not_flagged():
+    """A two-word pair echoed across only two messages (draft + one previous)
+    must NOT be flagged: short phrases keep the higher three-message threshold,
+    since a 2-word match is easily a coincidence."""
+    prev1 = "His eyes burned with quiet fury at the news."
+    draft = "A quiet fury settled over the room as he left."
+
+    report, _ = _run_contextual_audit(
+        draft=draft,
+        phrase_bank=[],
+        previous_assistant_msgs=[prev1],
+    )
+    assert report.phrase_result is not None
+    assert not report.phrase_result.flagged_phrases, (
+        "A two-word pair shared by only two messages must not be flagged at the "
+        f"three-message threshold, got {[p.phrase for p in report.phrase_result.flagged_phrases]}"
+    )
+
+
+def test_phrase_repetition_long_phrase_flagged_at_two_messages():
+    """A three-word phrase echoed across only two messages (draft + one previous)
+    MUST be flagged: longer phrases are distinctive enough that a single repeat is
+    damning, so they use the lower two-message threshold."""
     draft = "She met the shadowed red eyes across the crowded table without a word."
 
     report, _ = _run_contextual_audit(
@@ -57,9 +77,9 @@ def test_phrase_repetition_below_threshold_not_flagged():
         previous_assistant_msgs=[_PREV1],
     )
     assert report.phrase_result is not None
-    assert not report.phrase_result.flagged_phrases, (
-        "A phrase shared by only two messages must not be flagged at the "
-        f"three-message threshold, got {[p.phrase for p in report.phrase_result.flagged_phrases]}"
+    phrases = [p.phrase for p in report.phrase_result.flagged_phrases]
+    assert "shadowed red eyes" in phrases, (
+        f"A distinctive 3-word phrase shared by two messages must be flagged at the two-message threshold, got {phrases}"
     )
 
 

--- a/tests/unit/test_phrase_repetition_integration.py
+++ b/tests/unit/test_phrase_repetition_integration.py
@@ -63,6 +63,44 @@ def test_phrase_repetition_below_threshold_not_flagged():
     )
 
 
+def test_phrase_repetition_detects_two_word_pair():
+    """A distinctive two-content-word pair echoed across three messages must be
+    flagged even when the messages share no 3-word overlap. Proves min_n=2 is in
+    effect end-to-end."""
+    prev1 = "His eyes burned with quiet fury at the news."
+    prev2 = "She spoke with quiet fury, voice low and even."
+    draft = "A quiet fury settled over the room as he left."
+
+    report, _ = _run_contextual_audit(
+        draft=draft,
+        phrase_bank=[],
+        previous_assistant_msgs=[prev1, prev2],
+    )
+    assert report.phrase_result is not None
+    phrases = [p.phrase for p in report.phrase_result.flagged_phrases]
+    assert "quiet fury" in phrases, f"Expected 'quiet fury' to be flagged, got {phrases}"
+
+
+def test_phrase_repetition_two_word_pair_needs_two_content_words():
+    """A bigram echoed across three messages that is one stopword + one content
+    word (e.g. 'his gaze') must NOT be flagged. The min_content_words=2 floor
+    keeps 2-word detection from degenerating into a single-word match."""
+    prev1 = "He held his gaze on the horizon for a while."
+    prev2 = "She felt his gaze settle on her shoulders."
+    draft = "I returned his gaze without a single word."
+
+    report, _ = _run_contextual_audit(
+        draft=draft,
+        phrase_bank=[],
+        previous_assistant_msgs=[prev1, prev2],
+    )
+    assert report.phrase_result is not None
+    assert not report.phrase_result.flagged_phrases, (
+        "A content+stopword bigram has only one content word and must not be "
+        f"flagged, got {[p.phrase for p in report.phrase_result.flagged_phrases]}"
+    )
+
+
 def test_phrase_repetition_only_flags_echoes_in_draft():
     """A phrase repeated only among previous messages (absent from the draft)
     must not be flagged, since require_last_message focuses on the draft."""


### PR DESCRIPTION
Separate exact phrase repetition detector into 2-word pairs and 3-word+ pairs.

3-word+ pairs - flag the second appearance.
2-word pairs - flag the third appearance.

Deduplication logic for audit report to replace n-gram filtering.
