### PR TITLE
Fix brackets not being closed in OOC blocks across the core

### DIFF
--- a/backend/inference/prompt_builder.py
+++ b/backend/inference/prompt_builder.py
@@ -259,7 +259,8 @@ def build_director_tool_prompt(
         parts.append(f'User\'s next message (for context, take this into account when directing):\n"""{user_message}"""')
     elif tool_name == "rewrite_user_prompt":
         parts.append(build_rewrite_prompt(user_message))
-    return "\n\n".join(parts)
+    # Close the [OOC: aside opened in DIRECTOR_PREAMBLE; the whole instruction is the aside.
+    return "\n\n".join(parts) + "]"
 
 
 def _render_decided(value: Any) -> str:
@@ -312,7 +313,8 @@ def build_director_scene_step_prompt(
             parts.append(f"Previous value (update it): {progressive_prior}")
 
     parts.append(f'User\'s next message (context):\n"""{user_message}"""')
-    return "\n\n".join(parts)
+    # Close the [OOC: aside opened in DIRECTOR_PREAMBLE; the whole instruction is the aside.
+    return "\n\n".join(parts) + "]"
 
 
 def build_feedback_prompt(
@@ -335,7 +337,8 @@ def build_feedback_prompt(
     if tool_schema is not None:
         labels = {df["id"]: (df.get("injection_label") or "").strip() for df in feedback_fragments}
         parts.append(_tool_call_instruction("give_feedback", tool_schema, labels=labels))
-    return "\n\n".join(parts)
+    # Close the [OOC: aside opened in FEEDBACK_PREAMBLE; the whole instruction is the aside.
+    return "\n\n".join(parts) + "]"
 
 
 def build_editor_prompt(
@@ -364,7 +367,8 @@ def build_editor_prompt(
         parts.append(EDITOR_PATCH_INSTRUCTIONS)
         parts.append(report_text)
 
-    return "\n\n".join(parts)
+    # Close the [OOC: aside opened in EDITOR_PREAMBLE; the whole instruction is the aside.
+    return "\n\n".join(parts) + "]"
 
 
 # ── Style injection block

--- a/tests/unit/test_interactive_fragments.py
+++ b/tests/unit/test_interactive_fragments.py
@@ -7,6 +7,10 @@ import pytest
 from backend.database import SEED_INTERACTIVE_FRAGMENTS
 from backend.inference import (
     build_direct_scene_tool,
+    build_director_scene_step_prompt,
+    build_director_tool_prompt,
+    build_editor_prompt,
+    build_feedback_prompt,
     build_feedback_tool,
     build_style_injection,
     compute_style_injection_block,
@@ -527,3 +531,18 @@ class TestSeedInteractiveFragments:
             "suggested_actions",
         }
         assert ids == expected
+
+
+# build_director/editor/feedback preambles open [OOC: -- their builders must close it.
+def test_ooc_preambles_close_their_bracket():
+    """Each pass preamble opens an ``[OOC:`` aside; the builder must close it at the end so the
+    whole instruction is bracketed and the delimiters stay balanced (regression guard)."""
+    outs = [
+        build_director_tool_prompt("direct_scene", "hi", [], []),
+        build_director_scene_step_prompt("hi", [], []),
+        build_editor_prompt(False, "", False, ""),
+        build_feedback_prompt([]),
+    ]
+    for o in outs:
+        assert o.startswith("[OOC:")
+        assert o.endswith("]")


### PR DESCRIPTION
When working on #104, I found what I believe to be a bug, namely the fact that OOC blocks do not seem to close their brackets. I decided to ship what I believe to be a proper fix in a separate PR.