### PR TITLE
Add proper parsing of Gemma 4 native tool calling format for raw/semi-raw LLM backend server output

### DIFF
--- a/backend/inference/client.py
+++ b/backend/inference/client.py
@@ -9,6 +9,7 @@ from typing import Any, AsyncIterator, Mapping, Sequence
 import httpx
 
 from . import endpoint_profiles
+from .gemma_tool_format import parse_gemma_tool_calls
 
 logger = logging.getLogger(__name__)
 
@@ -303,9 +304,9 @@ class LLMClient:
 
 
 def _sanitize_args(obj):
-    """Recursively strip tokenizer-artifact quote tokens (``<|"|``) from string values."""
+    """Recursively strip tokenizer-artifact quote tokens (``<|"|>``) from string values."""
     if isinstance(obj, str):
-        return obj.replace('<|"|', "").replace('<|"|', "")
+        return obj.replace('<|"|>', "")
     if isinstance(obj, list):
         return [_sanitize_args(v) for v in obj]
     if isinstance(obj, dict):
@@ -326,9 +327,10 @@ def _make_tool_call(name: str, arguments) -> dict:
 def parse_tool_calls(message: dict) -> list[dict]:
     """Extract tool calls from a completion message.
 
-    Tries, in order: the standard ``tool_calls`` array, Gemma-style
-    ``<tool_call>...</tool_call>`` tags, then JSON embedded in the content
-    body (common with some local servers).
+    Tries, in order: the standard ``tool_calls`` array, Hermes-style
+    ``<tool_call>...</tool_call>`` tags, Gemma 4 native
+    ``<|tool_call>call:NAME{...}<tool_call|>`` tokens, then JSON embedded in
+    the content body (common with some local servers).
     """
     tool_calls = []
 
@@ -344,7 +346,7 @@ def parse_tool_calls(message: dict) -> list[dict]:
     if not content:
         return []
 
-    # Gemma-style <tool_call>...</tool_call> tags
+    # Hermes-style <tool_call>...</tool_call> tags
     for match in re.finditer(r"<tool_call>(.*?)</tool_call>", content, re.DOTALL):
         try:
             parsed = json.loads(match.group(1).strip())
@@ -354,6 +356,11 @@ def parse_tool_calls(message: dict) -> list[dict]:
             pass
     if tool_calls:
         return tool_calls
+
+    # Gemma 4 native <|tool_call>call:NAME{...}<tool_call|> tokens
+    gemma_calls = parse_gemma_tool_calls(content)
+    if gemma_calls:
+        return [_make_tool_call(c["name"], c["arguments"]) for c in gemma_calls]
 
     # Try to find JSON objects or arrays in the content
     for start_char, end_char in [("{", "}"), ("[", "]")]:

--- a/backend/inference/gemma_tool_format.py
+++ b/backend/inference/gemma_tool_format.py
@@ -1,0 +1,204 @@
+"""Parser for Gemma 4's native tool-call DSL.
+
+Gemma 4 emits tool calls as ``<|tool_call>call:NAME{key:value,...}<tool_call|>``
+built from dedicated vocabulary tokens. A server with a matching parser
+translates these into structured OpenAI ``tool_calls``; a server without one
+streams the raw token text as message content. This module recovers that
+second case, producing the same ``{"name", "arguments"}`` dicts a translating
+server would yield.
+
+Value forms: strings are wrapped in the symmetric ``<|"|>`` delimiter token,
+arrays in ``[]``, objects in ``{}`` (same ``key:value`` grammar as a call
+body), and bare scalars are int/float/true/false. Keys are unquoted and may
+contain hyphens.
+
+String values carry arbitrary prose, including the structural characters
+``, : { } [ ]``. Every scan therefore tracks whether it sits inside a ``<|"|>``
+span and treats those characters as structure only outside one -- a naive split
+would shred a string value on its own commas.
+
+All functions degrade rather than raise: malformed input yields a best-effort
+partial result (or ``[]``), never an exception, so one bad completion cannot
+break a turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+OPEN = "<|tool_call>"
+CLOSE = "<tool_call|>"
+# One special token, used as both the opening and closing string delimiter.
+QUOTE = '<|"|>'
+
+
+def parse_gemma_tool_calls(content: str) -> list[dict]:
+    """Return ``[{"name", "arguments"}, ...]`` for every native call in *content*."""
+    out: list[dict] = []
+    pos = 0
+    while True:
+        o = content.find(OPEN, pos)
+        if o == -1:
+            break
+        c = content.find(CLOSE, o + len(OPEN))
+        if c == -1:
+            break  # no closing tag: the call was truncated mid-stream
+        span = content[o + len(OPEN) : c]
+        pos = c + len(CLOSE)
+        call = _parse_call(span)
+        if call is not None:
+            out.append(call)
+    return out
+
+
+def _parse_call(span: str) -> dict | None:
+    """Parse one ``call:NAME{BODY}`` span; None if it is not a call."""
+    span = span.strip()
+    if not span.startswith("call:"):
+        return None
+    brace = span.find("{")
+    if brace == -1:
+        return None
+    name = span[len("call:") : brace].strip()
+    if not name:
+        return None
+    end = _match(span, brace, "{", "}")
+    body = span[brace + 1 : end] if end != -1 else span[brace + 1 :]
+    return {"name": name, "arguments": _parse_body(body)}
+
+
+def _parse_body(body: str) -> dict:
+    """Parse a ``key:value,...`` body into an arguments dict."""
+    args: dict = {}
+    for seg in _split_top(body, ","):
+        if not seg.strip():
+            continue
+        key, raw = _split_kv(seg)
+        if key:
+            args[key] = _parse_value(raw)
+    return args
+
+
+def _parse_value(s: str) -> Any:
+    s = s.strip()
+    if not s:
+        return ""
+    if s.startswith("["):
+        return _parse_array(s)
+    if s.startswith("{"):
+        return _parse_object(s)
+    if s.startswith(QUOTE):
+        return _parse_string(s)
+    if s == "true":
+        return True
+    if s == "false":
+        return False
+    try:
+        return int(s)
+    except ValueError:
+        pass
+    try:
+        return float(s)
+    except ValueError:
+        pass
+    return s
+
+
+def _parse_array(s: str) -> list:
+    end = _match(s, 0, "[", "]")
+    inner = s[1:end] if end != -1 else s[1:]
+    if not inner.strip():
+        return []
+    return [_parse_value(e) for e in _split_top(inner, ",")]
+
+
+def _parse_object(s: str) -> dict:
+    # An object shares the call body's key:value grammar.
+    end = _match(s, 0, "{", "}")
+    inner = s[1:end] if end != -1 else s[1:]
+    return _parse_body(inner)
+
+
+def _parse_string(s: str) -> str:
+    rest = s[len(QUOTE) :]
+    end = rest.find(QUOTE)
+    return rest[:end] if end != -1 else rest
+
+
+def _match(s: str, open_idx: int, oc: str, cc: str) -> int:
+    """String-aware index of the bracket closing the one at *open_idx*; -1 if none."""
+    i, in_str, depth = open_idx, False, 0
+    n = len(s)
+    while i < n:
+        if s.startswith(QUOTE, i):
+            in_str = not in_str
+            i += len(QUOTE)
+            continue
+        ch = s[i]
+        if not in_str:
+            if ch == oc:
+                depth += 1
+            elif ch == cc:
+                depth -= 1
+                if depth == 0:
+                    return i
+        i += 1
+    return -1
+
+
+def _split_top(s: str, sep: str) -> list[str]:
+    """Split on *sep*, ignoring it inside ``<|"|>`` strings and inside ``[]`` / ``{}``."""
+    parts: list[str] = []
+    buf: list[str] = []
+    i, in_str, brk, brc = 0, False, 0, 0
+    n = len(s)
+    while i < n:
+        if s.startswith(QUOTE, i):
+            in_str = not in_str
+            buf.append(QUOTE)
+            i += len(QUOTE)
+            continue
+        ch = s[i]
+        if not in_str:
+            if ch == "[":
+                brk += 1
+            elif ch == "]":
+                brk -= 1
+            elif ch == "{":
+                brc += 1
+            elif ch == "}":
+                brc -= 1
+            elif ch == sep and brk == 0 and brc == 0:
+                parts.append("".join(buf))
+                buf = []
+                i += 1
+                continue
+        buf.append(ch)
+        i += 1
+    parts.append("".join(buf))
+    return parts
+
+
+def _split_kv(seg: str) -> tuple[str, str]:
+    """Split *seg* on its first top-level ``:``; ``("", "")`` if there is none."""
+    i, in_str, brk, brc = 0, False, 0, 0
+    n = len(seg)
+    while i < n:
+        if seg.startswith(QUOTE, i):
+            in_str = not in_str
+            i += len(QUOTE)
+            continue
+        ch = seg[i]
+        if not in_str:
+            if ch == "[":
+                brk += 1
+            elif ch == "]":
+                brk -= 1
+            elif ch == "{":
+                brc += 1
+            elif ch == "}":
+                brc -= 1
+            elif ch == ":" and brk == 0 and brc == 0:
+                return seg[:i].strip(), seg[i + 1 :]
+        i += 1
+    return "", ""

--- a/backend/pipeline/passes/editor/editor.py
+++ b/backend/pipeline/passes/editor/editor.py
@@ -289,6 +289,11 @@ def apply_patches(draft: str, patches: list[dict]) -> tuple[str, list[str]]:
     logger.debug("Applying %d patches to draft (%d chars)", len(patches), len(draft))
 
     for i, p in enumerate(patches):
+        # A malformed tool call can place a non-dict where the schema expects a
+        # {search, replace} object; skip it rather than crash on .get().
+        if not isinstance(p, dict):
+            logger.debug("Patch %d: non-dict element (%s), skipping", i, type(p).__name__)
+            continue
         search = _unescape_llm_artifacts(p.get("search", ""))
         replace = _unescape_llm_artifacts(p.get("replace", ""))
         if not search:

--- a/tests/unit/test_apply_patches_guard.py
+++ b/tests/unit/test_apply_patches_guard.py
@@ -1,0 +1,10 @@
+from backend.pipeline.passes.editor.editor import apply_patches
+
+
+def test_non_dict_patch_element_skipped():
+    # The guard exists for runtime input the type system forbids, so the bad
+    # element is deliberately the wrong type here.
+    patches = [{"search": "foo", "replace": "bar"}, "junk"]
+    draft, errors = apply_patches("draft foo", patches)  # type: ignore[arg-type]
+    assert draft == "draft bar"
+    assert errors == []

--- a/tests/unit/test_gemma_tool_format.py
+++ b/tests/unit/test_gemma_tool_format.py
@@ -1,0 +1,128 @@
+from backend.inference.gemma_tool_format import parse_gemma_tool_calls
+
+OPEN = "<|tool_call>"
+CLOSE = "<tool_call|>"
+Q = '<|"|>'  # Gemma's symmetric string-delimiter token
+
+GOLDEN = (
+    OPEN
+    + "call:direct_scene{detected_repetitions:[],history-summary:"
+    + Q
+    + "Aqua was recruited by Anon for a high-level quest. She signed a binding contract "
+    "with the Eldritch Defense Guild, was dressed in ritual gear (including a plague "
+    "doctor mask), and was informed of a mission involving an ancient evil god in the "
+    "sewers. She has now been transported to a basement where a cage elevator awaits them."
+    + Q
+    + ",keywords:["
+    + Q
+    + "Eldritch Defense Guild"
+    + Q
+    + ","
+    + Q
+    + "cognitohazard"
+    + Q
+    + ","
+    + Q
+    + "sacrificial grounds"
+    + Q
+    + ","
+    + Q
+    + "void elevator"
+    + Q
+    + "],moods:["
+    + Q
+    + "talkative"
+    + Q
+    + ","
+    + Q
+    + "tense"
+    + Q
+    + "],relevant-history:"
+    + Q
+    + "Anon's refusal to share details -> Signing the contract -> Masking for cognitohazard "
+    "protection -> Reveal of the mission -> Teleportation to the void elevator." + Q + "}" + CLOSE
+)
+
+GOLDEN_ARGS = {
+    "detected_repetitions": [],
+    "history-summary": (
+        "Aqua was recruited by Anon for a high-level quest. She signed a binding contract "
+        "with the Eldritch Defense Guild, was dressed in ritual gear (including a plague "
+        "doctor mask), and was informed of a mission involving an ancient evil god in the "
+        "sewers. She has now been transported to a basement where a cage elevator awaits them."
+    ),
+    "keywords": ["Eldritch Defense Guild", "cognitohazard", "sacrificial grounds", "void elevator"],
+    "moods": ["talkative", "tense"],
+    "relevant-history": (
+        "Anon's refusal to share details -> Signing the contract -> Masking for cognitohazard "
+        "protection -> Reveal of the mission -> Teleportation to the void elevator."
+    ),
+}
+
+
+def test_golden_sample():
+    assert parse_gemma_tool_calls(GOLDEN) == [{"name": "direct_scene", "arguments": GOLDEN_ARGS}]
+
+
+def test_empty_array():
+    content = OPEN + "call:direct_scene{moods:[]}" + CLOSE
+    assert parse_gemma_tool_calls(content) == [{"name": "direct_scene", "arguments": {"moods": []}}]
+
+
+def test_hyphen_key():
+    content = OPEN + "call:direct_scene{history-summary:" + Q + "x" + Q + "}" + CLOSE
+    assert parse_gemma_tool_calls(content) == [{"name": "direct_scene", "arguments": {"history-summary": "x"}}]
+
+
+def test_comma_inside_string_not_split():
+    content = OPEN + "call:t{history-summary:" + Q + "a, b, c" + Q + "}" + CLOSE
+    assert parse_gemma_tool_calls(content)[0]["arguments"] == {"history-summary": "a, b, c"}
+
+
+def test_bracket_inside_string():
+    content = OPEN + "call:t{summary:" + Q + "see [ref] here" + Q + "}" + CLOSE
+    assert parse_gemma_tool_calls(content)[0]["arguments"] == {"summary": "see [ref] here"}
+
+
+def test_brace_inside_string():
+    content = OPEN + "call:t{summary:" + Q + "code {x} end" + Q + "}" + CLOSE
+    assert parse_gemma_tool_calls(content)[0]["arguments"] == {"summary": "code {x} end"}
+
+
+def test_multiple_concatenated_calls():
+    content = OPEN + "call:a{moods:[" + Q + "x" + Q + "]}" + CLOSE + OPEN + "call:b{keywords:[]}" + CLOSE
+    calls = parse_gemma_tool_calls(content)
+    assert [c["name"] for c in calls] == ["a", "b"]
+    assert calls[0]["arguments"] == {"moods": ["x"]}
+    assert calls[1]["arguments"] == {"keywords": []}
+
+
+def test_bare_scalars():
+    content = OPEN + "call:t{n:5,f:1.5,b:true,c:false}" + CLOSE
+    assert parse_gemma_tool_calls(content)[0]["arguments"] == {"n": 5, "f": 1.5, "b": True, "c": False}
+
+
+def test_string_array():
+    content = OPEN + "call:t{k:[" + Q + "a" + Q + "," + Q + "b" + Q + "]}" + CLOSE
+    assert parse_gemma_tool_calls(content)[0]["arguments"] == {"k": ["a", "b"]}
+
+
+def test_no_call_returns_empty():
+    assert parse_gemma_tool_calls("She smiled. The end.") == []
+
+
+def test_truncated_call_dropped():
+    content = OPEN + "call:t{moods:[" + Q + "a" + Q + "]"  # no close tag
+    assert parse_gemma_tool_calls(content) == []
+
+
+def test_unterminated_string_best_effort():
+    content = OPEN + "call:t{k:" + Q + "abc}" + CLOSE  # no closing delimiter
+    assert parse_gemma_tool_calls(content)[0]["arguments"] == {"k": "abc}"}
+
+
+def test_object_array_element():
+    content = OPEN + "call:editor_apply_patch{patches:[{search:" + Q + "foo" + Q + ",replace:" + Q + "bar" + Q + "}]}" + CLOSE
+    assert parse_gemma_tool_calls(content) == [
+        {"name": "editor_apply_patch", "arguments": {"patches": [{"search": "foo", "replace": "bar"}]}}
+    ]

--- a/tests/unit/test_parse_tool_calls.py
+++ b/tests/unit/test_parse_tool_calls.py
@@ -1,0 +1,46 @@
+from backend.inference.client import parse_tool_calls
+
+OPEN = "<|tool_call>"
+CLOSE = "<tool_call|>"
+Q = '<|"|>'
+
+
+def test_gemma_native_through_parse_tool_calls():
+    content = OPEN + "call:direct_scene{moods:[" + Q + "talkative" + Q + "],history-summary:" + Q + "x, y" + Q + "}" + CLOSE
+    assert parse_tool_calls({"content": content}) == [
+        {"name": "direct_scene", "arguments": {"moods": ["talkative"], "history-summary": "x, y"}}
+    ]
+
+
+def test_standard_tool_calls():
+    msg = {"tool_calls": [{"function": {"name": "x", "arguments": '{"a": 1}'}}]}
+    assert parse_tool_calls(msg) == [{"name": "x", "arguments": {"a": 1}}]
+
+
+def test_hermes_tags():
+    msg = {"content": '<tool_call>{"name": "x", "arguments": {"a": 1}}</tool_call>'}
+    assert parse_tool_calls(msg) == [{"name": "x", "arguments": {"a": 1}}]
+
+
+def test_json_in_content():
+    msg = {"content": '{"name": "x", "arguments": {}}'}
+    assert parse_tool_calls(msg) == [{"name": "x", "arguments": {}}]
+
+
+def test_sanitize_strips_leaked_delimiter():
+    # A server that parsed the DSL to JSON but left the <|"|> token inside a
+    # string value: arguments decodes to {"k": 'a<|"|>b'}, sanitized to 'ab'.
+    msg = {"tool_calls": [{"function": {"name": "x", "arguments": r'{"k":"a<|\"|>b"}'}}]}
+    assert parse_tool_calls(msg) == [{"name": "x", "arguments": {"k": "ab"}}]
+
+
+def test_empty_message():
+    assert parse_tool_calls({"content": ""}) == []
+    assert parse_tool_calls({}) == []
+
+
+def test_editor_apply_patch_objects():
+    content = OPEN + "call:editor_apply_patch{patches:[{search:" + Q + "foo" + Q + ",replace:" + Q + "bar" + Q + "}]}" + CLOSE
+    assert parse_tool_calls({"content": content}) == [
+        {"name": "editor_apply_patch", "arguments": {"patches": [{"search": "foo", "replace": "bar"}]}}
+    ]


### PR DESCRIPTION
When switching from DS4 to local llama.cpp with text generation webui (and running Gemma 4), I noticed director tool calls are skipped because they fail to parse. The existing Gemma-style parsing is actually more Hermes-like. This PR makes sure Gemma 4 native tool calling format is parsed properly.