### PR TITLE
doc mode logprobs + token swapping

### DIFF
--- a/backend/api/routes/documents.py
+++ b/backend/api/routes/documents.py
@@ -85,8 +85,20 @@ async def api_generate_document(did: str, data: DocumentGenerateRequest, request
 
     async def _gen():
         try:
-            async for delta in continuer.stream(data.prompt, settings.get("model_name", ""), assisted=data.assisted):
-                yield {"event": "token", "data": delta}
+            async for chunk in continuer.stream(
+                data.prompt,
+                settings.get("model_name", ""),
+                assisted=data.assisted,
+                token_probs=data.token_probs,
+            ):
+                if chunk["type"] == "content":
+                    # Byte-identical wire: plain string, \n-escaped by _sse_stream.
+                    yield {"event": "token", "data": chunk["delta"]}
+                else:  # token_probs — dict data auto-JSON-serialized by _sse_stream
+                    yield {
+                        "event": "probs",
+                        "data": {"token": chunk["token"], "prob": chunk["prob"], "top": chunk["top"]},
+                    }
             yield {"event": "done", "data": ""}
         except Exception as e:
             logger.error("Document generate error: %s", e)

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -262,6 +262,10 @@ class DocumentGenerateRequest(BaseModel):
     # Assisted continuation: interpret ### SYSTEM/USER/ASSISTANT line macros and
     # render through the model's chat template. Defaults false → Raw (verbatim).
     assisted: bool = False
+    # Capture per-token alternatives (mikupad-style token swapping). Off by
+    # default: logprobs cost generation speed on llama.cpp, and providers that
+    # can't supply them degrade to no-popup. Emits `event: probs` SSE frames.
+    token_probs: bool = False
 
 
 class CharacterCardCreate(BaseModel):

--- a/backend/features/documents/continuation.py
+++ b/backend/features/documents/continuation.py
@@ -61,6 +61,12 @@ _DEFAULT_USER = "Continue the text. Write several paragraphs."
 # literal prose.
 _MACRO_RE = re.compile(r"^###\s*(SYSTEM|USER|ASSISTANT)\s*:\s?(.*)$", re.IGNORECASE)
 
+# Per-token-alternatives counts, requested only when the client toggles probs on.
+# Text mode (llama.cpp /completion) matches mikupad's default of 10; chat mode
+# asks for 5, a safe floor across OpenAI-compat providers that support logprobs.
+_N_PROBS_TEXT = 10
+_TOP_LOGPROBS_CHAT = 5
+
 
 def _msg(role: str, content: str) -> ChatMessage:
     """Build a ChatMessage, narrowing *role* to the TypedDict's Literal."""
@@ -166,7 +172,9 @@ class DocumentContinuer:
             {"role": "user", "content": prompt},
         ]
 
-    async def stream(self, prompt: str, model: str, assisted: bool = False) -> AsyncGenerator[str, None]:
+    async def stream(
+        self, prompt: str, model: str, assisted: bool = False, token_probs: bool = False
+    ) -> AsyncGenerator[dict, None]:
         # Transport branch on the client's own completion_mode (single source of
         # truth — not a second settings read), crossed with the assisted flag:
         #
@@ -179,12 +187,20 @@ class DocumentContinuer:
         # Reasoning is always off in assisted mode: a no-op on the text/prefill
         # path (client drops chat_template_kwargs there) but load-bearing for the
         # chat fallback and the trailing-note generation prompt.
+        #
+        # token_probs adds the per-transport alternatives request (mikupad-style
+        # token swapping): n_probs on the llama.cpp branches, logprobs/top_logprobs
+        # on the OpenAI-compat branches. Unset → no extra fields, unchanged bodies.
+        probs_text = {"n_probs": _N_PROBS_TEXT} if token_probs else {}
+        probs_chat = {"logprobs": True, "top_logprobs": _TOP_LOGPROBS_CHAT} if token_probs else {}
         if self.client.completion_mode == "text":
             if assisted:
                 messages, prefill = parse_doc_macros(prompt)
-                gen = self.client.complete(messages, model, prefill=prefill, **self.params, **reasoning_cfg(False))
+                gen = self.client.complete(
+                    messages, model, prefill=prefill, **self.params, **probs_text, **reasoning_cfg(False)
+                )
             else:
-                gen = self.client.complete_raw(prompt, model, **self.params)
+                gen = self.client.complete_raw(prompt, model, **self.params, **probs_text)
         else:
             if assisted:
                 messages, prefill = parse_doc_macros(prompt)
@@ -198,11 +214,13 @@ class DocumentContinuer:
                         _msg("assistant", prefill),
                         _msg("user", DOC_ASSIST_CONTINUE),
                     ]
-                gen = self.client.complete(messages, model, **self.params, **reasoning_cfg(False))
+                gen = self.client.complete(messages, model, **self.params, **probs_chat, **reasoning_cfg(False))
             else:
-                gen = self.client.complete(self.build_chat_messages(prompt), model, **self.params, **reasoning_cfg(False))
-        # Yield content deltas only (drop reasoning) — same filter as
-        # ConversationSummarizer.stream.
+                gen = self.client.complete(
+                    self.build_chat_messages(prompt), model, **self.params, **probs_chat, **reasoning_cfg(False)
+                )
+        # Yield content + token_probs chunks (drop reasoning). The route frames
+        # content as `event: token` and token_probs as `event: probs`.
         async for chunk in gen:
-            if chunk["type"] == "content":
-                yield chunk["delta"]
+            if chunk["type"] in ("content", "token_probs"):
+                yield chunk

--- a/backend/inference/client.py
+++ b/backend/inference/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import re
 from typing import Any, AsyncIterator, Mapping, Sequence
 
@@ -60,6 +61,44 @@ def reasoning_cfg(on: bool) -> dict:
             "thinking": {"type": "disabled"},
         }
     )
+
+
+def _parse_chat_logprobs(choice: Mapping[str, Any]) -> list[dict]:
+    """Normalize an OpenAI-compat ``choice.logprobs`` block to Orb's prob shape.
+
+    Reads ``logprobs.content`` — an array of
+    ``{token, logprob, top_logprobs:[{token, logprob}]}`` — folding each into
+    ``{"token", "prob", "top": [{"t","p"}]}`` with linear probabilities
+    (``math.exp``). This is the chat-transport twin of
+    ``text_completion.parse_token_probs``; the output shape is identical so the
+    route frames both the same way. Returns ``[]`` when the provider omits
+    logprobs (graceful degrade → no popup) and skips malformed records; never
+    raises.
+    """
+    logprobs = choice.get("logprobs")
+    if not isinstance(logprobs, dict):
+        return []
+    content = logprobs.get("content")
+    if not isinstance(content, list):
+        return []
+    out: list[dict] = []
+    for rec in content:
+        if not isinstance(rec, dict) or not isinstance(rec.get("token"), str):
+            continue
+        try:
+            prob = math.exp(float(rec["logprob"]))
+        except (TypeError, ValueError, KeyError, OverflowError):
+            continue
+        top: list[dict] = []
+        for alt in rec.get("top_logprobs") or []:
+            if not isinstance(alt, dict) or not isinstance(alt.get("token"), str):
+                continue
+            try:
+                top.append({"t": alt["token"], "p": math.exp(float(alt["logprob"]))})
+            except (TypeError, ValueError, KeyError, OverflowError):
+                continue
+        out.append({"token": rec["token"], "prob": prob, "top": top})
+    return out
 
 
 class LLMClient:
@@ -136,6 +175,9 @@ class LLMClient:
         params.pop("prefill", None)
         params.pop("grammar", None)
         params.pop("json_schema", None)
+        # n_probs is a llama.cpp /completion field; a text→chat fallback (e.g. a
+        # call carrying image parts) must not leak it into the OpenAI-compat body.
+        params.pop("n_probs", None)
         async for event in self._complete_chat(messages, model, tools, tool_choice, **params):
             yield event
 
@@ -244,6 +286,12 @@ class LLMClient:
                             if c:
                                 content_parts.append(c)
                                 yield {"type": "content", "delta": c}
+
+                            # Per-token alternatives (Document mode steering) —
+                            # present only when the caller passed logprobs and the
+                            # provider honoured them; otherwise a no-op.
+                            for rec in _parse_chat_logprobs(choice):
+                                yield {"type": "token_probs", **rec}
 
                             # Tool call argument deltas — accumulate by index
                             for tc_delta in delta.get("tool_calls") or []:
@@ -511,6 +559,12 @@ class LLMClient:
                     for kind, text in splitter.feed(delta):
                         (reasoning_parts if kind == "reasoning" else content_parts).append(text)
                         yield {"type": kind, "delta": text}
+            # Per-token alternatives ride a separate channel (Document mode's
+            # token-swap steering); never for a forced tool call, whose output is
+            # buffered as arguments rather than surfaced as content.
+            if forced_name is None:
+                for rec in text_completion.parse_token_probs(data):
+                    yield {"type": "token_probs", **rec}
             if stop:
                 break
 
@@ -570,6 +624,10 @@ class LLMClient:
             if delta:
                 content_parts.append(delta)
                 yield {"type": "content", "delta": delta}
+            # Per-token alternatives on a separate channel (Document mode). Absent
+            # unless the caller passed n_probs, so this is a no-op by default.
+            for rec in text_completion.parse_token_probs(data):
+                yield {"type": "token_probs", **rec}
             if stop:
                 break
 

--- a/backend/inference/local_ml.py
+++ b/backend/inference/local_ml.py
@@ -85,8 +85,8 @@ GO_EMOTIONS: tuple[str, ...] = (
     "neutral",
 )
 
-_REPEAT_PENALTY = 1.5
-_FREQUENCY_PENALTY = 0.5
+_REPEAT_PENALTY = 1.1
+_FREQUENCY_PENALTY = 0.0
 _TOP_P = 0.9
 _TOP_K = 20
 

--- a/backend/inference/text_completion.py
+++ b/backend/inference/text_completion.py
@@ -42,8 +42,35 @@ _NONE: ThinkTags = ("", "", "")
 
 # An (optionally namespaced) reasoning tag pair: <think>, <thinking>,
 # <thought>, <reason>, <reasoning>, <mm:think> (MiniMax M3),
-# <seed:think> (ByteDance Seed), ...
-_THINK_RE = re.compile(r"<((?:[A-Za-z0-9_-]+:)?(?:think(?:ing)?|thought|reason(?:ing)?))>")
+# <seed:think> (ByteDance Seed), <think:opensource> (Hunyuan), ...
+# Namespace may sit before or after the keyword (models differ on which).
+_THINK_RE = re.compile(
+    r"<((?:[A-Za-z0-9_-]+:)?(?:think(?:ing)?|thought|reason(?:ing)?)(?::[A-Za-z0-9_-]+)?)>"
+)
+
+# Some templates don't write the tag literally; they build it from a namespace
+# variable, e.g. Hunyuan:  {% set HYTK=':opensource' %}
+#   {% set think_begin_token = '<think{}>'.format(HYTK) %}
+# The sniff below reads raw jinja, so it would only see the literal ``<think{}>``
+# unless we first resolve the ``.format(VAR)`` call. This pre-pass inlines any
+# ``'...{}...'.format(VAR)`` where VAR is a ``set``-bound string literal.
+_SET_STR_RE = re.compile(r"""\bset\s+(\w+)\s*=\s*(['"])([^'"]*)\2""")
+_FORMAT_RE = re.compile(r"""(['"])([^'"]*)\1\.format\(\s*(\w+)\s*\)""")
+
+
+def _resolve_format_tokens(chat_template: str) -> str:
+    """Inline ``'<tag{}>'.format(VAR)`` constructions using ``set``-bound vars."""
+    if ".format(" not in chat_template:
+        return chat_template
+    vars_ = {m[0]: m[2] for m in _SET_STR_RE.findall(chat_template)}
+
+    def sub(m: re.Match[str]) -> str:
+        literal, var = m.group(2), m.group(3)
+        if var in vars_ and "{}" in literal:
+            return literal.replace("{}", vars_[var])
+        return m.group(0)
+
+    return _FORMAT_RE.sub(sub, chat_template)
 
 
 def think_tags_from_template(chat_template: str) -> ThinkTags:
@@ -52,6 +79,7 @@ def think_tags_from_template(chat_template: str) -> ThinkTags:
     Gemma-4 channel pair wins over any ``<think>``-family tag when both markers
     appear (a template can mention both). Neither present => non-thinking model.
     """
+    chat_template = _resolve_format_tokens(chat_template)
     if "<|channel>thought" in chat_template:
         return _GEMMA4
     m = _THINK_RE.search(chat_template)

--- a/backend/inference/text_completion.py
+++ b/backend/inference/text_completion.py
@@ -15,6 +15,7 @@ Mirrors the HTTP-free leaf pattern of ``gemma_tool_format.py`` /
 from __future__ import annotations
 
 import logging
+import math
 import re
 from typing import Any, Awaitable, Callable, Mapping, Sequence
 
@@ -216,6 +217,87 @@ def build_completion_params(params: Mapping[str, Any]) -> dict:
         out["n_predict"] = params["max_tokens"]
     if params.get("repetition_penalty") is not None:
         out["repeat_penalty"] = params["repetition_penalty"]
+    # Per-token alternatives (mikupad-style steering). ``post_sampling_probs``
+    # asks for linear probabilities after sampling (matches what a writer sees);
+    # old servers ignore both unknown fields. ``bool`` is an ``int`` subclass, so
+    # exclude it explicitly — ``n_probs=True`` is not a request for 1 alternative.
+    n_probs = params.get("n_probs")
+    if isinstance(n_probs, int) and not isinstance(n_probs, bool) and n_probs > 0:
+        out["n_probs"] = n_probs
+        out["post_sampling_probs"] = True
+    return out
+
+
+def _linear_prob(rec: Mapping[str, Any]) -> float | None:
+    """Read a linear probability from a prob record, converting ``logprob`` via exp.
+
+    Prefers an explicit ``prob`` (post_sampling_probs / legacy); falls back to
+    ``math.exp(logprob)`` (the OpenAI-style logprob shape). Returns ``None`` when
+    neither is a finite number.
+    """
+    if "prob" in rec:
+        try:
+            return float(rec["prob"])
+        except (TypeError, ValueError):
+            return None
+    if "logprob" in rec:
+        try:
+            return math.exp(float(rec["logprob"]))
+        except (TypeError, ValueError, OverflowError):
+            return None
+    return None
+
+
+def _tok_str(rec: Mapping[str, Any]) -> str | None:
+    """Read a token string across the field names the three shapes use."""
+    for key in ("token", "tok_str", "content"):
+        v = rec.get(key)
+        if isinstance(v, str):
+            return v
+    return None
+
+
+def parse_token_probs(data: Mapping[str, Any]) -> list[dict]:
+    """Normalize a ``/completion`` chunk's ``completion_probabilities`` to Orb's shape.
+
+    llama.cpp has shipped three per-token-probability shapes across versions;
+    fold them all into ``[{"token", "prob", "top": [{"t","p"}]}]`` with linear
+    probabilities (logprob variants are ``math.exp``-ed):
+
+    * ``{token, prob, top_probs:[{token, prob}]}``   — current (post_sampling_probs)
+    * ``{token, logprob, top_logprobs:[{token, logprob}]}`` — OpenAI-style logprobs
+    * ``{content, probs:[{tok_str, prob}]}``          — legacy
+
+    Never raises: a missing/garbage payload or an unknown shape drift degrades to
+    ``[]`` (no popup) rather than breaking the stream. Individual malformed
+    records are skipped, not fatal.
+    """
+    records = data.get("completion_probabilities")
+    if not isinstance(records, list):
+        return []
+    out: list[dict] = []
+    for rec in records:
+        if not isinstance(rec, dict):
+            continue
+        token = _tok_str(rec)
+        if token is None:
+            continue
+        raw_alts = rec.get("top_probs") or rec.get("top_logprobs") or rec.get("probs") or []
+        top: list[dict] = []
+        if isinstance(raw_alts, list):
+            for alt in raw_alts:
+                if not isinstance(alt, dict):
+                    continue
+                t = _tok_str(alt)
+                p = _linear_prob(alt)
+                if t is not None and p is not None:
+                    top.append({"t": t, "p": p})
+        prob = _linear_prob(rec)
+        if prob is None:
+            # Legacy shape has no top-level prob: read the sampled token's own
+            # entry from the alternatives list.
+            prob = next((a["p"] for a in top if a["t"] == token), 0.0)
+        out.append({"token": token, "prob": prob, "top": top})
     return out
 
 

--- a/backend/inference/text_completion.py
+++ b/backend/inference/text_completion.py
@@ -44,9 +44,7 @@ _NONE: ThinkTags = ("", "", "")
 # <thought>, <reason>, <reasoning>, <mm:think> (MiniMax M3),
 # <seed:think> (ByteDance Seed), <think:opensource> (Hunyuan), ...
 # Namespace may sit before or after the keyword (models differ on which).
-_THINK_RE = re.compile(
-    r"<((?:[A-Za-z0-9_-]+:)?(?:think(?:ing)?|thought|reason(?:ing)?)(?::[A-Za-z0-9_-]+)?)>"
-)
+_THINK_RE = re.compile(r"<((?:[A-Za-z0-9_-]+:)?(?:think(?:ing)?|thought|reason(?:ing)?)(?::[A-Za-z0-9_-]+)?)>")
 
 # Some templates don't write the tag literally; they build it from a namespace
 # variable, e.g. Hunyuan:  {% set HYTK=':opensource' %}

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -76,6 +76,7 @@ import {
   renameActiveDocument,
   renameDocument,
   setDocAssisted,
+  setDocProbs,
   toggleDocumentMode,
 } from "./document.js";
 import {
@@ -398,6 +399,7 @@ Object.assign(window, {
   // document mode
   toggleDocumentMode,
   setDocAssisted,
+  setDocProbs,
   createDocument,
   openDocument,
   deleteDocument,

--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -7,13 +7,15 @@ body {
   font-family: var(--font-ui);
   background: var(--bg-deep);
   color: var(--text-primary);
-  height: 100vh;
+  height: var(--app-height, 100vh); /* mobile.js shrinks --app-height when the keyboard opens */
   overflow: hidden;
 }
 
 #app {
   display: flex;
-  height: 100vh;
+  height: var(--app-height, 100vh);
+  position: relative;
+  top: var(--app-offset, 0px); /* re-align with the visual viewport when the browser pans it (iOS) */
 }
 
 .hidden { display: none !important; }

--- a/frontend/css/document.css
+++ b/frontend/css/document.css
@@ -210,7 +210,6 @@
   color: var(--text-muted);
 }
 .doc-save-state { color: var(--text-secondary); }
-.doc-gen-status { color: var(--accent); }
 .doc-footer-actions { display: flex; gap: 8px; }
 
 /* Prompting-strategy segmented toggle (Raw ⇄ Assisted). */

--- a/frontend/css/document.css
+++ b/frontend/css/document.css
@@ -238,6 +238,67 @@
   box-shadow: inset 0 -2px 0 var(--accent);
 }
 
+/* Per-token alternatives toggle (opt-in; mikupad-style token swapping). */
+.doc-probs-toggle {
+  padding: 3px 10px;
+  font-size: 11px;
+  line-height: 1.4;
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.doc-probs-toggle:hover { color: var(--text-primary); }
+.doc-probs-toggle.active {
+  background: var(--accent-glow);
+  color: var(--text-primary);
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+
+/* ── Per-token alternatives popup (hover a generated token). ──────────────── */
+#doc-prob-popup {
+  position: fixed;
+  z-index: 60;
+  min-width: 120px;
+  max-width: 280px;
+  max-height: 40vh;
+  overflow-y: auto;
+  padding: 4px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+}
+#doc-prob-popup.hidden { display: none; }
+.prob-alt {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 4px 8px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-primary);
+}
+.prob-alt:hover { background: var(--bg-hover); }
+.prob-alt.current { background: var(--accent-glow); }
+.prob-tok {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: pre;
+}
+.prob-pct {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
 /* ── Mobile. ─────────────────────────────────────────────────────────────── */
 @media (max-width: 900px) {
   #doc-mobile-sidebar-toggle { display: inline-block; }

--- a/frontend/document.js
+++ b/frontend/document.js
@@ -12,6 +12,7 @@ import {
   setCaretOffset,
 } from "./document_editor.js";
 import {
+  addDelta,
   addToken,
   beginRun,
   clearPending,
@@ -19,7 +20,6 @@ import {
   hideProbPopup,
   initDocProbs,
   runAt,
-  spliceRunOffsets,
   swapRunToken,
   syncContent,
 } from "./document_probs.js";
@@ -595,9 +595,10 @@ export async function docGenerate() {
       resp,
       (delta) => {
         anchorTextNode.appendData(delta);
+        addDelta(delta); // positions the chunk's probs records within the run
         scrollAnchorIntoView();
       },
-      (rec) => addToken(rec), // per-token alternatives → side-store (Step 5)
+      (rec) => addToken(rec), // per-token alternatives → side-store
       (msg) => toast(msg || "Generation error", true),
     );
   } catch (e) {
@@ -655,8 +656,9 @@ export function docStop() {
 
 // Swap a generated token for one of its alternatives (mikupad-style), then
 // auto-continue from that point. Passed to initDocProbs as ctx.requestSwap.
-// Surgery is confined to the swapped token's own run: user text and later runs
-// are preserved by construction (slice boundaries at tokStart and run.end).
+// Everything after the swapped token is deleted — the continuation is being
+// rewritten from the swap point, so stale tail text (even user-typed) goes;
+// docCheckpoint makes the whole swap one Ctrl+Z step.
 function docSwapToken(run, tokenIndex, alt) {
   if (S.docStreaming || !S.activeDocId) return;
   const page = $("doc-page");
@@ -674,11 +676,14 @@ function docSwapToken(run, tokenIndex, alt) {
   hideProbPopup();
   docCheckpoint(); // pre-swap undo step
 
-  // Replace [tokStart, run.end) with the alternative — the swapped token plus the
-  // rest of this run only. content.slice(0, tokStart) (incl. user text) and
-  // content.slice(run.end) (later runs / user text) are untouched.
-  const newContent = content.slice(0, tokStart) + alt.t + content.slice(run.end);
-  const newSpans = spliceRunOffsets(spans, tokStart, run.end, alt.t.length);
+  // Truncate at the swap point: keep content before the token, then the
+  // alternative; everything after is deleted. Spans clip at tokStart and the
+  // swapped token itself stays tinted as generated text.
+  const newContent = content.slice(0, tokStart) + alt.t;
+  const newSpans = spans
+    .filter((s) => s.start < tokStart)
+    .map((s) => ({ start: s.start, end: Math.min(s.end, tokStart) }));
+  newSpans.push({ start: tokStart, end: newContent.length });
   swapRunToken(S.activeDocId, run, tokenIndex, alt, newContent);
 
   renderEditor(page, newContent, newSpans);

--- a/frontend/document.js
+++ b/frontend/document.js
@@ -59,9 +59,6 @@ function swapGenButtons(streaming) {
   $("doc-generate-btn")?.classList.toggle("hidden", streaming);
   $("doc-stop-btn")?.classList.toggle("hidden", !streaming);
 }
-function showGenStatus(on) {
-  $("doc-gen-status")?.classList.toggle("hidden", !on);
-}
 function updateTokenCount() {
   const page = $("doc-page");
   const len = page ? serializeEditor(page).content.length : 0;
@@ -579,7 +576,6 @@ export async function docGenerate() {
   S.docStreaming = true;
   S.docAbortController = new AbortController();
   swapGenButtons(true);
-  showGenStatus(true);
   updateUndoButton(); // greyed while streaming
   startFlushInterval();
 
@@ -596,6 +592,7 @@ export async function docGenerate() {
       (delta) => {
         anchorTextNode.appendData(delta);
         addDelta(delta); // positions the chunk's probs records within the run
+        updateTokenCount(); // live count instead of a static "Generating" label
         scrollAnchorIntoView();
       },
       (rec) => addToken(rec), // per-token alternatives → side-store
@@ -617,7 +614,6 @@ function finalizeGeneration() {
   page.setAttribute("contenteditable", "true");
   page.classList.remove("generating");
   swapGenButtons(false);
-  showGenStatus(false);
 
   const anchor = page.querySelector(".gen-active");
   let committedText = null;

--- a/frontend/document.js
+++ b/frontend/document.js
@@ -11,6 +11,18 @@ import {
   serializeEditor,
   setCaretOffset,
 } from "./document_editor.js";
+import {
+  addToken,
+  beginRun,
+  clearPending,
+  commitRun,
+  hideProbPopup,
+  initDocProbs,
+  runAt,
+  spliceRunOffsets,
+  swapRunToken,
+  syncContent,
+} from "./document_probs.js";
 import { showConfirmModal } from "./modal.js";
 import { S } from "./state.js";
 import { $, esc, escAttr, formatRelativeDate, toast } from "./utils.js";
@@ -18,6 +30,7 @@ import { $, esc, escAttr, formatRelativeDate, toast } from "./utils.js";
 const LS_MODE = "orb-doc-mode";
 const LS_ACTIVE = "orb-active-doc";
 const LS_ASSISTED = "orb-doc-assisted"; // Raw (0) ⇄ Assisted (1) prompting strategy
+const LS_PROBS = "orb-doc-probs"; // capture per-token alternatives (0/1)
 const SAVE_DEBOUNCE_MS = 1500;
 const STREAM_FLUSH_MS = 5000; // interval flush while streaming → tab crash loses ≤5s
 const HISTORY_DEBOUNCE_MS = 800; // typing pause → one undo step per burst
@@ -31,6 +44,7 @@ let saveTimer = null;
 let flushInterval = null;
 let anchorTextNode = null; // text node tokens stream into during generation
 let docAssisted = false; // false = Raw (verbatim), true = Assisted (### macros → chat template)
+let docProbsOn = false; // capture per-token alternatives (mikupad-style token swapping)
 
 // ── Small DOM helpers ────────────────────────────────────────────────────────
 function setSaveState(text) {
@@ -102,6 +116,7 @@ function docRestore(snap) {
   const max = Math.min(before.length, snap.content.length);
   while (caret < max && before[caret] === snap.content[caret]) caret++;
   renderEditor(page, snap.content, snap.spans);
+  if (S.activeDocId) syncContent(S.activeDocId, snap.content); // remap token-runs across the undo/redo jump
   setCaretOffset(page, caret);
   if (MOBILE.matches) page.blur(); // addRange refocuses the box → keyboard pops while reading; kill it on mobile
   // Programmatic render fires no input event → same bookkeeping as onEditorInput.
@@ -181,6 +196,19 @@ export function setDocAssisted(on) {
   docAssisted = !!on;
   localStorage.setItem(LS_ASSISTED, docAssisted ? "1" : "0");
   reflectAssistedToggle();
+}
+
+// ── Per-token alternatives toggle (mikupad-style token swapping), persisted. ──
+// Opt-in: logprobs cost generation speed on llama.cpp, and providers that can't
+// supply them degrade to no-popup. Sent as `token_probs` in the generate POST.
+function reflectProbsToggle() {
+  $("doc-probs-btn")?.classList.toggle("active", docProbsOn);
+}
+
+export function setDocProbs(on) {
+  docProbsOn = !!on;
+  localStorage.setItem(LS_PROBS, docProbsOn ? "1" : "0");
+  reflectProbsToggle();
 }
 
 // ── Documents list. ──────────────────────────────────────────────────────────
@@ -286,6 +314,7 @@ export async function openDocument(id) {
     toast("Stop generation first", true);
     return;
   }
+  hideProbPopup(); // switching docs → drop any popup from the previous one
   if (S.activeDocId && S.activeDocId !== id && S.docDirty) await flushSave();
   let doc;
   try {
@@ -301,6 +330,7 @@ export async function openDocument(id) {
 
   const page = $("doc-page");
   renderEditor(page, doc.content, doc.generated_spans || []);
+  syncContent(id, doc.content); // realign any session token-runs to the loaded content
   page.setAttribute("contenteditable", "true");
   $("doc-generate-btn").disabled = false;
   $("doc-title-text").textContent = doc.title;
@@ -422,6 +452,7 @@ function onEditorInput() {
   S.docDirty = true;
   setSaveState("Unsaved…");
   updateTokenCount();
+  if (S.activeDocId) syncContent(S.activeDocId, serializeEditor($("doc-page")).content); // keep token offsets aligned
   scheduleSave();
   clearTimeout(docHistoryTimer);
   docHistoryTimer = setTimeout(docCheckpoint, HISTORY_DEBOUNCE_MS);
@@ -483,10 +514,11 @@ function scrollAnchorIntoView() {
 }
 
 // Dedicated SSE reader (do NOT reuse the chat-coupled processSSEStream). Handles
-// the three wire facts of the backend's _sse_stream: \n is escaped in data,
+// the wire facts of the backend's _sse_stream: string data has \n escaped (token /
+// error), dict data is raw JSON (probs — must NOT be unescaped or the JSON breaks),
 // ": keepalive" comment frames appear during silent stretches, and errors arrive
 // in-band as `event: error`.
-async function readDocSSE(resp, onToken, onError) {
+async function readDocSSE(resp, onToken, onProbs, onError) {
   const reader = resp.body.getReader();
   const decoder = new TextDecoder();
   let buf = "";
@@ -506,10 +538,18 @@ async function readDocSSE(resp, onToken, onError) {
         if (line.startsWith("event: ")) event = line.slice(7);
         else if (line.startsWith("data: ")) data = line.slice(6);
       }
-      data = data.replace(/\\n/g, "\n"); // newlines are load-bearing in the editor
-      if (event === "token") onToken(data);
-      else if (event === "error") {
-        onError(data);
+      // Unescape ONLY string-data channels; probs data is JSON where a real
+      // newline inside a token would already be `\n`-escaped by json.dumps —
+      // unescaping it here would corrupt the payload.
+      if (event === "token") onToken(data.replace(/\\n/g, "\n"));
+      else if (event === "probs") {
+        try {
+          onProbs(JSON.parse(data));
+        } catch {
+          /* malformed probs frame → skip, never break the text stream */
+        }
+      } else if (event === "error") {
+        onError(data.replace(/\\n/g, "\n"));
         return;
       } else if (event === "done") return;
     }
@@ -519,6 +559,7 @@ async function readDocSSE(resp, onToken, onError) {
 export async function docGenerate() {
   if (!S.activeDocId || S.docStreaming) return;
   const page = $("doc-page");
+  hideProbPopup(); // no stale alternatives popup over a regenerating region
   if (S.docDirty) await flushSave();
   docCheckpoint(); // pre-generation state — Ctrl+Z after gen lands here
 
@@ -526,6 +567,7 @@ export async function docGenerate() {
   const caret = computeCaretOffset(page);
   const { content, spans } = serializeEditor(page);
   const prompt = content.slice(0, caret);
+  beginRun(S.activeDocId, caret); // token records (if any) collect against this run
 
   // Re-render with an empty streaming anchor at the caret (splits a straddling span).
   const anchor = renderEditor(page, content, spans, caret);
@@ -545,7 +587,7 @@ export async function docGenerate() {
     const resp = await fetch(`/api/documents/${S.activeDocId}/generate`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ prompt, assisted: docAssisted }),
+      body: JSON.stringify({ prompt, assisted: docAssisted, token_probs: docProbsOn }),
       signal: S.docAbortController.signal,
     });
     if (!resp.ok) throw new Error(await resp.text());
@@ -555,6 +597,7 @@ export async function docGenerate() {
         anchorTextNode.appendData(delta);
         scrollAnchorIntoView();
       },
+      (rec) => addToken(rec), // per-token alternatives → side-store (Step 5)
       (msg) => toast(msg || "Generation error", true),
     );
   } catch (e) {
@@ -576,14 +619,26 @@ function finalizeGeneration() {
   showGenStatus(false);
 
   const anchor = page.querySelector(".gen-active");
+  let committedText = null;
   if (anchor) {
     anchor.classList.remove("gen-active");
     if (!anchor.textContent) {
       anchor.remove(); // empty span (immediate EOS / abort before any token)
+      clearPending();
       toast("No text was generated");
     } else {
+      committedText = anchor.textContent;
       caretAfter(anchor);
     }
+  } else {
+    clearPending();
+  }
+  // Sync the side-store to the post-generation content FIRST (shifts any
+  // pre-existing runs for the inserted text), THEN commit the fresh run in those
+  // same coordinates — committing first would let the remap double-shift it.
+  if (S.activeDocId) {
+    syncContent(S.activeDocId, serializeEditor(page).content);
+    if (committedText != null) commitRun(S.activeDocId, committedText);
   }
   if (MOBILE.matches) $("doc-page").blur(); // no keyboard pop on Stop / gen-end while reading
   S.docDirty = true;
@@ -596,6 +651,45 @@ export function docStop() {
   if (!S.docStreaming) return;
   S.docAbortController?.abort();
   fetch(`/api/documents/${S.activeDocId}/stop`, { method: "POST" }).catch(() => {});
+}
+
+// Swap a generated token for one of its alternatives (mikupad-style), then
+// auto-continue from that point. Passed to initDocProbs as ctx.requestSwap.
+// Surgery is confined to the swapped token's own run: user text and later runs
+// are preserved by construction (slice boundaries at tokStart and run.end).
+function docSwapToken(run, tokenIndex, alt) {
+  if (S.docStreaming || !S.activeDocId) return;
+  const page = $("doc-page");
+  const { content, spans } = serializeEditor(page);
+
+  // Token start = run start + the lengths of the tokens before it.
+  let tokStart = run.start;
+  for (let i = 0; i < tokenIndex; i++) tokStart += run.tokens[i].text.length;
+  // Revalidate: the run must still tile the current content (no edit since hover).
+  // runAt drops the run and returns null on a mismatch → bail without touching text.
+  if (runAt(S.activeDocId, tokStart, content) !== run) {
+    hideProbPopup();
+    return;
+  }
+  hideProbPopup();
+  docCheckpoint(); // pre-swap undo step
+
+  // Replace [tokStart, run.end) with the alternative — the swapped token plus the
+  // rest of this run only. content.slice(0, tokStart) (incl. user text) and
+  // content.slice(run.end) (later runs / user text) are untouched.
+  const newContent = content.slice(0, tokStart) + alt.t + content.slice(run.end);
+  const newSpans = spliceRunOffsets(spans, tokStart, run.end, alt.t.length);
+  swapRunToken(S.activeDocId, run, tokenIndex, alt, newContent);
+
+  renderEditor(page, newContent, newSpans);
+  setCaretOffset(page, tokStart + alt.t.length); // caret right after the swapped token
+  S.docDirty = true;
+  setSaveState("Unsaved…");
+  updateTokenCount();
+
+  // Continue generation: docGenerate slices prompt = content up to the caret, so
+  // the swapped token is in the prompt and a fresh run begins exactly at the cut.
+  docGenerate();
 }
 
 // ── Shortcuts: Ctrl/Cmd+Enter generates, Esc stops, Ctrl/Cmd+Z / +Shift+Z / +Y
@@ -628,10 +722,19 @@ export function initDocumentMode() {
   if (!page) return;
   docAssisted = localStorage.getItem(LS_ASSISTED) === "1";
   reflectAssistedToggle();
+  docProbsOn = localStorage.getItem(LS_PROBS) === "1";
+  reflectProbsToggle();
   // Re-read the token cap on open — modelConfigs may load / change after init.
   $("doc-help")?.addEventListener("toggle", (e) => e.target.open && reflectAssistedToggle());
   installPlainTextGuards(page);
   initDocAutoscroll();
+  // Hover-to-inspect / click-to-swap per-token alternatives. Context is injected
+  // (S-free module): current doc, streaming guard, and the swap action.
+  initDocProbs(page, {
+    getDocId: () => S.activeDocId,
+    isStreaming: () => S.docStreaming,
+    requestSwap: docSwapToken,
+  });
   page.addEventListener("input", onEditorInput);
   // Context-menu Undo/Redo must hit our history, never the orphaned native stack.
   page.addEventListener("beforeinput", (e) => {

--- a/frontend/document_editor.js
+++ b/frontend/document_editor.js
@@ -117,22 +117,60 @@ export function renderEditor(pageEl, content, spans, anchorOffset = null) {
   return anchorEl;
 }
 
-// The serialized string offset of the collapsed selection within *pageEl*. A
-// selection outside the editor (e.g. focus on a button) resolves to end-of-doc.
-// Measures by serializing a fragment cloned from doc-start to the caret, so it
-// stays consistent with serializeEditor (spans + newlines counted identically).
-export function computeCaretOffset(pageEl) {
-  const full = serializeEditor(pageEl).content;
-  const sel = window.getSelection();
-  if (!sel || sel.rangeCount === 0) return full.length;
-  const range = sel.getRangeAt(0);
-  if (!pageEl.contains(range.startContainer)) return full.length;
+// The serialized string offset of a DOM position (*container*, *offset*) within
+// *pageEl* — a position outside the editor resolves to end-of-doc. Measures by
+// serializing a fragment cloned from doc-start to the position, so it stays
+// consistent with serializeEditor (spans + newlines counted identically). Shared
+// by the caret reader and the popup's caretPositionFromPoint hit-test.
+export function offsetOfPosition(pageEl, container, offset) {
+  if (!container || !pageEl.contains(container)) return serializeEditor(pageEl).content.length;
   const pre = document.createRange();
   pre.selectNodeContents(pageEl);
-  pre.setEnd(range.startContainer, range.startOffset);
+  pre.setEnd(container, offset);
   const tmp = document.createElement("div");
   tmp.appendChild(pre.cloneContents());
   return serializeEditor(tmp).content.length;
+}
+
+// The serialized string offset of the collapsed selection within *pageEl*. A
+// selection outside the editor (e.g. focus on a button) resolves to end-of-doc.
+export function computeCaretOffset(pageEl) {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return serializeEditor(pageEl).content.length;
+  const range = sel.getRangeAt(0);
+  return offsetOfPosition(pageEl, range.startContainer, range.startOffset);
+}
+
+// A DOM Range spanning serialized offsets [start, end) — the inverse of
+// serialize, used to position the alternatives popup over a token. Walks text
+// nodes in document order (same pattern as setCaretOffset), so it is exact on the
+// DOM renderEditor produces. Offsets past the end clamp to end-of-doc.
+export function rangeForOffsets(pageEl, start, end) {
+  const range = document.createRange();
+  const walker = document.createTreeWalker(pageEl, NodeFilter.SHOW_TEXT);
+  let pos = 0;
+  let startSet = false;
+  let lastNode = null;
+  let node = walker.nextNode();
+  while (node) {
+    const len = node.data.length;
+    if (!startSet && start <= pos + len) {
+      range.setStart(node, start - pos);
+      startSet = true;
+    }
+    if (startSet && end <= pos + len) {
+      range.setEnd(node, end - pos);
+      return range;
+    }
+    pos += len;
+    lastNode = node;
+    node = walker.nextNode();
+  }
+  // start and/or end fell past the last text node → clamp to end-of-doc.
+  if (!startSet) range.selectNodeContents(pageEl);
+  if (lastNode) range.setEndAfter(lastNode);
+  else range.selectNodeContents(pageEl);
+  return range;
 }
 
 // True when the collapsed caret sits inside a .gen-text span, i.e. native typing

--- a/frontend/document_editor.js
+++ b/frontend/document_editor.js
@@ -249,6 +249,27 @@ export function installPlainTextGuards(pageEl) {
       insertPlainText(pageEl, e.data);
     }
   });
+  // Mobile IMEs commit via composition (insertCompositionText), which beforeinput
+  // can't cancel — the chars land tinted inside the gen-text span. Once the
+  // composition commits, lift the just-typed run back out as plain text (this is
+  // what desktop gets up-front from the beforeinput guard above).
+  pageEl.addEventListener("compositionend", (e) => {
+    const data = e.data;
+    if (!data || !caretInGenText(pageEl)) return;
+    const sel = window.getSelection();
+    const range = sel.getRangeAt(0);
+    const node = range.startContainer;
+    const end = range.startOffset;
+    const start = end - data.length;
+    // ponytail: only the common case — the commit is a plain trailing run in one
+    // text node. Anything fancier (multi-node, autocorrect replacement) bails.
+    if (node.nodeType !== Node.TEXT_NODE || start < 0 || node.data.slice(start, end) !== data) return;
+    range.setStart(node, start);
+    range.deleteContents(); // drop the tinted copy; range collapses to `start`
+    sel.removeAllRanges();
+    sel.addRange(range);
+    insertPlainText(pageEl, data); // re-insert plain + split span + fire input
+  });
 }
 
 // Inverse of computeCaretOffset: place a collapsed caret at serialized string

--- a/frontend/document_probs.js
+++ b/frontend/document_probs.js
@@ -1,0 +1,385 @@
+// Per-token alternatives side-store for Document mode (mikupad-style token
+// swapping). Session-only: token data lives here in a JS Map keyed by docId, NOT
+// in the document schema — MB-scale logprob payloads must not ride the 1.5s
+// autosave. S-free by construction (no imports from state.js); the popup half
+// gets its context injected at init to avoid an import cycle with document.js.
+//
+// A "run" is one contiguous stretch of generated text with per-token records:
+//   { start, end, tokens: [{ text, prob, top: [{ t, p }] }] }
+// where [start, end) are UTF-16 offsets into the document's current content
+// (kept aligned by remapRuns on every edit) and concatenating tokens' text
+// exactly tiles content.slice(start, end).
+//
+// document_editor.js is a pure leaf (it never imports this module), so importing
+// its offset helpers here introduces no cycle — unlike document.js, whose context
+// is injected at init instead.
+
+import { offsetOfPosition, rangeForOffsets, serializeEditor } from "./document_editor.js";
+
+// ── Pure helpers (plain data in/out; unit-testable, no DOM, no store) ─────────
+
+// Longest common prefix length of two strings.
+function _commonPrefix(a, b) {
+  const m = Math.min(a.length, b.length);
+  let i = 0;
+  while (i < m && a[i] === b[i]) i++;
+  return i;
+}
+
+// Longest common suffix length, capped so it never overlaps the given prefix.
+function _commonSuffix(a, b, prefix) {
+  const max = Math.min(a.length, b.length) - prefix;
+  let i = 0;
+  while (i < max && a[a.length - 1 - i] === b[b.length - 1 - i]) i++;
+  return i;
+}
+
+// Remap runs from *oldContent* coordinates to *newContent* after an edit,
+// localizing the change to a single prefix/suffix diff window (mikupad parity):
+// runs entirely before the window keep, entirely after shift by the length
+// delta, and any run overlapping the edited window is dropped (its token data is
+// no longer trustworthy). Never mutates the inputs.
+export function remapRuns(runs, oldContent, newContent) {
+  if (oldContent === newContent) return runs.map((r) => ({ ...r }));
+  const prefix = _commonPrefix(oldContent, newContent);
+  const suffix = _commonSuffix(oldContent, newContent, prefix);
+  const editStart = prefix; // first divergent index
+  const oldEditEnd = oldContent.length - suffix; // one past last divergent (old)
+  const delta = newContent.length - oldContent.length;
+  const out = [];
+  for (const run of runs) {
+    if (run.end <= editStart) {
+      out.push({ ...run }); // wholly before the edit
+    } else if (run.start >= oldEditEnd) {
+      out.push({ ...run, start: run.start + delta, end: run.end + delta }); // wholly after
+    }
+    // else: straddles the edit window → drop (touched tokens lose their data)
+  }
+  return out;
+}
+
+// The longest leading run of *tokens* whose concatenation is a prefix of *text*
+// (chat-mode reconciliation: deltas don't always tile 1:1 onto token records).
+// Stops at the first token that would diverge — a full mismatch returns [], so
+// commitRun discards and no popup appears; the text is never touched.
+export function trimTokensToText(tokens, text) {
+  const out = [];
+  let acc = "";
+  for (const tok of tokens) {
+    const next = acc + tok.text;
+    if (text.startsWith(next)) {
+      out.push(tok);
+      acc = next;
+    } else {
+      break;
+    }
+  }
+  return out;
+}
+
+// Which token of *run* covers absolute offset *offset*, by cumulative lengths.
+// Returns { index, tokStart, tokEnd } (half-open [tokStart, tokEnd)) or null when
+// the offset is at/after the run's last token boundary (a hover on the seam).
+export function tokenAtOffset(run, offset) {
+  let pos = run.start;
+  for (let i = 0; i < run.tokens.length; i++) {
+    const tokEnd = pos + run.tokens[i].text.length;
+    if (offset < tokEnd) return { index: i, tokStart: pos, tokEnd };
+    pos = tokEnd;
+  }
+  return null;
+}
+
+// Adjust generated-span offsets for a token swap that replaces the content in
+// [tokStart, runEnd) with text of length *insertLen*. Endpoints at or before
+// tokStart hold; at or after runEnd shift by the length delta; interior points
+// clamp to the swapped token's new end (so the swapped token stays tinted).
+export function spliceRunOffsets(spans, tokStart, runEnd, insertLen) {
+  const delta = insertLen - (runEnd - tokStart);
+  const adj = (x) => (x <= tokStart ? x : x >= runEnd ? x + delta : tokStart + insertLen);
+  return spans.map((s) => ({ start: adj(s.start), end: adj(s.end) }));
+}
+
+// Render whitespace-only tokens legibly in the popup: space→␣, tab→⇥, newline→↵.
+export function visualizeWhitespace(text) {
+  return text.replace(/ /g, "␣").replace(/\t/g, "⇥").replace(/\n/g, "↵");
+}
+
+// ── Session store ─────────────────────────────────────────────────────────────
+
+const _store = new Map(); // docId -> { lastContent: string|null, runs: Run[] }
+let _pending = null; // { docId, start, tokens } during an active generation
+const RUNS_CAP = 50; // most-recent runs kept per doc
+
+function _entry(docId) {
+  let e = _store.get(docId);
+  if (!e) {
+    e = { lastContent: null, runs: [] };
+    _store.set(docId, e);
+  }
+  return e;
+}
+
+// Start collecting the tokens of a new run at *startOffset* (the generation caret).
+export function beginRun(docId, startOffset) {
+  _pending = { docId, start: startOffset, tokens: [] };
+}
+
+// Append one streamed token record ({token, prob, top}) to the pending run.
+export function addToken(rec) {
+  if (!_pending || !rec || typeof rec.token !== "string") return;
+  _pending.tokens.push({
+    text: rec.token,
+    prob: typeof rec.prob === "number" ? rec.prob : 0,
+    top: Array.isArray(rec.top) ? rec.top : [],
+  });
+}
+
+// Discard the pending run (nothing generated / aborted before any token).
+export function clearPending() {
+  _pending = null;
+}
+
+// Finalize the pending run against the text that actually landed in the editor.
+// Trims to the exactly-tiling prefix; commits only if ≥1 token survives (else the
+// run is dropped — no popup, honest for chat mode where tiling can fail).
+export function commitRun(docId, finalText) {
+  const pending = _pending;
+  _pending = null;
+  if (!pending || pending.docId !== docId) return;
+  const tokens = trimTokensToText(pending.tokens, finalText);
+  if (!tokens.length) return;
+  let tiled = 0;
+  for (const t of tokens) tiled += t.text.length;
+  const run = { start: pending.start, end: pending.start + tiled, tokens };
+  const e = _entry(docId);
+  // A fresh run shouldn't overlap existing ones (syncContent shifted them first),
+  // but drop any overlap defensively, then insert sorted and cap to the newest.
+  e.runs = e.runs.filter((r) => r.end <= run.start || r.start >= run.end);
+  e.runs.push(run);
+  e.runs.sort((a, b) => a.start - b.start);
+  if (e.runs.length > RUNS_CAP) e.runs = e.runs.slice(e.runs.length - RUNS_CAP);
+}
+
+// Realign a doc's runs to *content* after it changed (edit, generation, undo).
+// Must be called with the NEW content before adding a run for that same change,
+// so a freshly committed run isn't shifted by its own edit's remap.
+export function syncContent(docId, content) {
+  const e = _entry(docId);
+  if (e.lastContent != null && e.lastContent !== content && e.runs.length) {
+    e.runs = remapRuns(e.runs, e.lastContent, content);
+  }
+  e.lastContent = content;
+}
+
+// Apply a token swap to the store (the mutation half of docSwapToken): replace
+// run.tokens[index] with the chosen alternative — keeping the token's ORIGINAL
+// top-N list so it can be swapped again — discard the tokens after it (mikupad
+// truncates the run tail, which is being regenerated), set the new run end, and
+// shift later runs by the content-length delta. Sets lastContent to *newContent*
+// so the runs are already aligned and a following syncContent won't re-remap them.
+export function swapRunToken(docId, run, index, alt, newContent) {
+  const e = _store.get(docId);
+  if (!e?.runs.includes(run) || index < 0 || index >= run.tokens.length) return;
+  let tokStart = run.start;
+  for (let i = 0; i < index; i++) tokStart += run.tokens[i].text.length;
+  const oldEnd = run.end;
+  const newEnd = tokStart + alt.t.length;
+  const delta = newEnd - oldEnd;
+  const origTop = run.tokens[index].top;
+  run.tokens = [...run.tokens.slice(0, index), { text: alt.t, prob: alt.p, top: origTop }];
+  run.end = newEnd;
+  for (const r of e.runs) {
+    if (r !== run && r.start >= oldEnd) {
+      r.start += delta;
+      r.end += delta;
+    }
+  }
+  e.lastContent = newContent;
+}
+
+// The run covering *offset*, or null. Validate-on-use: the run's tokens must
+// still exactly tile the current content slice; a run that fails (content edited
+// without a clean remap) is dropped and null returned, so stale data never shows.
+export function runAt(docId, offset, content) {
+  const e = _store.get(docId);
+  if (!e) return null;
+  for (const run of e.runs) {
+    if (offset >= run.start && offset < run.end) {
+      let concat = "";
+      for (const t of run.tokens) concat += t.text;
+      if (content.slice(run.start, run.end) === concat) return run;
+      e.runs = e.runs.filter((r) => r !== run);
+      return null;
+    }
+  }
+  return null;
+}
+
+// ── Popup: hover a generated token → alternatives, click to swap ──────────────
+//
+// No per-token DOM nodes — the content model stays text-nodes-and-spans. We
+// hit-test the pointer to a caret position, resolve it to a token via the store,
+// and float a fixed popup over the token measured with rangeForOffsets. Context
+// (getDocId / isStreaming / requestSwap) is injected so this stays S-free.
+
+const HOVER_DELAY = 300; // debounce; logprobs steering is deliberate, not twitchy
+const HIDE_GRACE = 120; // let the pointer travel from token to popup without closing
+
+let _ctx = null;
+let _page = null;
+let _popup = null;
+let _hoverTimer = null;
+let _hideTimer = null;
+let _shownFor = null; // { run, index } — dedupe re-renders of the same token
+
+// Wire the popup once (from initDocumentMode). *ctx* = { getDocId, isStreaming,
+// requestSwap }. Silently a no-op when the popup element is absent or neither
+// caret-from-point API exists (feature degrades to nothing).
+export function initDocProbs(page, ctx) {
+  _page = page;
+  _ctx = ctx;
+  _popup = document.getElementById("doc-prob-popup");
+  if (!_popup) return;
+  const canHover = window.matchMedia("(hover: hover)");
+
+  page.addEventListener("mousemove", (e) => {
+    if (!_ctx || _ctx.isStreaming() || !canHover.matches) return;
+    if (!e.target.closest?.(".gen-text")) {
+      scheduleHide();
+      return;
+    }
+    clearTimeout(_hideTimer); // back over generated text → cancel a pending hide
+    const x = e.clientX;
+    const y = e.clientY;
+    clearTimeout(_hoverTimer);
+    _hoverTimer = setTimeout(() => _tryShow(x, y), HOVER_DELAY);
+  });
+  page.addEventListener("mouseleave", scheduleHide);
+  _popup.addEventListener("mouseenter", () => clearTimeout(_hideTimer));
+  _popup.addEventListener("mouseleave", scheduleHide);
+
+  document.getElementById("doc-editor-scroll")?.addEventListener("scroll", hideProbPopup, { passive: true });
+  document.addEventListener("mousedown", (e) => {
+    if (_popup && !_popup.classList.contains("hidden") && !_popup.contains(e.target)) hideProbPopup();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") hideProbPopup();
+  });
+}
+
+// Public: hide + reset (called on generation start and doc switch by document.js).
+export function hideProbPopup() {
+  clearTimeout(_hoverTimer);
+  clearTimeout(_hideTimer);
+  if (_popup) _popup.classList.add("hidden");
+  _shownFor = null;
+}
+
+function scheduleHide() {
+  clearTimeout(_hoverTimer);
+  clearTimeout(_hideTimer);
+  _hideTimer = setTimeout(hideProbPopup, HIDE_GRACE);
+}
+
+// Pointer → caret DOM position, across the Firefox/Chromium API split. Returns
+// { node, offset } inside the editor, or null (also when neither API is present).
+function _hitTest(x, y) {
+  let node = null;
+  let offset = 0;
+  if (document.caretPositionFromPoint) {
+    const pos = document.caretPositionFromPoint(x, y);
+    if (!pos) return null;
+    node = pos.offsetNode;
+    offset = pos.offset;
+  } else if (document.caretRangeFromPoint) {
+    const r = document.caretRangeFromPoint(x, y);
+    if (!r) return null;
+    node = r.startContainer;
+    offset = r.startOffset;
+  } else {
+    return null;
+  }
+  if (!node || !_page.contains(node)) return null;
+  return { node, offset };
+}
+
+function _tryShow(x, y) {
+  if (!_ctx || _ctx.isStreaming()) return;
+  const docId = _ctx.getDocId();
+  if (!docId) return;
+  const hit = _hitTest(x, y);
+  if (!hit) {
+    hideProbPopup();
+    return;
+  }
+  const content = serializeEditor(_page).content;
+  const offset = offsetOfPosition(_page, hit.node, hit.offset);
+  const run = runAt(docId, offset, content);
+  if (!run) {
+    hideProbPopup();
+    return;
+  }
+  const at = tokenAtOffset(run, offset);
+  if (!at) {
+    hideProbPopup();
+    return;
+  }
+  if (_shownFor && _shownFor.run === run && _shownFor.index === at.index) {
+    clearTimeout(_hideTimer); // same token → keep it up, no rebuild
+    return;
+  }
+  _render(run, at);
+}
+
+// Alternatives sorted desc by prob, with the sampled token guaranteed present
+// (prepended when it fell outside the returned top-N).
+function _sortedAlts(token) {
+  const alts = (token.top || []).slice().sort((a, b) => b.p - a.p);
+  if (!alts.some((a) => a.t === token.text)) alts.unshift({ t: token.text, p: token.prob });
+  return alts;
+}
+
+function _render(run, at) {
+  const token = run.tokens[at.index];
+  _popup.textContent = ""; // token text is arbitrary → build via DOM, never innerHTML
+  let currentMarked = false;
+  for (const alt of _sortedAlts(token)) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "prob-alt";
+    if (!currentMarked && alt.t === token.text) {
+      btn.classList.add("current");
+      currentMarked = true;
+    }
+    const tokSpan = document.createElement("span");
+    tokSpan.className = "prob-tok";
+    tokSpan.textContent = visualizeWhitespace(alt.t);
+    const pctSpan = document.createElement("span");
+    pctSpan.className = "prob-pct";
+    pctSpan.textContent = `${(alt.p * 100).toFixed(2)}%`;
+    btn.append(tokSpan, pctSpan);
+    btn.addEventListener("click", () => _ctx.requestSwap?.(run, at.index, alt));
+    _popup.appendChild(btn);
+  }
+  _position(at);
+  _shownFor = { run, index: at.index };
+}
+
+// Float the popup above the token (fixed positioning → viewport coords), flipping
+// below and clamping to the viewport when there isn't room.
+function _position(at) {
+  const rect = rangeForOffsets(_page, at.tokStart, at.tokEnd).getBoundingClientRect();
+  _popup.style.visibility = "hidden";
+  _popup.classList.remove("hidden"); // measure with layout applied
+  const pw = _popup.offsetWidth;
+  const ph = _popup.offsetHeight;
+  let top = rect.top - ph - 6;
+  if (top < 4) top = rect.bottom + 6; // no room above → below the token
+  let left = rect.left;
+  left = Math.max(4, Math.min(left, window.innerWidth - pw - 4));
+  top = Math.max(4, Math.min(top, window.innerHeight - ph - 4));
+  _popup.style.left = `${left}px`;
+  _popup.style.top = `${top}px`;
+  _popup.style.visibility = "";
+}

--- a/frontend/document_probs.js
+++ b/frontend/document_probs.js
@@ -8,7 +8,9 @@
 //   { start, end, tokens: [{ text, prob, top: [{ t, p }] }] }
 // where [start, end) are UTF-16 offsets into the document's current content
 // (kept aligned by remapRuns on every edit) and concatenating tokens' text
-// exactly tiles content.slice(start, end).
+// exactly tiles content.slice(start, end). One generation can commit several
+// runs: servers may send probs for only some tokens (llama.cpp speculative
+// decoding skips draft-accepted ones), and each covered stretch is a run.
 //
 // document_editor.js is a pure leaf (it never imports this module), so importing
 // its offset helpers here introduces no cycle — unlike document.js, whose context
@@ -58,23 +60,29 @@ export function remapRuns(runs, oldContent, newContent) {
   return out;
 }
 
-// The longest leading run of *tokens* whose concatenation is a prefix of *text*
-// (chat-mode reconciliation: deltas don't always tile 1:1 onto token records).
-// Stops at the first token that would diverge — a full mismatch returns [], so
-// commitRun discards and no popup appears; the text is never touched.
-export function trimTokensToText(tokens, text) {
-  const out = [];
-  let acc = "";
+// Group position-carrying token records ({ text, start, … }) into contiguous
+// segments that exactly tile *text* — probs coverage can have gaps (llama.cpp
+// speculative decoding omits probs for draft-accepted tokens), so one generation
+// may yield several covered stretches, each committed as its own run. A token
+// whose text no longer matches *text* at its recorded start (chat-mode deltas
+// that don't tile 1:1, abort truncation) is dropped and splits the segment.
+export function segmentTokens(tokens, text) {
+  const segs = [];
+  let cur = null;
   for (const tok of tokens) {
-    const next = acc + tok.text;
-    if (text.startsWith(next)) {
-      out.push(tok);
-      acc = next;
+    if (text.slice(tok.start, tok.start + tok.text.length) !== tok.text) {
+      cur = null;
+      continue;
+    }
+    if (cur && tok.start === cur.start + cur.len) {
+      cur.tokens.push(tok);
+      cur.len += tok.text.length;
     } else {
-      break;
+      cur = { start: tok.start, len: tok.text.length, tokens: [tok] };
+      segs.push(cur);
     }
   }
-  return out;
+  return segs;
 }
 
 // Which token of *run* covers absolute offset *offset*, by cumulative lengths.
@@ -88,16 +96,6 @@ export function tokenAtOffset(run, offset) {
     pos = tokEnd;
   }
   return null;
-}
-
-// Adjust generated-span offsets for a token swap that replaces the content in
-// [tokStart, runEnd) with text of length *insertLen*. Endpoints at or before
-// tokStart hold; at or after runEnd shift by the length delta; interior points
-// clamp to the swapped token's new end (so the swapped token stays tinted).
-export function spliceRunOffsets(spans, tokStart, runEnd, insertLen) {
-  const delta = insertLen - (runEnd - tokStart);
-  const adj = (x) => (x <= tokStart ? x : x >= runEnd ? x + delta : tokStart + insertLen);
-  return spans.map((s) => ({ start: adj(s.start), end: adj(s.end) }));
 }
 
 // Render whitespace-only tokens legibly in the popup: space→␣, tab→⇥, newline→↵.
@@ -122,17 +120,32 @@ function _entry(docId) {
 
 // Start collecting the tokens of a new run at *startOffset* (the generation caret).
 export function beginRun(docId, startOffset) {
-  _pending = { docId, start: startOffset, tokens: [] };
+  _pending = { docId, start: startOffset, tokens: [], text: "", chunkPos: 0 };
 }
 
-// Append one streamed token record ({token, prob, top}) to the pending run.
+// Record one streamed content delta. The route emits a chunk's content before its
+// probs records, so the delta's start is where that chunk's tokens begin — this
+// is what positions probs records even when earlier chunks carried none.
+export function addDelta(delta) {
+  if (!_pending || typeof delta !== "string") return;
+  _pending.chunkPos = _pending.text.length;
+  _pending.text += delta;
+}
+
+// Append one streamed token record ({token, prob, top}) to the pending run,
+// anchored at the current chunk position. A record that doesn't match the
+// streamed text there (reasoning tokens, provider drift) is dropped.
 export function addToken(rec) {
   if (!_pending || !rec || typeof rec.token !== "string") return;
+  const start = _pending.chunkPos;
+  if (_pending.text.slice(start, start + rec.token.length) !== rec.token) return;
   _pending.tokens.push({
     text: rec.token,
     prob: typeof rec.prob === "number" ? rec.prob : 0,
     top: Array.isArray(rec.top) ? rec.top : [],
+    start,
   });
+  _pending.chunkPos = start + rec.token.length;
 }
 
 // Discard the pending run (nothing generated / aborted before any token).
@@ -140,23 +153,27 @@ export function clearPending() {
   _pending = null;
 }
 
-// Finalize the pending run against the text that actually landed in the editor.
-// Trims to the exactly-tiling prefix; commits only if ≥1 token survives (else the
-// run is dropped — no popup, honest for chat mode where tiling can fail).
+// Finalize the pending tokens against the text that actually landed in the
+// editor: each contiguous covered stretch becomes its own run (probs coverage
+// can be gappy — see segmentTokens); zero surviving tokens → nothing committed.
 export function commitRun(docId, finalText) {
   const pending = _pending;
   _pending = null;
   if (!pending || pending.docId !== docId) return;
-  const tokens = trimTokensToText(pending.tokens, finalText);
-  if (!tokens.length) return;
-  let tiled = 0;
-  for (const t of tokens) tiled += t.text.length;
-  const run = { start: pending.start, end: pending.start + tiled, tokens };
+  const segs = segmentTokens(pending.tokens, finalText);
+  if (!segs.length) return;
   const e = _entry(docId);
-  // A fresh run shouldn't overlap existing ones (syncContent shifted them first),
-  // but drop any overlap defensively, then insert sorted and cap to the newest.
-  e.runs = e.runs.filter((r) => r.end <= run.start || r.start >= run.end);
-  e.runs.push(run);
+  for (const seg of segs) {
+    const run = {
+      start: pending.start + seg.start,
+      end: pending.start + seg.start + seg.len,
+      tokens: seg.tokens.map(({ text, prob, top }) => ({ text, prob, top })),
+    };
+    // Fresh runs shouldn't overlap existing ones (syncContent shifted them
+    // first), but drop any overlap defensively.
+    e.runs = e.runs.filter((r) => r.end <= run.start || r.start >= run.end);
+    e.runs.push(run);
+  }
   e.runs.sort((a, b) => a.start - b.start);
   if (e.runs.length > RUNS_CAP) e.runs = e.runs.slice(e.runs.length - RUNS_CAP);
 }
@@ -174,27 +191,19 @@ export function syncContent(docId, content) {
 
 // Apply a token swap to the store (the mutation half of docSwapToken): replace
 // run.tokens[index] with the chosen alternative — keeping the token's ORIGINAL
-// top-N list so it can be swapped again — discard the tokens after it (mikupad
-// truncates the run tail, which is being regenerated), set the new run end, and
-// shift later runs by the content-length delta. Sets lastContent to *newContent*
-// so the runs are already aligned and a following syncContent won't re-remap them.
+// top-N list so it can be swapped again — and discard everything after it: the
+// run's own tail tokens AND all later runs, since the document is truncated at
+// the swap point (mikupad semantics). Sets lastContent to *newContent* so the
+// runs are already aligned and a following syncContent won't re-remap them.
 export function swapRunToken(docId, run, index, alt, newContent) {
   const e = _store.get(docId);
   if (!e?.runs.includes(run) || index < 0 || index >= run.tokens.length) return;
   let tokStart = run.start;
   for (let i = 0; i < index; i++) tokStart += run.tokens[i].text.length;
-  const oldEnd = run.end;
-  const newEnd = tokStart + alt.t.length;
-  const delta = newEnd - oldEnd;
   const origTop = run.tokens[index].top;
   run.tokens = [...run.tokens.slice(0, index), { text: alt.t, prob: alt.p, top: origTop }];
-  run.end = newEnd;
-  for (const r of e.runs) {
-    if (r !== run && r.start >= oldEnd) {
-      r.start += delta;
-      r.end += delta;
-    }
-  }
+  run.end = tokStart + alt.t.length;
+  e.runs = e.runs.filter((r) => r === run || r.end <= run.start);
   e.lastContent = newContent;
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -185,6 +185,7 @@ Write a haiku about the sea.&lt;|im_end|&gt;
           <button type="button" class="doc-mode-opt active" id="doc-mode-raw" onclick="setDocAssisted(false)" title="Raw: send the document verbatim — you type any chat-template tokens">Raw</button>
           <button type="button" class="doc-mode-opt" id="doc-mode-assisted" onclick="setDocAssisted(true)" title="Assisted: write ### SYSTEM / ### USER notes and the model's chat template is applied for you">Assisted</button>
         </div>
+        <button type="button" class="doc-probs-toggle" id="doc-probs-btn" onclick="setDocProbs(!this.classList.contains('active'))" title="Capture per-token alternatives (may slow local generation)">Probs</button>
         <span id="doc-gen-status" class="doc-gen-status hidden">Generating…</span>
       </div>
       <div class="doc-footer-actions">
@@ -193,6 +194,7 @@ Write a haiku about the sea.&lt;|im_end|&gt;
         <button class="btn btn-sm hidden" id="doc-stop-btn" onclick="docStop()" title="Stop (Esc)">■ Stop</button>
       </div>
     </div>
+    <div id="doc-prob-popup" class="hidden"></div>
   </div>
   <div id="tools-panel"><div class="tools-inner">
     <div class="inspector-title">Workflows</div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content">
 <title>Orb</title>
 <link rel="stylesheet" href="/static/fonts.css">
 <link id="theme-link" rel="stylesheet" href="/static/themes/dark.css">
@@ -186,7 +186,6 @@ Write a haiku about the sea.&lt;|im_end|&gt;
           <button type="button" class="doc-mode-opt" id="doc-mode-assisted" onclick="setDocAssisted(true)" title="Assisted: write ### SYSTEM / ### USER notes and the model's chat template is applied for you">Assisted</button>
         </div>
         <button type="button" class="doc-probs-toggle" id="doc-probs-btn" onclick="setDocProbs(!this.classList.contains('active'))" title="Capture per-token alternatives (may slow local generation)">Probs</button>
-        <span id="doc-gen-status" class="doc-gen-status hidden">Generating…</span>
       </div>
       <div class="doc-footer-actions">
         <button class="btn btn-sm" id="doc-undo-btn" onclick="docUndo()" disabled title="Undo (Ctrl+Z)">↶ Undo</button>

--- a/frontend/mobile.js
+++ b/frontend/mobile.js
@@ -295,11 +295,32 @@ function bindViewportListener(handler) {
   MOBILE_VIEWPORT.addListener(handler);
 }
 
+// Mobile keyboards shrink the visual viewport but leave 100vh at full height, so
+// the footer buttons get stranded under the keyboard. Mirror the visible height
+// into --app-height (the shell keys off it) so the app shrinks to fit instead.
+// ponytail: assumes the viewport top stays at 0 (bottom-docked keyboard).
+function trackVisualViewport() {
+  const vv = window.visualViewport;
+  if (!vv) return;
+  const apply = () => {
+    const root = document.documentElement.style;
+    root.setProperty("--app-height", `${Math.round(vv.height)}px`);
+    // Browsers that don't resize the layout viewport (iOS Safari; Chrome without
+    // interactive-widget support) pan it instead — offsetTop shifts the visible
+    // window down and the shrunken app slides off-screen. Pull it back in line.
+    root.setProperty("--app-offset", `${Math.round(vv.offsetTop)}px`);
+  };
+  apply();
+  vv.addEventListener("resize", apply);
+  vv.addEventListener("scroll", apply); // offsetTop changes fire scroll, not resize
+}
+
 // ── Init
 export function initMobileUi(deps) {
   if (_initialized) return;
   _initialized = true;
   _closeBurger = deps.closeBurger;
+  trackVisualViewport();
 
   document.addEventListener("click", handleDocumentClick);
   window.addEventListener("keydown", handleEscape);

--- a/tests/integration/_llm_mock.py
+++ b/tests/integration/_llm_mock.py
@@ -129,8 +129,9 @@ class FakeLLMClient:
         }
         # Raw text-completion queue (complete_raw, document text mode) — separate
         # from the tool_choice-dispatched chat queues above; keyed by the call,
-        # not by a pass. capture prompt+params for assertions.
-        self._raw_queue: list[str] = []
+        # not by a pass. capture prompt+params for assertions. Each entry is
+        # {"content": str, "probs": list} so a test can attach per-token probs.
+        self._raw_queue: list[dict] = []
         self.raw_calls: list[dict] = []
         self.completion_mode = "chat"
         self._gates: dict[str, list[PassGate]] = {
@@ -169,8 +170,11 @@ class FakeLLMClient:
         _validate_tool_calls(tool_calls)
         self._queues["director"].append({"tool_calls": tool_calls})
 
-    def enqueue_writer(self, text: str) -> None:
-        self._queues["writer"].append({"content": text})
+    def enqueue_writer(self, text: str, probs: list[dict] | None = None) -> None:
+        # Optional *probs* is a list of normalized token-prob records
+        # ({"token","prob","top":[{"t","p"}]}); the mock interleaves them as
+        # token_probs chunks after the content delta (chat doc path with logprobs).
+        self._queues["writer"].append({"content": text, "probs": probs or []})
 
     def enqueue_editor(self, decision: dict | None = None) -> None:
         """Queue an editor response. ``decision`` is the ``message`` dict
@@ -195,9 +199,14 @@ class FakeLLMClient:
     def enqueue_workflow(self, message: dict) -> None:
         self._queues["workflow"].append({"message": message})
 
-    def enqueue_raw(self, text: str) -> None:
-        """Queue a raw text-completion response (``complete_raw``, doc text mode)."""
-        self._raw_queue.append(text)
+    def enqueue_raw(self, text: str, probs: list[dict] | None = None) -> None:
+        """Queue a raw text-completion response (``complete_raw``, doc text mode).
+
+        Optional *probs* is a list of normalized token-prob records
+        (``{"token","prob","top":[{"t","p"}]}``); when given the mock interleaves
+        them as token_probs chunks after the content delta (mirrors the real
+        client when n_probs is requested)."""
+        self._raw_queue.append({"content": text, "probs": probs or []})
 
     def gate(self, pass_name: str) -> PassGate:
         """Return a ``PassGate`` controlling the next *pass_name* call.
@@ -257,6 +266,11 @@ class FakeLLMClient:
             text = payload.get("content", "")
             if text:
                 yield {"type": "content", "delta": text}
+            # Faithful to a real provider: probs come back only when logprobs
+            # were requested (the token_probs flag threads through to params).
+            if params.get("logprobs"):
+                for rec in payload.get("probs") or []:
+                    yield {"type": "token_probs", **rec}
             yield {"type": "done", "message": {"role": "assistant", "content": text}}
             return
 
@@ -310,9 +324,14 @@ class FakeLLMClient:
         self.raw_calls.append({"prompt": prompt, "model": model, "params": params})
         if self.abort_token.is_aborted:
             return
-        text = self._raw_queue.pop(0) if self._raw_queue else ""
+        payload = self._raw_queue.pop(0) if self._raw_queue else {"content": "", "probs": []}
+        text = payload["content"]
         if text:
             yield {"type": "content", "delta": text}
+        # llama.cpp returns completion_probabilities only when n_probs is set.
+        if params.get("n_probs"):
+            for rec in payload.get("probs") or []:
+                yield {"type": "token_probs", **rec}
         yield {"type": "done", "message": {"content": text}, "usage": None}
 
 

--- a/tests/integration/test_documents.py
+++ b/tests/integration/test_documents.py
@@ -8,6 +8,8 @@ tests use ``enqueue_writer``; only text-mode tests use ``enqueue_raw``.
 
 from __future__ import annotations
 
+import json
+
 from backend.features.documents import DOC_ASSIST_CONTINUE, DOC_ASSIST_INSTRUCTION
 
 
@@ -185,3 +187,65 @@ async def test_stop_with_and_without_active_token(client):
     did = (await client.post("/api/documents", json={})).json()["id"]
     # no active generation → still a clean 200
     assert (await client.post("/api/documents/" + did + "/stop")).json() == {"ok": True}
+
+
+# ── token_probs wire: `event: probs` frames ───────────────────────────────────
+
+# Mock token records live on a separate channel from the text; keep their token
+# strings newline-free so the test-only _parse_sse (which unescapes \n on every
+# frame, unlike the real reader) doesn't corrupt the probs JSON.
+_PROBS = [{"token": " Paris", "prob": 0.86, "top": [{"t": " Paris", "p": 0.86}, {"t": " Lyon", "p": 0.1}]}]
+
+
+async def test_generate_text_mode_probs_frames(client, llm_mock):
+    await _activate_text_endpoint(client)
+    did = (await client.post("/api/documents", json={})).json()["id"]
+    llm_mock.enqueue_raw(" Paris", probs=_PROBS)
+
+    r = await client.post(
+        "/api/documents/" + did + "/generate",
+        json={"prompt": "The capital of France is", "token_probs": True},
+    )
+    assert r.status_code == 200
+    events = _parse_sse(r.text)
+
+    # token frame is byte-identical to the no-probs wire.
+    assert events[0] == {"event": "token", "data": " Paris"}
+    # a probs frame follows, JSON-decoding to the normalized shape.
+    probs = [json.loads(e["data"]) for e in events if e["event"] == "probs"]
+    assert probs == _PROBS
+    assert events[-1]["event"] == "done"
+    # n_probs threaded into the /completion request.
+    assert llm_mock.raw_calls[-1]["params"]["n_probs"] == 10
+
+
+async def test_generate_chat_mode_probs_frames(client, llm_mock):
+    did = (await client.post("/api/documents", json={})).json()["id"]
+    llm_mock.enqueue_writer(" Paris", probs=_PROBS)
+
+    r = await client.post(
+        "/api/documents/" + did + "/generate",
+        json={"prompt": "The capital of France is", "token_probs": True},
+    )
+    assert r.status_code == 200
+    events = _parse_sse(r.text)
+    assert events[0] == {"event": "token", "data": " Paris"}
+    probs = [json.loads(e["data"]) for e in events if e["event"] == "probs"]
+    assert probs == _PROBS
+    # logprobs threaded into the chat request.
+    assert llm_mock.captured[-1]["params"]["logprobs"] is True
+    assert llm_mock.captured[-1]["params"]["top_logprobs"] == 5
+
+
+async def test_generate_no_probs_frames_when_flag_unset(client, llm_mock):
+    # Probs enqueued, but token_probs omitted → the continuer sends no n_probs, so
+    # the mock (like a real server) returns none; the wire carries only tokens.
+    await _activate_text_endpoint(client)
+    did = (await client.post("/api/documents", json={})).json()["id"]
+    llm_mock.enqueue_raw(" Paris", probs=_PROBS)
+
+    r = await client.post("/api/documents/" + did + "/generate", json={"prompt": "x"})
+    assert r.status_code == 200
+    events = _parse_sse(r.text)
+    assert not any(e["event"] == "probs" for e in events)
+    assert "n_probs" not in llm_mock.raw_calls[-1]["params"]

--- a/tests/unit/test_complete_raw.py
+++ b/tests/unit/test_complete_raw.py
@@ -67,3 +67,76 @@ async def test_complete_raw_streams_content_deltas_no_think_split():
     content = "".join(e["delta"] for e in events if e["type"] == "content")
     assert content == "<think>not reasoning</think> tail"
     assert events[-1]["message"]["content"] == content
+
+
+async def test_complete_raw_body_carries_n_probs_when_passed():
+    client = _client()
+    captured: dict = {}
+
+    async def fake_stream(url, body):
+        captured["body"] = body
+        yield {"content": "x", "stop": True, "tokens_evaluated": 1, "tokens_predicted": 1, "timings": {"prompt_n": 1}}
+
+    client._stream_completion = fake_stream  # type: ignore[method-assign]
+
+    await _drain(client.complete_raw("p", "m", n_probs=10))
+    assert captured["body"]["n_probs"] == 10
+    assert captured["body"]["post_sampling_probs"] is True
+
+
+async def test_complete_raw_body_omits_n_probs_when_absent():
+    client = _client()
+    captured: dict = {}
+
+    async def fake_stream(url, body):
+        captured["body"] = body
+        yield {"content": "x", "stop": True, "tokens_evaluated": 1, "tokens_predicted": 1, "timings": {"prompt_n": 1}}
+
+    client._stream_completion = fake_stream  # type: ignore[method-assign]
+
+    await _drain(client.complete_raw("p", "m"))
+    assert "n_probs" not in captured["body"]
+    assert "post_sampling_probs" not in captured["body"]
+
+
+async def test_complete_raw_interleaves_token_probs_chunks():
+    client = _client()
+
+    async def fake_stream(url, body):
+        yield {
+            "content": " Paris",
+            "stop": False,
+            "completion_probabilities": [
+                {
+                    "token": " Paris",
+                    "prob": 0.86,
+                    "top_probs": [{"token": " Paris", "prob": 0.86}, {"token": " own", "prob": 0.1}],
+                }
+            ],
+        }
+        yield {"content": "", "stop": True, "tokens_evaluated": 1, "tokens_predicted": 1, "timings": {"prompt_n": 1}}
+
+    client._stream_completion = fake_stream  # type: ignore[method-assign]
+
+    events = await _drain(client.complete_raw("p", "m", n_probs=10))
+    # content delta precedes its token_probs frame; the frame carries the normalized shape.
+    types = [e["type"] for e in events]
+    assert types[0] == "content" and types[1] == "token_probs"
+    probs = [e for e in events if e["type"] == "token_probs"]
+    assert probs == [
+        {"type": "token_probs", "token": " Paris", "prob": 0.86, "top": [{"t": " Paris", "p": 0.86}, {"t": " own", "p": 0.1}]}
+    ]
+
+
+async def test_complete_raw_no_token_probs_when_server_omits_them():
+    client = _client()
+
+    async def fake_stream(url, body):
+        # Server ignored n_probs (old build) → no completion_probabilities field.
+        yield {"content": "hi", "stop": False}
+        yield {"content": "", "stop": True, "tokens_evaluated": 1, "tokens_predicted": 1, "timings": {"prompt_n": 1}}
+
+    client._stream_completion = fake_stream  # type: ignore[method-assign]
+
+    events = await _drain(client.complete_raw("p", "m", n_probs=10))
+    assert not any(e["type"] == "token_probs" for e in events)

--- a/tests/unit/test_document_continuation.py
+++ b/tests/unit/test_document_continuation.py
@@ -29,16 +29,26 @@ class _StubClient:
         self.chat_calls.append({"messages": messages, "model": model, "params": params})
         yield {"type": "reasoning", "delta": "thinking..."}
         yield {"type": "content", "delta": "chat-out"}
+        # Real clients emit token_probs only when logprobs were requested.
+        if params.get("logprobs"):
+            yield {"type": "token_probs", "token": "chat-out", "prob": 0.9, "top": [{"t": "chat-out", "p": 0.9}]}
         yield {"type": "done", "message": {"content": "chat-out"}}
 
     async def complete_raw(self, prompt, model, **params):
         self.raw_calls.append({"prompt": prompt, "model": model, "params": params})
         yield {"type": "content", "delta": "raw-out"}
+        if params.get("n_probs"):
+            yield {"type": "token_probs", "token": "raw-out", "prob": 0.8, "top": [{"t": "raw-out", "p": 0.8}]}
         yield {"type": "done", "message": {"content": "raw-out"}}
 
 
 async def _drain(agen):
     return [x async for x in agen]
+
+
+def _deltas(chunks):
+    """Content deltas from the dict chunks stream now yields."""
+    return [c["delta"] for c in chunks if c["type"] == "content"]
 
 
 def _assert_alternates(messages, prefill):
@@ -234,7 +244,7 @@ async def test_chat_path_builds_system_user_and_suppresses_thinking():
     cont = DocumentContinuer(client, {"temperature": 0.9, "max_tokens": 100})
     out = await _drain(cont.stream("the prefix", "m"))
 
-    assert out == ["chat-out"]  # reasoning delta dropped
+    assert _deltas(out) == ["chat-out"]  # reasoning delta dropped
     call = client.chat_calls[0]
     assert call["messages"] == [
         {"role": "system", "content": DOC_CHAT_INSTRUCTION},
@@ -251,7 +261,7 @@ async def test_text_path_calls_complete_raw_with_verbatim_prompt():
     cont = DocumentContinuer(client, {})
     out = await _drain(cont.stream("continue me", "m"))
 
-    assert out == ["raw-out"]
+    assert _deltas(out) == ["raw-out"]
     assert client.raw_calls[0]["prompt"] == "continue me"
     # unset max_tokens defaults to 512 (guards n_predict=-1 runaway).
     assert client.raw_calls[0]["params"]["max_tokens"] == 512
@@ -264,7 +274,7 @@ async def test_text_assisted_calls_complete_with_parsed_messages_and_prefill():
     text = "### USER: be vivid\nThe old lighthouse"
     out = await _drain(cont.stream(text, "m", assisted=True))
 
-    assert out == ["chat-out"]  # reasoning delta dropped
+    assert _deltas(out) == ["chat-out"]  # reasoning delta dropped
     assert not client.raw_calls  # assisted goes through complete(), not complete_raw
     call = client.chat_calls[0]
     assert call["messages"] == [
@@ -282,7 +292,7 @@ async def test_text_assisted_trailing_note_passes_none_prefill():
     cont = DocumentContinuer(client, {})
     out = await _drain(cont.stream("prose\n### USER: write the ending", "m", assisted=True))
 
-    assert out == ["chat-out"]
+    assert _deltas(out) == ["chat-out"]
     call = client.chat_calls[0]
     # prefill=None → client falls through to the generation-prompt branch;
     # reasoning kwargs still sent (load-bearing for the trailing-note case).
@@ -296,7 +306,7 @@ async def test_chat_assisted_closes_prefill_and_appends_reanchor_turn():
     cont = DocumentContinuer(client, {})
     out = await _drain(cont.stream("### USER: be brief\nThe story so far", "m", assisted=True))
 
-    assert out == ["chat-out"]
+    assert _deltas(out) == ["chat-out"]
     call = client.chat_calls[0]
     # Chat transport can't hold an open prefill: close it + re-anchor with a user turn.
     assert call["messages"] == [
@@ -319,3 +329,62 @@ async def test_chat_assisted_trailing_note_sends_messages_as_is():
     # prefill is None → no closed-prefill/re-anchor turns; messages end on the note.
     assert call["messages"][-1] == {"role": "user", "content": "wrap it up"}
     assert not any(m["content"] == DOC_ASSIST_CONTINUE for m in call["messages"])
+
+
+# ── token_probs flag: per-branch request params + chunk forwarding ────────────
+
+
+async def test_token_probs_off_by_default_sends_no_prob_params():
+    # Every branch: neither n_probs nor logprobs when the flag is unset.
+    for mode, assisted in [("text", False), ("text", True), ("chat", False), ("chat", True)]:
+        client = _StubClient(mode)
+        cont = DocumentContinuer(client, {})
+        out = await _drain(cont.stream("### USER: go\nsome prose", "m", assisted=assisted))
+        params = (client.raw_calls or client.chat_calls)[0]["params"]
+        assert "n_probs" not in params, (mode, assisted)
+        assert "logprobs" not in params, (mode, assisted)
+        assert "top_logprobs" not in params, (mode, assisted)
+        assert not any(c["type"] == "token_probs" for c in out), (mode, assisted)
+
+
+async def test_text_raw_token_probs_adds_n_probs_and_forwards_chunks():
+    client = _StubClient("text")
+    cont = DocumentContinuer(client, {})
+    out = await _drain(cont.stream("continue me", "m", token_probs=True))
+
+    assert client.raw_calls[0]["params"]["n_probs"] == 10  # _N_PROBS_TEXT
+    # The token_probs chunk is forwarded unchanged; content still flows.
+    assert _deltas(out) == ["raw-out"]
+    probs = [c for c in out if c["type"] == "token_probs"]
+    assert probs == [{"type": "token_probs", "token": "raw-out", "prob": 0.8, "top": [{"t": "raw-out", "p": 0.8}]}]
+
+
+async def test_text_assisted_token_probs_adds_n_probs():
+    client = _StubClient("text")
+    cont = DocumentContinuer(client, {})
+    await _drain(cont.stream("### USER: be vivid\nThe old lighthouse", "m", assisted=True, token_probs=True))
+    # Assisted text uses complete(), still on the llama.cpp transport → n_probs.
+    assert client.chat_calls[0]["params"]["n_probs"] == 10
+    assert "logprobs" not in client.chat_calls[0]["params"]
+
+
+async def test_chat_raw_token_probs_adds_logprobs_and_top_logprobs():
+    client = _StubClient("chat")
+    cont = DocumentContinuer(client, {})
+    out = await _drain(cont.stream("the prefix", "m", token_probs=True))
+
+    params = client.chat_calls[0]["params"]
+    assert params["logprobs"] is True
+    assert params["top_logprobs"] == 5  # _TOP_LOGPROBS_CHAT
+    assert "n_probs" not in params
+    probs = [c for c in out if c["type"] == "token_probs"]
+    assert probs == [{"type": "token_probs", "token": "chat-out", "prob": 0.9, "top": [{"t": "chat-out", "p": 0.9}]}]
+
+
+async def test_chat_assisted_token_probs_adds_logprobs():
+    client = _StubClient("chat")
+    cont = DocumentContinuer(client, {})
+    await _drain(cont.stream("### USER: be brief\nThe story so far", "m", assisted=True, token_probs=True))
+    params = client.chat_calls[0]["params"]
+    assert params["logprobs"] is True
+    assert params["top_logprobs"] == 5

--- a/tests/unit/test_text_completion.py
+++ b/tests/unit/test_text_completion.py
@@ -121,6 +121,21 @@ def test_think_tags_novel_namespace_derived():
     )
 
 
+def test_think_tags_hunyuan_format_constructed():
+    # Hunyuan builds the tag from a namespace var rather than writing it
+    # literally; the sniff must resolve `.format(HYTK)` to see the real bytes.
+    raw = (
+        "{%- set HYTK = ':opensource' %}"
+        "{%- set think_begin_token = '<think{}>'.format(HYTK) %}"
+        "{{ think_begin_token }}"
+    )
+    assert tc.think_tags_from_template(raw) == (
+        "<think:opensource>",
+        "</think:opensource>",
+        "<think:opensource>\n\n</think:opensource>\n\n",
+    )
+
+
 def test_think_tags_thinking_and_thought_variants():
     assert tc.think_tags_from_template("...<thinking>...")[0:2] == ("<thinking>", "</thinking>")
     assert tc.think_tags_from_template("...<thought>...")[0:2] == ("<thought>", "</thought>")

--- a/tests/unit/test_text_completion.py
+++ b/tests/unit/test_text_completion.py
@@ -9,9 +9,10 @@ no httpx faking.
 from __future__ import annotations
 
 import httpx
+import pytest
 
 from backend.inference import text_completion as tc
-from backend.inference.client import LLMClient, parse_tool_calls, reasoning_cfg
+from backend.inference.client import LLMClient, _parse_chat_logprobs, parse_tool_calls, reasoning_cfg
 
 GEMMA_OPEN, GEMMA_CLOSE, GEMMA_DISABLE = tc._GEMMA4
 
@@ -185,6 +186,148 @@ def test_build_completion_params_remaps_and_drops():
         "n_predict": 512,
         "repeat_penalty": 1.1,
     }
+
+
+def test_build_completion_params_n_probs_adds_post_sampling():
+    out = tc.build_completion_params({"n_probs": 10})
+    assert out["n_probs"] == 10
+    assert out["post_sampling_probs"] is True
+
+
+def test_build_completion_params_n_probs_absent_by_default():
+    # No n_probs → neither field appears (old servers, probs toggle off).
+    out = tc.build_completion_params({"temperature": 0.7})
+    assert "n_probs" not in out
+    assert "post_sampling_probs" not in out
+
+
+def test_build_completion_params_n_probs_ignores_nonpositive_and_bool():
+    # 0, negatives, and the bool True (an int subclass) are not real requests.
+    for bad in (0, -1, True, "10", None):
+        out = tc.build_completion_params({"n_probs": bad})
+        assert "n_probs" not in out, bad
+        assert "post_sampling_probs" not in out, bad
+
+
+# ── parse_token_probs: three llama.cpp shapes + garbage ───────────────────────
+
+
+def test_parse_token_probs_post_sampling_shape():
+    # Current shape: {token, prob, top_probs:[{token, prob}]} (linear probs).
+    data = {
+        "completion_probabilities": [
+            {
+                "token": " Paris",
+                "prob": 0.86,
+                "top_probs": [{"token": " Paris", "prob": 0.86}, {"token": " own", "prob": 0.1}],
+            }
+        ]
+    }
+    assert tc.parse_token_probs(data) == [
+        {"token": " Paris", "prob": 0.86, "top": [{"t": " Paris", "p": 0.86}, {"t": " own", "p": 0.1}]}
+    ]
+
+
+def test_parse_token_probs_logprob_shape_exponentiated():
+    # {token, logprob, top_logprobs:[{token, logprob}]} → math.exp to linear.
+    import math
+
+    data = {
+        "completion_probabilities": [
+            {"token": "x", "logprob": -0.1, "top_logprobs": [{"token": "x", "logprob": -0.1}, {"token": "y", "logprob": -2.0}]}
+        ]
+    }
+    [rec] = tc.parse_token_probs(data)
+    assert rec["token"] == "x"
+    assert rec["prob"] == pytest.approx(math.exp(-0.1))
+    assert rec["top"][0]["t"] == "x" and rec["top"][0]["p"] == pytest.approx(math.exp(-0.1))
+    assert rec["top"][1]["p"] == pytest.approx(math.exp(-2.0))
+
+
+def test_parse_token_probs_legacy_shape_derives_prob_from_alts():
+    # Legacy {content, probs:[{tok_str, prob}]} — no top-level prob; the sampled
+    # token's prob is read from the alternatives.
+    data = {
+        "completion_probabilities": [
+            {"content": " the", "probs": [{"tok_str": " the", "prob": 0.7}, {"tok_str": " a", "prob": 0.2}]}
+        ]
+    }
+    assert tc.parse_token_probs(data) == [
+        {"token": " the", "prob": 0.7, "top": [{"t": " the", "p": 0.7}, {"t": " a", "p": 0.2}]}
+    ]
+
+
+def test_parse_token_probs_garbage_returns_empty_never_raises():
+    assert tc.parse_token_probs({}) == []
+    assert tc.parse_token_probs({"completion_probabilities": None}) == []
+    assert tc.parse_token_probs({"completion_probabilities": "nope"}) == []
+    assert tc.parse_token_probs({"completion_probabilities": [42, "x", None]}) == []
+    # A record with no usable token string is skipped, not fatal.
+    assert tc.parse_token_probs({"completion_probabilities": [{"prob": 0.5}]}) == []
+
+
+def test_parse_token_probs_multiple_records_and_missing_alts():
+    # More than one token in a chunk; a record with no alternatives keeps prob.
+    data = {
+        "completion_probabilities": [
+            {"token": "a", "prob": 0.9, "top_probs": []},
+            {"token": "b", "prob": 0.5},
+        ]
+    }
+    assert tc.parse_token_probs(data) == [
+        {"token": "a", "prob": 0.9, "top": []},
+        {"token": "b", "prob": 0.5, "top": []},
+    ]
+
+
+# ── Chat-transport logprobs normalization ─────────────────────────────────────
+
+
+def test_parse_chat_logprobs_exponentiates_to_linear():
+    import math
+
+    choice = {
+        "logprobs": {
+            "content": [
+                {
+                    "token": " the",
+                    "logprob": -0.2,
+                    "top_logprobs": [{"token": " the", "logprob": -0.2}, {"token": " a", "logprob": -1.6}],
+                }
+            ]
+        }
+    }
+    [rec] = _parse_chat_logprobs(choice)
+    assert rec["token"] == " the"
+    assert rec["prob"] == pytest.approx(math.exp(-0.2))
+    assert rec["top"][0] == {"t": " the", "p": pytest.approx(math.exp(-0.2))}
+    assert rec["top"][1] == {"t": " a", "p": pytest.approx(math.exp(-1.6))}
+
+
+def test_parse_chat_logprobs_absent_returns_empty():
+    # Provider omitted logprobs entirely (graceful degrade → no popup).
+    assert _parse_chat_logprobs({}) == []
+    assert _parse_chat_logprobs({"logprobs": None}) == []
+    assert _parse_chat_logprobs({"logprobs": {}}) == []
+    assert _parse_chat_logprobs({"logprobs": {"content": None}}) == []
+
+
+def test_parse_chat_logprobs_skips_malformed_records():
+    choice = {
+        "logprobs": {
+            "content": [
+                42,
+                {"token": None, "logprob": -0.1},  # non-str token → skip
+                {"token": "x"},  # missing logprob → skip
+                {"token": "y", "logprob": -0.5, "top_logprobs": ["junk", {"token": "z", "logprob": -0.9}]},
+            ]
+        }
+    }
+    out = _parse_chat_logprobs(choice)
+    assert len(out) == 1
+    assert out[0]["token"] == "y"
+    # The junk alternative is dropped; the valid one survives.
+    assert out[0]["top"] == [{"t": "z", "p": pytest.approx(__import__("math").exp(-0.9))}]
 
 
 # ── Usage synthesis (F8) ──────────────────────────────────────────────────────

--- a/tests/unit/test_text_completion.py
+++ b/tests/unit/test_text_completion.py
@@ -124,11 +124,7 @@ def test_think_tags_novel_namespace_derived():
 def test_think_tags_hunyuan_format_constructed():
     # Hunyuan builds the tag from a namespace var rather than writing it
     # literally; the sniff must resolve `.format(HYTK)` to see the real bytes.
-    raw = (
-        "{%- set HYTK = ':opensource' %}"
-        "{%- set think_begin_token = '<think{}>'.format(HYTK) %}"
-        "{{ think_begin_token }}"
-    )
+    raw = "{%- set HYTK = ':opensource' %}{%- set think_begin_token = '<think{}>'.format(HYTK) %}{{ think_begin_token }}"
     assert tc.think_tags_from_template(raw) == (
         "<think:opensource>",
         "</think:opensource>",

--- a/tests/unit/test_text_completion.py
+++ b/tests/unit/test_text_completion.py
@@ -12,7 +12,12 @@ import httpx
 import pytest
 
 from backend.inference import text_completion as tc
-from backend.inference.client import LLMClient, _parse_chat_logprobs, parse_tool_calls, reasoning_cfg
+from backend.inference.client import (
+    LLMClient,
+    _parse_chat_logprobs,
+    parse_tool_calls,
+    reasoning_cfg,
+)
 
 GEMMA_OPEN, GEMMA_CLOSE, GEMMA_DISABLE = tc._GEMMA4
 


### PR DESCRIPTION
Support getting logprobs in Document Mode in both Chat Completion and Text Completion.

<img width="501" height="315" alt="image" src="https://github.com/user-attachments/assets/b9626573-808e-49e5-9ef2-eea5c4fcb99b" />
