### PR TITLE
feat: retry on transient errors

### DIFF
--- a/backend/api/routes/conversations.py
+++ b/backend/api/routes/conversations.py
@@ -46,7 +46,7 @@ from ...database import (
 from ...database.models import ConversationRow
 from ...features import lorebook
 from ...features.summarization import ConversationSummarizer
-from ...inference import AbortToken, LLMClient, prompt_builder
+from ...inference import AbortToken, LLMClient, RetryPolicy, prompt_builder
 from ...pipeline import agent_enabled, resolve_persona_id
 from ..deps import _active_aborts, _CleanupStreamingResponse, _sse_stream
 from ..schemas import (
@@ -185,6 +185,7 @@ async def api_summarize_conversation(cid: str, data: SummarizeRequest, request: 
         api_key=settings.get("api_key", ""),
         abort_token=abort_token,
         completion_mode=settings.get("completion_mode", "chat"),
+        retry=RetryPolicy.from_settings(settings),
     )
     summarizer = ConversationSummarizer(client, settings)
     llm_messages = summarizer.build_messages(

--- a/backend/api/routes/documents.py
+++ b/backend/api/routes/documents.py
@@ -21,7 +21,7 @@ from ...database import (
     update_document,
 )
 from ...features.documents import DocumentContinuer
-from ...inference import AbortToken, LLMClient
+from ...inference import AbortToken, LLMClient, RetryPolicy
 from ..deps import _active_aborts, _CleanupStreamingResponse, _sse_stream
 from ..schemas import DocumentCreate, DocumentGenerateRequest, DocumentUpdate
 
@@ -80,6 +80,7 @@ async def api_generate_document(did: str, data: DocumentGenerateRequest, request
         api_key=settings.get("api_key", ""),
         abort_token=abort_token,
         completion_mode=settings.get("completion_mode", "chat"),
+        retry=RetryPolicy.from_settings(settings),
     )
     continuer = DocumentContinuer(client, settings)
 

--- a/backend/api/routes/workflows.py
+++ b/backend/api/routes/workflows.py
@@ -27,7 +27,7 @@ from ...database import (
     get_workflow_attachment_by_id,
     set_workflow_enabled,
 )
-from ...inference import LLMClient
+from ...inference import LLMClient, RetryPolicy
 from ...workflows import (
     HookType,
     OnDemandCtx,
@@ -147,6 +147,7 @@ async def api_trigger_workflow(cid: str, workflow_id: str, body: dict = Body(def
             settings_snapshot["endpoint_url"],
             api_key=settings_snapshot.get("api_key", ""),
             completion_mode=settings_snapshot.get("completion_mode", "chat"),
+            retry=RetryPolicy.from_settings(settings_snapshot),
         )
         async with workflow_character_state_lock(conv.get("character_card_id") or "", workflow_id):
             try:
@@ -200,6 +201,7 @@ async def api_regenerate_attachment(cid: str, mid: int, aid: int, body: dict = B
             settings_snapshot["endpoint_url"],
             api_key=settings_snapshot.get("api_key", ""),
             completion_mode=settings_snapshot.get("completion_mode", "chat"),
+            retry=RetryPolicy.from_settings(settings_snapshot),
         )
 
         card_id = conv.get("character_card_id")
@@ -390,6 +392,7 @@ async def api_reroll_gen_attachment(cid: str, mid: int, aid: int, body: dict = B
             settings_snapshot["endpoint_url"],
             api_key=settings_snapshot.get("api_key", ""),
             completion_mode=settings_snapshot.get("completion_mode", "chat"),
+            retry=RetryPolicy.from_settings(settings_snapshot),
         )
 
         try:
@@ -519,6 +522,7 @@ async def api_rehydrate_attachment(cid: str, mid: int, aid: int, body: dict = Bo
             settings_snapshot["endpoint_url"],
             api_key=settings_snapshot.get("api_key", ""),
             completion_mode=settings_snapshot.get("completion_mode", "chat"),
+            retry=RetryPolicy.from_settings(settings_snapshot),
         )
 
         try:

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -53,6 +53,9 @@ class SettingsUpdate(BaseModel):
     direction_notes_inject: Optional[Literal["off", "director", "writer", "both"]] = None
     inspector_open_states: Optional[dict] = None
     workflows_globally_enabled: Optional[bool] = None
+    retry_enabled: Optional[bool] = None
+    retry_count: Optional[int] = None
+    retry_delay_seconds: Optional[float] = None
 
 
 class DirectionNoteUpdate(BaseModel):

--- a/backend/database/migrations/0040_retry_on_error.py
+++ b/backend/database/migrations/0040_retry_on_error.py
@@ -1,0 +1,27 @@
+"""
+0040_retry_on_error -- add the transient-error retry settings.
+
+`retry_enabled` (default 0/off) toggles re-issuing a completion that failed with
+a temporary server-side error; `retry_count` (default 10) is the number of
+retries after the initial attempt; `retry_delay_seconds` (default 5) is the wait
+between attempts. Fresh installs get these from schema.py; this backfills
+existing DBs. The retryable status-code set is a code constant (inference/retry.py),
+not a column.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(settings)").fetchall()}
+    if "retry_enabled" not in cols:
+        conn.execute("ALTER TABLE settings ADD COLUMN retry_enabled INTEGER NOT NULL DEFAULT 0")
+        print("[migrations] 0040: added retry_enabled column to settings")
+    if "retry_count" not in cols:
+        conn.execute("ALTER TABLE settings ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 10")
+        print("[migrations] 0040: added retry_count column to settings")
+    if "retry_delay_seconds" not in cols:
+        conn.execute("ALTER TABLE settings ADD COLUMN retry_delay_seconds REAL NOT NULL DEFAULT 5")
+        print("[migrations] 0040: added retry_delay_seconds column to settings")

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -101,6 +101,9 @@ class _SettingsBase(TypedDict):
     direction_notes_record: int
     direction_notes_inject: str
     workflows_globally_enabled: int
+    retry_enabled: int
+    retry_count: int
+    retry_delay_seconds: float
 
 
 class SettingsRow(_SettingsBase, total=False):

--- a/backend/database/queries/settings.py
+++ b/backend/database/queries/settings.py
@@ -252,6 +252,9 @@ async def update_settings(data: dict) -> SettingsRow:
             "direction_notes_inject",
             "inspector_open_states",
             "workflows_globally_enabled",
+            "retry_enabled",
+            "retry_count",
+            "retry_delay_seconds",
         ]
         sets, vals = _build_set_clause(
             allowed,

--- a/backend/database/schema.py
+++ b/backend/database/schema.py
@@ -46,6 +46,9 @@ CREATE TABLE IF NOT EXISTS settings (
     workflows_globally_enabled INTEGER NOT NULL DEFAULT 1,
     workflow_enabled TEXT NOT NULL DEFAULT '{}',
     local_ml_enabled TEXT NOT NULL DEFAULT '{}',
+    retry_enabled INTEGER NOT NULL DEFAULT 0,
+    retry_count INTEGER NOT NULL DEFAULT 10,
+    retry_delay_seconds REAL NOT NULL DEFAULT 5,
     attachment_cache_budget_bytes INTEGER NOT NULL DEFAULT 524288000,
     attachment_access_counter INTEGER NOT NULL DEFAULT 0,
     generated_chars INTEGER DEFAULT NULL

--- a/backend/database/seeds.py
+++ b/backend/database/seeds.py
@@ -221,6 +221,9 @@ DEFAULT_SETTINGS = {
     "direction_notes_record": 0,
     "direction_notes_inject": "off",
     "workflows_globally_enabled": 1,
+    "retry_enabled": 0,
+    "retry_count": 10,
+    "retry_delay_seconds": 5,
 }
 
 

--- a/backend/inference/__init__.py
+++ b/backend/inference/__init__.py
@@ -11,7 +11,6 @@ from .cached_call import CachedBase
 from .client import AbortToken, LLMClient, parse_tool_calls, reasoning_cfg
 from .endpoint_profiles import ModelProfile, is_forced_tool_choice, profile_for
 from .kv_tracker import _KVCacheTracker
-from .retry import RetryPolicy
 from .prompt_builder import (
     build_direction_note_prompt,
     build_director_scene_step_prompt,
@@ -26,6 +25,7 @@ from .prompt_builder import (
     format_message_with_attachments,
     render_direction_notes_block,
 )
+from .retry import RetryPolicy
 from .text_completion import has_image_parts
 from .tool_registry import (
     BUILTIN_TOOL_NAMES,

--- a/backend/inference/__init__.py
+++ b/backend/inference/__init__.py
@@ -11,6 +11,7 @@ from .cached_call import CachedBase
 from .client import AbortToken, LLMClient, parse_tool_calls, reasoning_cfg
 from .endpoint_profiles import ModelProfile, is_forced_tool_choice, profile_for
 from .kv_tracker import _KVCacheTracker
+from .retry import RetryPolicy
 from .prompt_builder import (
     build_direction_note_prompt,
     build_director_scene_step_prompt,
@@ -46,6 +47,7 @@ __all__ = [
     # client — LLM transport
     "AbortToken",
     "LLMClient",
+    "RetryPolicy",
     "parse_tool_calls",
     "reasoning_cfg",
     # endpoint_profiles — provider adapter

--- a/backend/inference/client.py
+++ b/backend/inference/client.py
@@ -5,12 +5,13 @@ import json
 import logging
 import math
 import re
-from typing import Any, AsyncIterator, Mapping, Sequence
+from typing import Any, AsyncIterator, Callable, Mapping, Sequence
 
 import httpx
 
 from . import endpoint_profiles, text_completion
 from .gemma_tool_format import parse_gemma_tool_calls
+from .retry import RetryPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +110,7 @@ class LLMClient:
         timeout: float = 120.0,
         abort_token: AbortToken | None = None,
         completion_mode: str = "chat",
+        retry: RetryPolicy | None = None,
     ):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
@@ -120,6 +122,9 @@ class LLMClient:
         # Shared across the turn's clients when passed in; otherwise a private
         # token so a standalone client (e.g. a workflow hook) is still abortable.
         self.abort_token = abort_token or AbortToken()
+        # Transient-error retry, off by default: an omitted policy behaves exactly
+        # as before (single attempt, error propagates). See retry.py.
+        self.retry = retry or RetryPolicy()
 
     def abort(self) -> None:
         """Stop all ongoing completions and close their connections."""
@@ -165,21 +170,81 @@ class LLMClient:
                 — assembled message (content and/or tool_calls) and the
                   provider usage object (``None`` when the server omits it).
         """
+        # Transport choice and chat-only param scrubbing happen once, outside the
+        # retry loop; each attempt re-opens a fresh stream from the same inputs.
         if self.completion_mode == "text" and not text_completion.has_image_parts(messages):
-            async for event in self._complete_text(messages, model, tools, tool_choice, **params):
-                yield event
-            return
-        # Chat transport: prefill (no render step), raw GBNF grammar, and the
-        # per-call json_schema narrowing are text-mode concepts; drop them so
-        # such calls degrade cleanly here.
-        params.pop("prefill", None)
-        params.pop("grammar", None)
-        params.pop("json_schema", None)
-        # n_probs is a llama.cpp /completion field; a text→chat fallback (e.g. a
-        # call carrying image parts) must not leak it into the OpenAI-compat body.
-        params.pop("n_probs", None)
-        async for event in self._complete_chat(messages, model, tools, tool_choice, **params):
+            transport = self._complete_text
+        else:
+            # Chat transport: prefill (no render step), raw GBNF grammar, and the
+            # per-call json_schema narrowing are text-mode concepts; drop them so
+            # such calls degrade cleanly here.
+            params.pop("prefill", None)
+            params.pop("grammar", None)
+            params.pop("json_schema", None)
+            # n_probs is a llama.cpp /completion field; a text→chat fallback (e.g. a
+            # call carrying image parts) must not leak it into the OpenAI-compat body.
+            params.pop("n_probs", None)
+            transport = self._complete_chat
+
+        # Retry transient server failures via _with_retry, which re-opens a fresh
+        # transport stream per attempt. Disabled by default -> straight passthrough.
+        async for event in self._with_retry(lambda: transport(messages, model, tools, tool_choice, **params)):
             yield event
+
+    async def _with_retry(self, open_stream: Callable[[], AsyncIterator[dict]]) -> AsyncIterator[dict]:
+        """Yield events from ``open_stream()``, re-opening it on a transient failure.
+
+        ``open_stream`` is a zero-arg factory returning a fresh completion stream;
+        it is called once per attempt. A retry fires only while no event has been
+        yielded -- once the stream emits content, re-issuing would double it, and
+        both transports raise before their first event (HTTP status check /
+        connect), so "produced is still False" is exactly the clean-retry window.
+        With the default disabled policy ``should_retry`` is always False, so the
+        original error propagates on the first attempt, unchanged.
+        """
+        attempt = 0
+        while True:
+            produced = False
+            try:
+                async for event in open_stream():
+                    produced = True
+                    yield event
+                return
+            except httpx.HTTPError as exc:
+                if produced or self.is_aborted or attempt >= self.retry.count or not self.retry.should_retry(exc):
+                    raise
+                attempt += 1
+                detail = (
+                    f"HTTP {exc.response.status_code}"
+                    if isinstance(exc, httpx.HTTPStatusError)
+                    else type(exc).__name__
+                )
+                logger.warning(
+                    "LLM retry %d/%d after %s; waiting %.1fs",
+                    attempt,
+                    self.retry.count,
+                    detail,
+                    self.retry.delay,
+                )
+                if not await self._sleep_or_abort(self.retry.delay):
+                    raise  # aborted mid-wait: surface the real error, stop retrying
+
+    async def _sleep_or_abort(self, delay: float) -> bool:
+        """Wait up to *delay* seconds, returning early if the turn is aborted.
+
+        Returns True if the full delay elapsed, False if aborted first, so the
+        retry loop drops out immediately on Stop instead of sleeping out its
+        remaining attempts. The abort token is a shared ``asyncio.Event``; waiting
+        on it (rather than a bare ``asyncio.sleep``) is what makes the delay
+        interruptible.
+        """
+        if delay <= 0:
+            return not self.is_aborted
+        try:
+            await asyncio.wait_for(self.abort_token.wait(), timeout=delay)
+            return False  # abort fired within the delay
+        except asyncio.TimeoutError:
+            return True  # full delay elapsed, no abort
 
     async def _complete_chat(
         self,
@@ -616,6 +681,11 @@ class LLMClient:
         native ``/completion`` endpoint serves whatever model the server loaded,
         so it is not sent in the body).
         """
+        async for event in self._with_retry(lambda: self._complete_raw(prompt, **params)):
+            yield event
+
+    async def _complete_raw(self, prompt: str, **params) -> AsyncIterator[dict]:
+        """Raw ``/completion`` stream backing :meth:`complete_raw` (one attempt)."""
         body = text_completion.build_completion_params(params)
         body["prompt"] = prompt
         body["stream"] = True

--- a/backend/inference/client.py
+++ b/backend/inference/client.py
@@ -214,11 +214,7 @@ class LLMClient:
                 if produced or self.is_aborted or attempt >= self.retry.count or not self.retry.should_retry(exc):
                     raise
                 attempt += 1
-                detail = (
-                    f"HTTP {exc.response.status_code}"
-                    if isinstance(exc, httpx.HTTPStatusError)
-                    else type(exc).__name__
-                )
+                detail = f"HTTP {exc.response.status_code}" if isinstance(exc, httpx.HTTPStatusError) else type(exc).__name__
                 logger.warning(
                     "LLM retry %d/%d after %s; waiting %.1fs",
                     attempt,

--- a/backend/inference/retry.py
+++ b/backend/inference/retry.py
@@ -1,0 +1,85 @@
+"""
+retry.py -- transient-error retry policy for the LLM transport.
+
+A completion that dies with a temporary server-side error (a 503, an overloaded
+529, a refused or dropped connection) otherwise wastes the whole turn's compute,
+and the later the pass fails the more is thrown away. :class:`RetryPolicy` lets
+:meth:`LLMClient.complete` re-issue such a request a bounded number of times with
+a fixed delay.
+
+This is transport config, injected like ``timeout``/``completion_mode``; the
+inference layer never reads settings itself (that would couple it to the database
+layer), so callers build a policy from a settings mapping via
+:meth:`RetryPolicy.from_settings` and pass it to the client constructor.
+
+Retrying is only safe before the first streamed event -- once content has been
+emitted, re-issuing would double it. That guard lives in
+:meth:`LLMClient.complete`, not here; this module only decides *whether* an error
+is retryable and *how long* to wait.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import httpx
+
+# Temporary server-side HTTP statuses. 429/503/529 are explicit "busy/overloaded"
+# signals; 408/500/502/504 are transient often enough on LLM backends (request
+# timeouts, OOM/CUDA hiccups, gateway blips) to be worth a bounded retry.
+# Client-side 4xx (400/401/404/422 ...) are deterministic and never retried.
+RETRYABLE_STATUS: frozenset[int] = frozenset({408, 429, 500, 502, 503, 504, 529})
+
+# Connection-level failures that mean the server was briefly unreachable rather
+# than that the request was bad: a refused or timed-out connect, a read/protocol
+# error or dropped connection before any response, or no free pool slot. Write-side
+# and local/proxy protocol errors are excluded -- those are our fault, not a
+# transient server blip. These only ever surface pre-stream, so retrying them is
+# subject to the same "no event yet" guard as a status-code failure.
+RETRYABLE_TRANSPORT_ERRORS: tuple[type[Exception], ...] = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.ReadError,
+    httpx.ReadTimeout,
+    httpx.RemoteProtocolError,
+    httpx.PoolTimeout,
+)
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """When and how to retry a completion that failed with a transient error.
+
+    ``count`` is the number of *retries* after the initial attempt, so at most
+    ``1 + count`` requests and ``count`` waits of ``delay`` seconds. The default
+    instance is disabled: constructing an :class:`LLMClient` without a policy
+    behaves exactly as before -- one attempt, error propagates.
+    """
+
+    enabled: bool = False
+    count: int = 10
+    delay: float = 5.0
+    status_codes: frozenset[int] = RETRYABLE_STATUS
+
+    @classmethod
+    def from_settings(cls, settings: Mapping[str, Any]) -> "RetryPolicy":
+        """Build a policy from a settings row.
+
+        Missing or malformed values degrade to a safe disabled/no-op shape rather
+        than raising on the gameplay path (an old DB predating the columns, a
+        null slipping through).
+        """
+        return cls(
+            enabled=bool(settings.get("retry_enabled", 0)),
+            count=max(0, int(settings.get("retry_count", 10) or 0)),
+            delay=max(0.0, float(settings.get("retry_delay_seconds", 5) or 0)),
+        )
+
+    def should_retry(self, exc: BaseException) -> bool:
+        """True if *exc* is a transient failure worth retrying under this policy."""
+        if not self.enabled:
+            return False
+        if isinstance(exc, httpx.HTTPStatusError):
+            return exc.response.status_code in self.status_codes
+        return isinstance(exc, RETRYABLE_TRANSPORT_ERRORS)

--- a/backend/pipeline/context.py
+++ b/backend/pipeline/context.py
@@ -41,6 +41,7 @@ from ..features.lorebook import (
 from ..inference import (
     AbortToken,
     LLMClient,
+    RetryPolicy,
     _KVCacheTracker,
     build_prefix,
 )
@@ -113,6 +114,7 @@ async def _load_pipeline_context(conversation_id: str, *, abort_token: AbortToke
         api_key=settings.get("api_key", ""),
         abort_token=abort_token,
         completion_mode=settings.get("completion_mode", "chat"),
+        retry=RetryPolicy.from_settings(settings),
     )
 
     card_id = conv.get("character_card_id")
@@ -135,6 +137,7 @@ async def _load_pipeline_context(conversation_id: str, *, abort_token: AbortToke
             api_key=agent_api_key,
             abort_token=abort_token,
             completion_mode=settings.get("agent_completion_mode", "chat"),
+            retry=RetryPolicy.from_settings(settings),
         )
         agent_system_prompt, _, _ = await db.resolve_char_context(
             conv, settings, shared_key="agent_shared_system_prompt", card=card

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -185,7 +185,7 @@ export function renderSettings() {
           <span class="tog-slider"></span>
         </label>
       </div>
-      <div class="tool-card-desc">Retry completions that fail with a temporary server error (503, 429, 529, dropped connection, ...) so a late-stage failure doesn't waste the whole turn's compute.</div>
+      <div class="tool-card-desc">Retry completions that fail with a temporary server error (503, 429, 529, dropped connection, etc).</div>
       ${
         S.retryEnabled
           ? `<div class="lg-config">

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -122,6 +122,11 @@ export async function loadSettings() {
   else if (typeof S.settings.prevent_prompt_overrides === "boolean")
     S.preventPromptOverrides = S.settings.prevent_prompt_overrides;
 
+  if (typeof S.settings.retry_enabled === "number") S.retryEnabled = S.settings.retry_enabled !== 0;
+  else if (typeof S.settings.retry_enabled === "boolean") S.retryEnabled = S.settings.retry_enabled;
+  if (typeof S.settings.retry_count === "number") S.retryCount = S.settings.retry_count;
+  if (typeof S.settings.retry_delay_seconds === "number") S.retryDelay = S.settings.retry_delay_seconds;
+
   if (typeof S.settings.agent_same_as_writer === "number") S.agentSameAsWriter = S.settings.agent_same_as_writer !== 0;
   else if (typeof S.settings.agent_same_as_writer === "boolean") S.agentSameAsWriter = S.settings.agent_same_as_writer;
   S.agentEndpointId = S.settings.agent_endpoint_id || null;
@@ -172,6 +177,32 @@ export function renderSettings() {
       </div>
       <div class="tool-card-desc">Ignore system prompt and post-history instructions from character cards.</div>
     </div>
+    <div class="tool-card ${S.retryEnabled ? "tool-on" : ""}">
+      <div class="tool-card-header">
+        <span class="tool-card-name">Retry on error</span>
+        <label class="tog">
+          <input id="retry-enabled" type="checkbox" ${S.retryEnabled ? "checked" : ""}>
+          <span class="tog-slider"></span>
+        </label>
+      </div>
+      <div class="tool-card-desc">Retry completions that fail with a temporary server error (503, 429, 529, dropped connection, ...) so a late-stage failure doesn't waste the whole turn's compute.</div>
+      ${
+        S.retryEnabled
+          ? `<div class="lg-config">
+      <div class="lg-config-row">
+        <div class="lg-field">
+          <label>Max retries</label>
+          <input id="retry-count" type="number" min="1" max="100" step="1" value="${S.retryCount}">
+        </div>
+        <div class="lg-field">
+          <label>Delay (seconds)</label>
+          <input id="retry-delay" type="number" min="0" max="300" step="1" value="${S.retryDelay}">
+        </div>
+      </div>
+    </div>`
+          : ""
+      }
+    </div>
     <div style="display:flex;align-items:center;gap:12px;margin:16px 0 8px"><div style="flex:1;height:1px;background:var(--accent-dim)"></div><span style="font-size:11px;text-transform:uppercase;letter-spacing:1px;color:var(--accent-dim)">Local ML</span><div style="flex:1;height:1px;background:var(--accent-dim)"></div></div>
     <div id="local-ml-section"><div class="tool-card-desc">Loading…</div></div>
     <div style="display:flex;align-items:center;gap:12px;margin:16px 0 8px"><div style="flex:1;height:1px;background:var(--accent-dim)"></div><span style="font-size:11px;text-transform:uppercase;letter-spacing:1px;color:var(--accent-dim)">Data</span><div style="flex:1;height:1px;background:var(--accent-dim)"></div></div>
@@ -180,6 +211,11 @@ export function renderSettings() {
       <button class="btn btn-danger" onclick="showResetConfirmModal()" style="width:100%;justify-content:center">⚠️ Reset to Defaults</button>
     </div>
   `;
+  // Wired here rather than inline on*= handlers: the frontend layer check ratchets
+  // the inline-handler count down, so new controls attach listeners in JS.
+  $("retry-enabled")?.addEventListener("change", (e) => toggleRetryEnabled(e.target.checked));
+  $("retry-count")?.addEventListener("change", saveRetryConfig);
+  $("retry-delay")?.addEventListener("change", saveRetryConfig);
   loadLocalMLSection();
 }
 
@@ -433,6 +469,35 @@ export async function togglePreventPromptOverrides(on) {
   S.preventPromptOverrides = on;
   renderSettings();
   await persistSettings({ prevent_prompt_overrides: on });
+}
+
+export async function toggleRetryEnabled(on) {
+  S.retryEnabled = on;
+  renderSettings();
+  await persistSettings({ retry_enabled: on });
+}
+
+export async function saveRetryConfig() {
+  const count = parseInt($("retry-count").value, 10);
+  const delay = parseFloat($("retry-delay").value);
+  const countValidation = validate.validateSetting("retry_count", count);
+  if (!countValidation.valid) {
+    toast(countValidation.error, true);
+    return;
+  }
+  const delayValidation = validate.validateSetting("retry_delay_seconds", delay);
+  if (!delayValidation.valid) {
+    toast(delayValidation.error, true);
+    return;
+  }
+  S.retryCount = count;
+  S.retryDelay = delay;
+  try {
+    S.settings = await api.put("/settings", { retry_count: count, retry_delay_seconds: delay });
+    toast("Retry settings saved");
+  } catch (_e) {
+    toast("Failed to save retry settings", true);
+  }
 }
 
 export async function saveLengthGuardConfig() {

--- a/frontend/state.js
+++ b/frontend/state.js
@@ -47,6 +47,9 @@ export const S = {
   directionNotesInject: "off", // injection target: off | director | writer | both (read side, independent of recording)
   hideUntilBaked: false, // when true, in-flight streaming message is kept detached from DOM until stream finalizes
   preventPromptOverrides: false, // when true, character card system_prompt and post_history_instructions are ignored
+  retryEnabled: false, // when true, completions that fail with a transient server error are retried
+  retryCount: 10, // retries after the initial attempt
+  retryDelay: 5, // seconds between attempts
   showEditorDiff: true, // when false, editor-pass diff highlights + "clear diff" button are suppressed
   reasoningEnabled: { director: false, writer: false, editor: false, scripter: false },
   editorAuditToggles: {

--- a/frontend/validate.js
+++ b/frontend/validate.js
@@ -470,6 +470,18 @@ export function validateSetting(key, value) {
       if (!range.valid) return range;
       return isInteger(numCheck.parsed, "Max paragraphs");
     }
+    case "retry_count": {
+      const numCheck = isNumber(value, "Max retries");
+      if (!numCheck.valid) return numCheck;
+      const range = numberRange(numCheck.parsed, 1, 100, "Max retries");
+      if (!range.valid) return range;
+      return isInteger(numCheck.parsed, "Max retries");
+    }
+    case "retry_delay_seconds": {
+      const numCheck = isNumber(value, "Retry delay");
+      if (!numCheck.valid) return numCheck;
+      return numberRange(numCheck.parsed, 0, 300, "Retry delay");
+    }
     default:
       return { valid: true };
   }

--- a/tests/integration/test_retry_settings.py
+++ b/tests/integration/test_retry_settings.py
@@ -1,0 +1,36 @@
+"""Retry settings round-trip through the /api/settings stack.
+
+Guards the wiring a new settings column silently depends on: the field must be on
+``SettingsUpdate`` (or the PUT drops it as an extra field) and in
+``update_settings``' allowlist (or the write is a no-op), and
+``RetryPolicy.from_settings`` must read the persisted row back correctly.
+"""
+
+from __future__ import annotations
+
+from backend.database.queries.settings import get_settings
+from backend.inference.retry import RetryPolicy
+
+
+async def test_retry_settings_default_off(client):
+    s = (await client.get("/api/settings")).json()
+    assert s["retry_enabled"] == 0
+    assert s["retry_count"] == 10
+    assert s["retry_delay_seconds"] == 5
+
+
+async def test_retry_settings_roundtrip_and_policy(client):
+    updated = (
+        await client.put(
+            "/api/settings",
+            json={"retry_enabled": True, "retry_count": 3, "retry_delay_seconds": 2},
+        )
+    ).json()
+    assert updated["retry_enabled"] == 1
+    assert updated["retry_count"] == 3
+    assert updated["retry_delay_seconds"] == 2
+
+    policy = RetryPolicy.from_settings(await get_settings())
+    assert policy.enabled is True
+    assert policy.count == 3
+    assert policy.delay == 2.0

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -1,0 +1,218 @@
+"""Unit tests for transient-error retry (RetryPolicy + the LLMClient retry loop).
+
+RetryPolicy decides whether an error is retryable and how long to wait; the loop
+in LLMClient.complete / complete_raw re-issues a failed request only while no
+event has been streamed yet. Tests patch the documented transport seams
+(``_complete_chat`` / ``_stream_completion``) so no sockets are touched, and use
+``delay=0`` so retries are instant.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from backend.inference.client import AbortToken, LLMClient
+from backend.inference.retry import RETRYABLE_STATUS, RetryPolicy
+
+
+def _status_error(code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "http://x/v1/chat/completions")
+    response = httpx.Response(code, request=request)
+    return httpx.HTTPStatusError(f"HTTP {code}", request=request, response=response)
+
+
+async def _drain(agen):
+    return [e async for e in agen]
+
+
+def _chat_script(client: LLMClient, script: list) -> dict:
+    """Fake ``_complete_chat``: on call i, raise ``script[i]`` if it is an exception,
+    else yield the events in ``script[i]``. The last entry repeats. Returns a call
+    counter so a test can assert how many attempts happened."""
+    calls = {"n": 0}
+
+    async def fake_chat(*_a, **_k):
+        i = calls["n"]
+        calls["n"] += 1
+        action = script[i] if i < len(script) else script[-1]
+        if isinstance(action, BaseException):
+            raise action
+        for ev in action:
+            yield ev
+
+    client._complete_chat = fake_chat  # type: ignore[method-assign]
+    return calls
+
+
+# -- RetryPolicy.should_retry -------------------------------------------------
+
+
+def test_should_retry_disabled_never_retries():
+    policy = RetryPolicy(enabled=False)
+    assert policy.should_retry(_status_error(503)) is False
+    assert policy.should_retry(httpx.ConnectError("x")) is False
+
+
+def test_should_retry_status_codes():
+    policy = RetryPolicy(enabled=True)
+    for code in (408, 429, 500, 502, 503, 504, 529):
+        assert policy.should_retry(_status_error(code)) is True, code
+    for code in (400, 401, 403, 404, 409, 422):
+        assert policy.should_retry(_status_error(code)) is False, code
+
+
+def test_should_retry_transport_errors():
+    policy = RetryPolicy(enabled=True)
+    assert policy.should_retry(httpx.ConnectError("x")) is True
+    assert policy.should_retry(httpx.ConnectTimeout("x")) is True
+    assert policy.should_retry(httpx.ReadError("x")) is True
+    assert policy.should_retry(httpx.ReadTimeout("x")) is True
+    assert policy.should_retry(httpx.RemoteProtocolError("x")) is True
+    assert policy.should_retry(httpx.PoolTimeout("x")) is True
+    # A transport error deliberately excluded (client-side write) is not retried.
+    assert policy.should_retry(httpx.WriteError("x")) is False
+    # A completely unrelated exception is not retried.
+    assert policy.should_retry(ValueError("x")) is False
+
+
+# -- RetryPolicy.from_settings ------------------------------------------------
+
+
+def test_from_settings_reads_values():
+    policy = RetryPolicy.from_settings({"retry_enabled": 1, "retry_count": 3, "retry_delay_seconds": 2.5})
+    assert policy.enabled is True
+    assert policy.count == 3
+    assert policy.delay == 2.5
+    assert policy.status_codes == RETRYABLE_STATUS
+
+
+def test_from_settings_defaults_when_keys_absent():
+    policy = RetryPolicy.from_settings({})
+    assert policy.enabled is False
+    assert policy.count == 10
+    assert policy.delay == 5.0
+
+
+def test_from_settings_degrades_on_bad_values():
+    # None / negative must clamp to a safe shape rather than raise on the hot path.
+    policy = RetryPolicy.from_settings({"retry_enabled": 0, "retry_count": None, "retry_delay_seconds": -4})
+    assert policy.count == 0
+    assert policy.delay == 0.0
+
+
+# -- LLMClient retry loop -----------------------------------------------------
+
+
+async def test_retries_then_succeeds():
+    client = LLMClient("http://x/v1", retry=RetryPolicy(enabled=True, count=5, delay=0))
+    done = {"type": "done", "message": {"content": "ok"}, "usage": None}
+    calls = _chat_script(client, [_status_error(503), _status_error(503), [{"type": "content", "delta": "ok"}, done]])
+    events = await _drain(client.complete([], "m"))
+    assert calls["n"] == 3
+    assert events[-1] == done
+
+
+async def test_disabled_policy_raises_on_first_error():
+    client = LLMClient("http://x/v1")  # default policy: disabled
+    calls = _chat_script(client, [_status_error(503)])
+    with pytest.raises(httpx.HTTPStatusError):
+        await _drain(client.complete([], "m"))
+    assert calls["n"] == 1
+
+
+async def test_no_retry_after_event_streamed():
+    client = LLMClient("http://x/v1", retry=RetryPolicy(enabled=True, count=5, delay=0))
+
+    async def fake_chat(*_a, **_k):
+        # A delta reaches the caller, THEN the stream fails: retrying would double it.
+        yield {"type": "content", "delta": "partial"}
+        raise _status_error(503)
+
+    client._complete_chat = fake_chat  # type: ignore[method-assign]
+    seen = []
+    with pytest.raises(httpx.HTTPStatusError):
+        async for event in client.complete([], "m"):
+            seen.append(event)
+    assert seen == [{"type": "content", "delta": "partial"}]
+
+
+async def test_exhausts_retries_then_raises():
+    client = LLMClient("http://x/v1", retry=RetryPolicy(enabled=True, count=2, delay=0))
+    calls = _chat_script(client, [_status_error(503)])  # always fails
+    with pytest.raises(httpx.HTTPStatusError):
+        await _drain(client.complete([], "m"))
+    assert calls["n"] == 3  # initial attempt + 2 retries
+
+
+async def test_non_retryable_status_not_retried():
+    client = LLMClient("http://x/v1", retry=RetryPolicy(enabled=True, count=5, delay=0))
+    calls = _chat_script(client, [_status_error(400)])
+    with pytest.raises(httpx.HTTPStatusError):
+        await _drain(client.complete([], "m"))
+    assert calls["n"] == 1
+
+
+async def test_transport_error_is_retried():
+    client = LLMClient("http://x/v1", retry=RetryPolicy(enabled=True, count=3, delay=0))
+    done = {"type": "done", "message": {"content": "ok"}, "usage": None}
+    calls = _chat_script(client, [httpx.ConnectError("refused"), [done]])
+    events = await _drain(client.complete([], "m"))
+    assert calls["n"] == 2
+    assert events[-1] == done
+
+
+async def test_aborted_client_does_not_retry():
+    token = AbortToken()
+    token.abort()
+    client = LLMClient("http://x/v1", abort_token=token, retry=RetryPolicy(enabled=True, count=5, delay=0))
+    calls = _chat_script(client, [_status_error(503)])
+    with pytest.raises(httpx.HTTPStatusError):
+        await _drain(client.complete([], "m"))
+    assert calls["n"] == 1  # is_aborted short-circuits the retry decision
+
+
+async def test_abort_during_delay_stops_retry():
+    client = LLMClient("http://x/v1", retry=RetryPolicy(enabled=True, count=5, delay=1))
+    calls = _chat_script(client, [_status_error(503)])  # always fails
+
+    async def aborted_wait(_delay):
+        return False  # simulate the abort signal firing during the wait
+
+    client._sleep_or_abort = aborted_wait  # type: ignore[method-assign]
+    with pytest.raises(httpx.HTTPStatusError):
+        await _drain(client.complete([], "m"))
+    assert calls["n"] == 1  # wait aborted -> no further attempts
+
+
+async def test_complete_raw_is_retried():
+    client = LLMClient("http://x/v1", completion_mode="text", retry=RetryPolicy(enabled=True, count=3, delay=0))
+    calls = {"n": 0}
+
+    async def fake_stream(_url, _body):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _status_error(503)
+        yield {"content": "hi", "stop": True, "tokens_evaluated": 1, "tokens_predicted": 1, "timings": {"prompt_n": 1}}
+
+    client._stream_completion = fake_stream  # type: ignore[method-assign]
+    events = await _drain(client.complete_raw("p", "m"))
+    assert calls["n"] == 2
+    assert events[-1]["type"] == "done"
+    assert events[-1]["message"]["content"] == "hi"
+
+
+# -- _sleep_or_abort ----------------------------------------------------------
+
+
+async def test_sleep_or_abort_true_when_not_aborted():
+    client = LLMClient("http://x/v1")
+    assert await client._sleep_or_abort(0) is True
+
+
+async def test_sleep_or_abort_false_when_already_aborted():
+    token = AbortToken()
+    token.abort()
+    client = LLMClient("http://x/v1", abort_token=token)
+    # A long delay still returns at once (False) because the event is already set.
+    assert await client._sleep_or_abort(30) is False


### PR DESCRIPTION
What the name says. This is for cases where 503s, the 549s, and others appear frequently (NanoGPT is no stranger to such issues).