### PR TITLE
Bump python floor to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,17 +102,13 @@ jobs:
         if: needs.detect-changes.outputs.backend == 'true'
         run: pip install -r requirements-dev.txt
 
-      - name: Ruff import sort check
-        if: needs.detect-changes.outputs.backend == 'true'
-        run: python -m ruff check --select I backend/ tests/
-
       - name: Ruff format check
         if: needs.detect-changes.outputs.backend == 'true'
         run: python -m ruff format --line-length 128 --check backend/ tests/
 
       - name: Ruff lint
         if: needs.detect-changes.outputs.backend == 'true'
-        run: python -m ruff check --select E,W,F,B --ignore E203,E501,B905 --line-length 128 backend/ tests/
+        run: python -m ruff check backend/ tests/
 
       - name: Pyright type check
         if: needs.detect-changes.outputs.backend == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
               - 'tests/**'
               - 'requirements*.txt'
               - 'pytest.ini'
+              - 'ruff.toml'
+              - 'scripts/**'
             frontend:
               - 'frontend/**'
               - 'biome.json'
@@ -44,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.14"]
+        python-version: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@v4
 
@@ -61,6 +63,26 @@ jobs:
       - name: Resolve dependencies for Python ${{ matrix.python-version }}
         run: scripts/check_resolve.sh ${{ matrix.python-version }}
 
+  security-audit:
+    name: Runtime Dependency Audit
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.requirements == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install pip-audit
+        run: python -m pip install pip-audit==2.10.1
+
+      - name: Audit runtime dependencies
+        run: python -m pip_audit -r requirements.txt
+
   lint-and-format:
     name: Lint & Format Check
     runs-on: ubuntu-latest
@@ -73,7 +95,7 @@ jobs:
         if: needs.detect-changes.outputs.backend == 'true'
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: pip
 
       - name: Install dev dependencies
@@ -90,7 +112,7 @@ jobs:
 
       - name: Ruff lint
         if: needs.detect-changes.outputs.backend == 'true'
-        run: python -m ruff check --select E,W,F,B --ignore E203,E501 --line-length 128 backend/ tests/
+        run: python -m ruff check --select E,W,F,B --ignore E203,E501,B905 --line-length 128 backend/ tests/
 
       - name: Pyright type check
         if: needs.detect-changes.outputs.backend == 'true'
@@ -111,17 +133,21 @@ jobs:
         run: biome format frontend/
 
   tests:
-    name: Tests
+    name: Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.backend == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
 
       - name: Install dev dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.14"]
+        python-version: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@v6
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Dependency order (top to bottom — each layer may only import layers below it):
 
 | Layer | Purpose |
 |-------|---------|
-| `core/` | Dependency-free kernel: `llm_types`, `macros`, `locks`, `utils` |
+| `core/` | Dependency-free kernel: `domain_types`, `llm_types`, `macros`, `locks`, `utils` |
 | `database/` | aiosqlite foundation: schema, migrations, queries, models (TypedDicts) |
 | `inference/` | LLM transport + prompt/tool assembly (`client`, `cached_call`, `prompt_builder`, `tool_registry`) |
 | `analysis/` | Pure prose-quality detection: `audit.py` + detectors; shared by editor + workflows |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 Orb is an **agentic AI roleplay/writing frontend**: Python/FastAPI backend, vanilla JS frontend. Orchestrates a multi-pass LLM pipeline (Director → Writer → Editor). Characters are PNG cards (V2 spec). Conversations are branching message trees with lorebooks, mood/interactive fragments, and personas.
 
-**Stack:** Python 3.9+, FastAPI, aiosqlite, SQLite, vanilla JS (no framework), uvicorn
+**Stack:** Python 3.11+, FastAPI, aiosqlite, SQLite, vanilla JS (no framework), uvicorn
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for wanting to contribute. Here's what to do before opening a PR.
 
 Make sure the feature or fix works first.
 
-Start the backend with `./run_unix.sh` (or `run_windows.bat` on Windows). Python 3.9+ required.
+Start the backend with `./run_unix.sh` (or `run_windows.bat` on Windows). Python 3.11+ required.
 
 ### Optional: Auto-formatting on commit
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For a stepped visual walkthrough of the cache mechanism across all three passes 
 ## Requirements
 1. A model with solid tool/function calling capabilities (recommended: Gemma 4)
 2. OpenAI-compatible LLM inference backend API that supports prompt-caching
-3. Python 3.9+
+3. Python 3.11+
 
 ## Wiki
 

--- a/backend/analysis/audit.py
+++ b/backend/analysis/audit.py
@@ -97,7 +97,7 @@ class AuditReport:
         self.echo_result = echo_result
 
     @classmethod
-    def clean(cls) -> "AuditReport":
+    def clean(cls) -> AuditReport:
         """Return a clean report with zero issues (used when audit is disabled)."""
         return cls(
             cliche_result=DetectionResult([], [], 0, 0),

--- a/backend/analysis/detectors/anti_echo.py
+++ b/backend/analysis/detectors/anti_echo.py
@@ -57,14 +57,14 @@ __all__ = [
 # ---------- public dataclasses ----------
 
 
-@dataclass
+@dataclass(slots=True)
 class FlaggedEcho:
     echo: str  # the interrogative sentence flagged
     matched_phrase: str  # the contiguous run copied from the user (normalized)
     n_words: int  # length of that run, in words
 
 
-@dataclass
+@dataclass(slots=True)
 class EchoResult:
     flagged_echoes: list[FlaggedEcho] = field(default_factory=list)
 

--- a/backend/analysis/detectors/opening_monotony.py
+++ b/backend/analysis/detectors/opening_monotony.py
@@ -27,7 +27,7 @@ DEBUG = "DEBUG_OPENING_MONOTONY" in os.environ
 # ---------- public dataclasses (unchanged) ----------
 
 
-@dataclass
+@dataclass(slots=True)
 class FlaggedOpener:
     opener: str
     count: int
@@ -36,7 +36,7 @@ class FlaggedOpener:
     sentences: list[str] = field(default_factory=list)
 
 
-@dataclass
+@dataclass(slots=True)
 class MonotonyResult:
     flagged_openers: list[FlaggedOpener]
     all_openers: dict[str, int]

--- a/backend/analysis/detectors/phrase_repetition.py
+++ b/backend/analysis/detectors/phrase_repetition.py
@@ -57,7 +57,7 @@ __all__ = [
 # ---------- public dataclasses ----------
 
 
-@dataclass
+@dataclass(slots=True)
 class FlaggedPhrase:
     phrase: str
     count: int
@@ -65,7 +65,7 @@ class FlaggedPhrase:
     example_sentences: list[str] = field(default_factory=list)
 
 
-@dataclass
+@dataclass(slots=True)
 class PhraseResult:
     flagged_phrases: list[FlaggedPhrase]
     total_messages: int

--- a/backend/analysis/detectors/slop_detector.py
+++ b/backend/analysis/detectors/slop_detector.py
@@ -53,19 +53,19 @@ _WINDOW_PADDING = 2
 _SENTENCE_BOUNDARY = re.compile(r'[.!?]["”’\'*_)\]]*(\s|[A-Z])')
 
 
-@dataclass
+@dataclass(slots=True)
 class ClicheHit:
     phrase: str
     score: float
 
 
-@dataclass
+@dataclass(slots=True)
 class FlaggedSentence:
     sentence: str
     cliches: list[ClicheHit] = field(default_factory=list)
 
 
-@dataclass
+@dataclass(slots=True)
 class DetectionResult:
     flagged_sentences: list[FlaggedSentence]
     unique_cliches: list[str]

--- a/backend/analysis/detectors/structural_repetition.py
+++ b/backend/analysis/detectors/structural_repetition.py
@@ -34,14 +34,14 @@ __all__ = ["detect_structural_repetition", "StructuralResult", "MessageStructure
 # ---------- dataclasses ----------
 
 
-@dataclass
+@dataclass(slots=True)
 class MessageStructure:
     index: int
     signature: list[str]
     blocks: list[tuple[str, str]] = field(default_factory=list)
 
 
-@dataclass
+@dataclass(slots=True)
 class StructuralResult:
     is_repetitive: bool
     min_similarity: float

--- a/backend/analysis/detectors/template_repetition.py
+++ b/backend/analysis/detectors/template_repetition.py
@@ -44,7 +44,7 @@ __all__ = [
 # ---------- public dataclasses ----------
 
 
-@dataclass
+@dataclass(slots=True)
 class FlaggedTemplate:
     template: str
     count: int
@@ -52,7 +52,7 @@ class FlaggedTemplate:
     sentences: list[str] = field(default_factory=list)
 
 
-@dataclass
+@dataclass(slots=True)
 class TemplateResult:
     flagged_templates: list[FlaggedTemplate]
     all_templates: dict[str, int]

--- a/backend/analysis/format_consistency.py
+++ b/backend/analysis/format_consistency.py
@@ -30,7 +30,8 @@ import re
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
+from typing import TypeVar
 
 from .text.text_segmentation import extract_block_spans, split_paragraphs
 
@@ -46,19 +47,22 @@ __all__ = [
 ]
 
 
-class Dialogue(str, Enum):
+class Dialogue(StrEnum):
     QUOTED = "quoted"
     BARE = "bare"
     UNKNOWN = "unknown"
 
 
-class Narration(str, Enum):
+class Narration(StrEnum):
     ASTERISK = "asterisk"
     BARE = "bare"
     UNKNOWN = "unknown"
 
 
-@dataclass(frozen=True)
+_StyleT = TypeVar("_StyleT", Dialogue, Narration)
+
+
+@dataclass(frozen=True, slots=True)
 class AxisStyle:
     dialogue: Dialogue
     narration: Narration
@@ -67,7 +71,7 @@ class AxisStyle:
         return f"dialogue={self.dialogue.value}, narration={self.narration.value}"
 
 
-@dataclass
+@dataclass(slots=True)
 class FormatDriftReport:
     """What the normalizer decided. ``changed`` is True only when the draft text
     was actually rewritten."""
@@ -239,7 +243,7 @@ def classify_axes(text: str) -> AxisStyle:
     return AxisStyle(dialogue=dialogue, narration=narration)
 
 
-def _stable(values: list[Enum], unknown: Enum) -> Enum:
+def _stable(values: list[_StyleT], unknown: _StyleT) -> _StyleT:
     """The agreed value across a baseline window, or *unknown* if it isn't stable.
 
     Confident (non-unknown) classifications must form a clear majority. A single
@@ -258,8 +262,8 @@ def baseline_axes(messages: list[str]) -> AxisStyle:
     only when the window agrees on it; otherwise it stays UNKNOWN (not enforced)."""
     styles = [classify_axes(m) for m in messages if m and m.strip()]
     return AxisStyle(
-        dialogue=_stable([s.dialogue for s in styles], Dialogue.UNKNOWN),  # type: ignore[arg-type]
-        narration=_stable([s.narration for s in styles], Narration.UNKNOWN),  # type: ignore[arg-type]
+        dialogue=_stable([s.dialogue for s in styles], Dialogue.UNKNOWN),
+        narration=_stable([s.narration for s in styles], Narration.UNKNOWN),
     )
 
 

--- a/backend/analysis/patching.py
+++ b/backend/analysis/patching.py
@@ -11,6 +11,7 @@ unchanged.
 from __future__ import annotations
 
 import logging
+from dataclasses import fields
 
 from .audit import AuditReport
 from .detectors.opening_monotony import FlaggedOpener, MonotonyResult
@@ -38,7 +39,11 @@ def _filter_flagged_items(items, sentences: set[str], total: int, *, cls, label_
     for item in items:
         kept = [s for s in item.sentences if s in sentences]
         if kept:
-            extra = {k: v for k, v in vars(item).items() if k not in (label_field, "count", "fraction", "sentences")}
+            extra = {
+                descriptor.name: getattr(item, descriptor.name)
+                for descriptor in fields(item)
+                if descriptor.name not in (label_field, "count", "fraction", "sentences")
+            }
             filtered.append(
                 cls(
                     **{label_field: getattr(item, label_field)},

--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -18,8 +18,9 @@ import json
 import logging
 import os
 import re
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Callable, Mapping, Sequence, cast
+from typing import Any, cast
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse

--- a/backend/api/routes/messages.py
+++ b/backend/api/routes/messages.py
@@ -3,8 +3,6 @@ SSE-streaming regenerate / rewrite endpoints."""
 
 from __future__ import annotations
 
-from typing import Optional
-
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from ...core.macros import Macros, resolve_inline
@@ -131,7 +129,7 @@ async def api_regenerate_msg(
     cid: str,
     msg_id: int,
     request: Request,
-    data: Optional[RegenerateMsg] = None,
+    data: RegenerateMsg | None = None,
     _conv: ConversationRow = Depends(require_conversation),  # noqa: B008
 ):
     """Regenerate a specific assistant message as a new sibling branch."""
@@ -143,7 +141,7 @@ async def api_super_regenerate_msg(
     cid: str,
     msg_id: int,
     request: Request,
-    data: Optional[RegenerateMsg] = None,
+    data: RegenerateMsg | None = None,
     _conv: ConversationRow = Depends(require_conversation),  # noqa: B008
 ):
     """Super-regenerate: keeps prior response as context, asks model for a different direction."""
@@ -179,7 +177,7 @@ async def api_send_message(
 async def api_continue_from_user(
     cid: str,
     request: Request,
-    data: Optional[RegenerateMsg] = None,
+    data: RegenerateMsg | None = None,
     _conv: ConversationRow = Depends(require_conversation),  # noqa: B008
 ):
     """Generate an assistant response for the current user turn without creating a new message."""

--- a/backend/api/routes/workflows.py
+++ b/backend/api/routes/workflows.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -7,58 +7,60 @@ it needs and the shapes stay discoverable in one place.
 
 from __future__ import annotations
 
-from typing import Any, List, Literal, Optional
+from typing import Any, Literal
 from urllib.parse import urlsplit
 
 from pydantic import BaseModel, Field, field_validator, model_validator
+
+from ..core.domain_types import AgentLane, CompletionMode
 
 
 class SettingsUpdate(BaseModel):
     model_config = {"protected_namespaces": ()}
 
-    endpoint_url: Optional[str] = None
-    api_key: Optional[str] = None
-    model_name: Optional[str] = None
+    endpoint_url: str | None = None
+    api_key: str | None = None
+    model_name: str | None = None
     # Hyperparameters (temperature, min_p, top_k, top_p, repetition_penalty,
     # max_tokens) are intentionally NOT on this contract: they live on the active
     # endpoint's model_config and are edited via /models/{id}. get_settings()
     # overlays them for reads, so a write here would be silently discarded. The
     # frontend still includes them in its /settings PUT payload; extra fields are
     # ignored (default Pydantic behavior), mirroring completion_mode.
-    shared_system_prompt: Optional[str] = None
-    system_prompt: Optional[str] = None
-    user_name: Optional[str] = None
-    user_description: Optional[str] = None
-    enabled_tools: Optional[dict[str, bool]] = None
-    enable_agent: Optional[bool] = None
-    length_guard_enabled: Optional[bool] = None
-    length_guard_enforce: Optional[bool] = None
-    agentic_lorebook_enabled: Optional[bool] = None
-    length_guard_max_words: Optional[int] = None
-    length_guard_max_paragraphs: Optional[int] = None
-    reasoning_enabled_passes: Optional[dict] = None
-    active_persona_id: Optional[int] = None
-    character_library_view: Optional[str] = None
-    character_library_sort: Optional[str] = None
-    active_endpoint_id: Optional[int] = None
-    show_editor_diff: Optional[bool] = None
-    editor_audit_toggles: Optional[dict] = None
+    shared_system_prompt: str | None = None
+    system_prompt: str | None = None
+    user_name: str | None = None
+    user_description: str | None = None
+    enabled_tools: dict[str, bool] | None = None
+    enable_agent: bool | None = None
+    length_guard_enabled: bool | None = None
+    length_guard_enforce: bool | None = None
+    agentic_lorebook_enabled: bool | None = None
+    length_guard_max_words: int | None = None
+    length_guard_max_paragraphs: int | None = None
+    reasoning_enabled_passes: dict | None = None
+    active_persona_id: int | None = None
+    character_library_view: str | None = None
+    character_library_sort: str | None = None
+    active_endpoint_id: int | None = None
+    show_editor_diff: bool | None = None
+    editor_audit_toggles: dict | None = None
     # Document-mode Output Auditor (doc-owned columns; deliberately not shared
     # with editor_audit_toggles so a doc-mode save can't perturb chat scanners).
-    document_audit_enabled: Optional[bool] = None
-    document_audit_autopatch: Optional[bool] = None
-    document_audit_toggles: Optional[dict] = None
-    hide_streaming_until_baked: Optional[bool] = None
-    prevent_prompt_overrides: Optional[bool] = None
-    agent_same_as_writer: Optional[bool] = None
-    agent_endpoint_id: Optional[int] = None
-    agent_shared_system_prompt: Optional[str] = None
-    feedback_enabled: Optional[bool] = None
-    director_individual_fragments: Optional[bool] = None
-    direction_notes_record: Optional[bool] = None
-    direction_notes_inject: Optional[Literal["off", "director", "writer", "both"]] = None
-    inspector_open_states: Optional[dict] = None
-    workflows_globally_enabled: Optional[bool] = None
+    document_audit_enabled: bool | None = None
+    document_audit_autopatch: bool | None = None
+    document_audit_toggles: dict | None = None
+    hide_streaming_until_baked: bool | None = None
+    prevent_prompt_overrides: bool | None = None
+    agent_same_as_writer: bool | None = None
+    agent_endpoint_id: int | None = None
+    agent_shared_system_prompt: str | None = None
+    feedback_enabled: bool | None = None
+    director_individual_fragments: bool | None = None
+    direction_notes_record: bool | None = None
+    direction_notes_inject: Literal["off", "director", "writer", "both"] | None = None
+    inspector_open_states: dict | None = None
+    workflows_globally_enabled: bool | None = None
 
 
 class DirectionNoteUpdate(BaseModel):
@@ -91,16 +93,16 @@ class EndpointCreate(BaseModel):
 
 
 class EndpointUpdate(BaseModel):
-    url: Optional[str] = None
-    api_key: Optional[str] = None
-    active_model_config_id: Optional[int] = None
-    agent_active_model_config_id: Optional[int] = None
-    completion_mode: Optional[Literal["chat", "text"]] = None
-    proxy: Optional[str] = None
+    url: str | None = None
+    api_key: str | None = None
+    active_model_config_id: int | None = None
+    agent_active_model_config_id: int | None = None
+    completion_mode: CompletionMode | None = None
+    proxy: str | None = None
 
     @field_validator("proxy")
     @classmethod
-    def _validate_proxy(cls, v: Optional[str]) -> Optional[str]:
+    def _validate_proxy(cls, v: str | None) -> str | None:
         # Empty/blank means "no proxy". A set value must use a scheme httpx
         # accepts (http/https, or socks5 via the httpx[socks] extra); reject
         # anything else here so a typo fails at save time, not on every LLM turn.
@@ -125,7 +127,7 @@ class ModelConfigCreate(BaseModel):
     top_p: float = 0.95
     repetition_penalty: float = 1.0
     max_tokens: int = 4096
-    role: str = "writer"
+    role: AgentLane = "writer"
     reasoning_effort: str = ""
     reasoning_effort_param: str = ""
     reasoning_effort_value: str = ""
@@ -134,17 +136,17 @@ class ModelConfigCreate(BaseModel):
 class ModelConfigUpdate(BaseModel):
     model_config = {"protected_namespaces": ()}
 
-    model_name: Optional[str] = None
-    system_prompt: Optional[str] = None
-    temperature: Optional[float] = None
-    min_p: Optional[float] = None
-    top_k: Optional[int] = None
-    top_p: Optional[float] = None
-    repetition_penalty: Optional[float] = None
-    max_tokens: Optional[int] = None
-    reasoning_effort: Optional[str] = None
-    reasoning_effort_param: Optional[str] = None
-    reasoning_effort_value: Optional[str] = None
+    model_name: str | None = None
+    system_prompt: str | None = None
+    temperature: float | None = None
+    min_p: float | None = None
+    top_k: int | None = None
+    top_p: float | None = None
+    repetition_penalty: float | None = None
+    max_tokens: int | None = None
+    reasoning_effort: str | None = None
+    reasoning_effort_param: str | None = None
+    reasoning_effort_value: str | None = None
 
 
 class MoodFragmentCreate(BaseModel):
@@ -157,11 +159,11 @@ class MoodFragmentCreate(BaseModel):
 
 
 class MoodFragmentUpdate(BaseModel):
-    label: Optional[str] = None
-    description: Optional[str] = None
-    prompt_text: Optional[str] = None
-    negative_prompt: Optional[str] = None
-    enabled: Optional[bool] = None
+    label: str | None = None
+    description: str | None = None
+    prompt_text: str | None = None
+    negative_prompt: str | None = None
+    enabled: bool | None = None
 
 
 class InteractiveFragmentCreate(BaseModel):
@@ -177,14 +179,14 @@ class InteractiveFragmentCreate(BaseModel):
 
 
 class InteractiveFragmentUpdate(BaseModel):
-    label: Optional[str] = None
-    description: Optional[str] = None
-    field_type: Optional[str] = None
-    required: Optional[bool] = None
-    enabled: Optional[bool] = None
-    injection_label: Optional[str] = None
-    sort_order: Optional[int] = None
-    direction_note_timing: Optional[Literal["pre_writer", "post_turn"]] = None
+    label: str | None = None
+    description: str | None = None
+    field_type: str | None = None
+    required: bool | None = None
+    enabled: bool | None = None
+    injection_label: str | None = None
+    sort_order: int | None = None
+    direction_note_timing: Literal["pre_writer", "post_turn"] | None = None
 
 
 class WorldCreate(BaseModel):
@@ -192,8 +194,8 @@ class WorldCreate(BaseModel):
 
 
 class WorldUpdate(BaseModel):
-    name: Optional[str] = None
-    enabled: Optional[bool] = None
+    name: str | None = None
+    enabled: bool | None = None
 
 
 class LorebookEntryCreate(BaseModel):
@@ -207,13 +209,13 @@ class LorebookEntryCreate(BaseModel):
 
 
 class LorebookEntryUpdate(BaseModel):
-    name: Optional[str] = None
-    content: Optional[str] = None
-    keywords: Optional[list[str]] = None
-    case_insensitive: Optional[bool] = None
-    constant: Optional[bool] = None
-    priority: Optional[int] = None
-    enabled: Optional[bool] = None
+    name: str | None = None
+    content: str | None = None
+    keywords: list[str] | None = None
+    case_insensitive: bool | None = None
+    constant: bool | None = None
+    priority: int | None = None
+    enabled: bool | None = None
 
 
 class LorebookImportPayload(BaseModel):
@@ -228,7 +230,7 @@ class LorebookImportPayload(BaseModel):
 
 class ConversationCreate(BaseModel):
     title: str = "New Conversation"
-    character_card_id: Optional[str] = None
+    character_card_id: str | None = None
     character_name: str = ""
     character_scenario: str = ""
     first_mes: str = ""
@@ -236,15 +238,15 @@ class ConversationCreate(BaseModel):
 
 
 class ConversationUpdate(BaseModel):
-    title: Optional[str] = None
+    title: str | None = None
     # Persona lock for this conversation; an explicit null clears it (the route
     # uses model_dump(exclude_unset=True), so absence leaves it untouched).
-    persona_lock_id: Optional[int] = None
+    persona_lock_id: int | None = None
 
 
 class SummarizeRequest(BaseModel):
     keep_count: int  # must be one of 2, 4, 6, 8
-    custom_instructions: Optional[str] = None
+    custom_instructions: str | None = None
 
 
 class CompressRequest(BaseModel):
@@ -253,7 +255,7 @@ class CompressRequest(BaseModel):
 
 
 class CheckpointRequest(BaseModel):
-    title: Optional[str] = None
+    title: str | None = None
 
 
 class DocumentSpan(BaseModel):
@@ -266,16 +268,16 @@ class DocumentSpan(BaseModel):
 
 
 class DocumentCreate(BaseModel):
-    title: Optional[str] = None
+    title: str | None = None
 
 
 class DocumentUpdate(BaseModel):
-    title: Optional[str] = None
-    content: Optional[str] = None
-    generated_spans: Optional[List[DocumentSpan]] = None
+    title: str | None = None
+    content: str | None = None
+    generated_spans: list[DocumentSpan] | None = None
 
     @model_validator(mode="after")
-    def _spans_need_content(self) -> "DocumentUpdate":
+    def _spans_need_content(self) -> DocumentUpdate:
         # content and generated_spans must travel together: spans without content
         # would apply offsets to stale server-side text. Title-only updates are
         # unaffected (neither field set). Uses model_fields_set so an explicit
@@ -322,7 +324,7 @@ class DocumentAuditResponse(BaseModel):
     report: AuditReportPayload
     # "no_complete_sentence" when a truncated draft had nothing auditable left
     # after trimming (the /patch route also uses "clean": nothing to fix).
-    skipped: Optional[str] = None
+    skipped: str | None = None
     # True when a truncated tail fragment was excluded from the scan.
     tail_excluded: bool = False
 
@@ -334,7 +336,7 @@ class DocumentPatchResponse(BaseModel):
     patch_count: int
     errors: list[str] = []
     report_after: AuditReportPayload
-    skipped: Optional[str] = None
+    skipped: str | None = None
 
 
 class CharacterCardCreate(BaseModel):
@@ -344,8 +346,8 @@ class CharacterCardCreate(BaseModel):
     # SHA-256-derived UUID of the raw bytes), then the frontend passes it back
     # here on Save. Preserving the original ID means re-importing a card after
     # deletion relinks its conversation history instead of creating an orphan.
-    id: Optional[str] = None
-    source_format: Optional[str] = None
+    id: str | None = None
+    source_format: str | None = None
     name: str
     description: str = ""
 
@@ -367,23 +369,23 @@ class CharacterCardCreate(BaseModel):
     tags: list[str] = []
     creator: str = ""
     alternate_greetings: list[str] = []
-    avatar_b64: Optional[str] = None
-    avatar_mime: Optional[str] = None
-    world_id: Optional[str] = None
-    character_book: Optional[dict] = None
+    avatar_b64: str | None = None
+    avatar_mime: str | None = None
+    world_id: str | None = None
+    character_book: dict | None = None
     # V2 card extensions dict, stored verbatim (third-party keys round-trip
     # through export). Orb's card-embedded fragments live at orb.fragments;
     # card_embedded_fragments() validates that subtree on consumption.
-    extensions: Optional[dict] = None
+    extensions: dict | None = None
 
 
 class CharacterCardUpdate(BaseModel):
-    name: Optional[str] = None
-    description: Optional[str] = None
+    name: str | None = None
+    description: str | None = None
 
     @field_validator("name")
     @classmethod
-    def name_must_not_be_blank(cls, v: Optional[str]) -> Optional[str]:
+    def name_must_not_be_blank(cls, v: str | None) -> str | None:
         if v is not None:
             stripped = v.strip()
             if not stripped:
@@ -391,30 +393,30 @@ class CharacterCardUpdate(BaseModel):
             return stripped
         return v
 
-    personality: Optional[str] = None
-    scenario: Optional[str] = None
-    first_mes: Optional[str] = None
-    mes_example: Optional[str] = None
-    creator_notes: Optional[str] = None
-    system_prompt: Optional[str] = None
-    post_history_instructions: Optional[str] = None
-    tags: Optional[list[str]] = None
-    creator: Optional[str] = None
-    alternate_greetings: Optional[list[str]] = None
-    avatar_b64: Optional[str] = None
-    avatar_mime: Optional[str] = None
-    world_id: Optional[str] = None
-    extensions: Optional[dict] = None
+    personality: str | None = None
+    scenario: str | None = None
+    first_mes: str | None = None
+    mes_example: str | None = None
+    creator_notes: str | None = None
+    system_prompt: str | None = None
+    post_history_instructions: str | None = None
+    tags: list[str] | None = None
+    creator: str | None = None
+    alternate_greetings: list[str] | None = None
+    avatar_b64: str | None = None
+    avatar_mime: str | None = None
+    world_id: str | None = None
+    extensions: dict | None = None
     # Persona lock for this character card; an explicit null clears it (handled
     # via model_fields_set in api_update_character since the route drops Nones).
-    persona_lock_id: Optional[int] = None
+    persona_lock_id: int | None = None
 
 
 class AttachmentIn(BaseModel):
     b64: str
     mime: str
-    filename: Optional[str] = None
-    size: Optional[int] = None
+    filename: str | None = None
+    size: int | None = None
 
     @field_validator("size")
     @classmethod
@@ -439,14 +441,14 @@ class AttachmentIn(BaseModel):
 class SendMessage(BaseModel):
     content: str
     enable_agent: bool = True
-    turn_index: Optional[int] = None
-    attachments: List[AttachmentIn] = []
+    turn_index: int | None = None
+    attachments: list[AttachmentIn] = []
 
 
 class EditMessage(BaseModel):
     content: str
     enable_agent: bool = True
-    attachments: List[AttachmentIn] = []
+    attachments: list[AttachmentIn] = []
 
 
 class RegenerateMsg(BaseModel):
@@ -476,13 +478,13 @@ class PhraseGroupUpdate(BaseModel):
 class UserPersonaCreate(BaseModel):
     name: str
     description: str = ""
-    avatar_color: Optional[str] = None
+    avatar_color: str | None = None
 
 
 class UserPersonaUpdate(BaseModel):
-    name: Optional[str] = None
-    description: Optional[str] = None
-    avatar_color: Optional[str] = None
+    name: str | None = None
+    description: str | None = None
+    avatar_color: str | None = None
 
 
 class ResetConfirm(BaseModel):
@@ -495,6 +497,6 @@ class ImportUrlRequest(BaseModel):
 
 
 class PresetExportRequest(BaseModel):
-    domains: List[str]
+    domains: list[str]
     strip_keys: bool = True
     label: str = ""

--- a/backend/core/domain_types.py
+++ b/backend/core/domain_types.py
@@ -1,0 +1,11 @@
+"""Dependency-free aliases for closed string domains shared across layers."""
+
+from __future__ import annotations
+
+from typing import Literal, TypeAlias
+
+AgentLane: TypeAlias = Literal["writer", "agent"]
+CompletionMode: TypeAlias = Literal["chat", "text"]
+MessageRole: TypeAlias = Literal["user", "assistant"]
+
+__all__ = ["AgentLane", "CompletionMode", "MessageRole"]

--- a/backend/core/llm_types.py
+++ b/backend/core/llm_types.py
@@ -12,9 +12,7 @@ catch-all.
 
 from __future__ import annotations
 
-from typing import Any, Literal, TypedDict, Union
-
-from typing_extensions import NotRequired
+from typing import Any, Literal, NotRequired, TypedDict
 
 
 class TextPart(TypedDict):
@@ -40,7 +38,7 @@ class ImagePart(TypedDict):
 # A message body is either a plain string or, for vision-capable turns, a list
 # of typed parts. ``build_multimodal_content`` and
 # ``format_message_with_attachments`` emit the list form.
-ContentPart = Union[TextPart, ImagePart]
+ContentPart = TextPart | ImagePart
 
 
 class ChatMessage(TypedDict):
@@ -90,4 +88,4 @@ class ToolResultMessage(TypedDict):
 # ``ChatMessage`` could not flow into it. As a union member it flows in
 # directly, letting a buffer be built ``[*prefix, ...]`` and typed
 # ``list[WireMessage]`` with no cast.
-WireMessage = Union[ChatMessage, AssistantToolMessage, ToolResultMessage]
+WireMessage = ChatMessage | AssistantToolMessage | ToolResultMessage

--- a/backend/core/macros.py
+++ b/backend/core/macros.py
@@ -67,8 +67,9 @@ from __future__ import annotations
 
 import random
 import re
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from datetime import datetime
-from typing import Any, Callable, Mapping, MutableMapping, NamedTuple, Sequence
+from typing import Any, NamedTuple
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -296,7 +297,7 @@ class Macros(NamedTuple):
         char_name: str,
         active_persona: Mapping[str, Any] | None = None,
         seed: str = "",
-    ) -> "Macros":
+    ) -> Macros:
         user = active_persona.get("name", "User") if active_persona else settings.get("user_name", "User")
         return cls(user=user, char=char_name, seed=seed)
 

--- a/backend/core/utils.py
+++ b/backend/core/utils.py
@@ -4,7 +4,8 @@ utils.py — Shared helpers.
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from .llm_types import ContentPart
 
@@ -53,7 +54,7 @@ def extract_hyperparams(settings: Mapping[str, Any], *, defaults: Mapping[str, A
     return params
 
 
-def build_multimodal_content(text: str, attachments: Optional[Sequence[Mapping[str, Any]]] = None) -> str | list[ContentPart]:
+def build_multimodal_content(text: str, attachments: Sequence[Mapping[str, Any]] | None = None) -> str | list[ContentPart]:
     """Wrap *text* (and optional image attachments) into a multimodal content list.
 
     Returns a plain string when there are no attachments, or a list of content

--- a/backend/database/bootstrap.py
+++ b/backend/database/bootstrap.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from .connection import get_db
 from .schema import CREATE_TABLES_SQL
@@ -126,7 +126,7 @@ async def _seed_settings(db) -> None:
 
 async def _seed_default_persona(db) -> None:
     """Create the default persona and link it as active (was migration 0003)."""
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(UTC).isoformat()
     cur = await db.execute(
         "INSERT INTO user_personas (name, description, avatar_color, created_at, updated_at) VALUES ('User', '', '#3b82f6', ?, ?)",
         (now, now),

--- a/backend/database/migrations/0003_create_default_persona.py
+++ b/backend/database/migrations/0003_create_default_persona.py
@@ -6,7 +6,7 @@ and settings.user_description, and link it as active_persona_id.
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def migrate(conn: sqlite3.Connection) -> None:
@@ -30,7 +30,7 @@ def migrate(conn: sqlite3.Connection) -> None:
         pass
 
     # Create a default persona
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(UTC).isoformat()
     # Use a pleasant default avatar color (blue)
     avatar_color = "#3b82f6"
     cursor = conn.execute(

--- a/backend/database/migrations/0007_add_user_personas_columns.py
+++ b/backend/database/migrations/0007_add_user_personas_columns.py
@@ -7,7 +7,7 @@ were added.
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def migrate(conn: sqlite3.Connection) -> None:
@@ -19,7 +19,7 @@ def migrate(conn: sqlite3.Connection) -> None:
         print("[migrations] 0007: added avatar_color column to user_personas")
 
     if "updated_at" not in columns:
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         conn.execute("ALTER TABLE user_personas ADD COLUMN updated_at TEXT")
         # Backfill existing rows with current timestamp
         conn.execute("UPDATE user_personas SET updated_at = ? WHERE updated_at IS NULL", (now,))

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -9,7 +9,9 @@ architectural inversion; put the shape here instead.
 
 from __future__ import annotations
 
-from typing import Literal, TypedDict, Union
+from typing import Literal, TypedDict
+
+from ..core.domain_types import AgentLane, CompletionMode, MessageRole
 
 
 # A phrase-bank group is one of three shapes. ``get_phrase_bank()`` emits the
@@ -31,7 +33,7 @@ class RegexPhraseGroup(TypedDict):
     pattern: str
 
 
-PhraseGroup = Union[list[str], LiteralPhraseGroup, RegexPhraseGroup]
+PhraseGroup = list[str] | LiteralPhraseGroup | RegexPhraseGroup
 
 
 class PhraseBankRow(TypedDict):
@@ -138,8 +140,8 @@ class SettingsRow(_SettingsBase, total=False):
     # Per-endpoint transport mode, surfaced by the get_settings() overlay from
     # the active/agent endpoint row (default 'chat'). agent_completion_mode
     # falls back to completion_mode when the agent shares the writer endpoint.
-    completion_mode: Literal["chat", "text"]
-    agent_completion_mode: Literal["chat", "text"]
+    completion_mode: CompletionMode
+    agent_completion_mode: CompletionMode
     # Per-endpoint proxy URL, surfaced by the same overlay (default ''); empty
     # means a direct connection. agent_proxy falls back to proxy when the agent
     # shares the writer endpoint.
@@ -214,7 +216,7 @@ class MessageRow(TypedDict):
 
     id: int
     conversation_id: str
-    role: Literal["user", "assistant"]
+    role: MessageRole
     content: str
     turn_index: int
     parent_id: int | None
@@ -303,7 +305,7 @@ class EndpointRow(TypedDict):
     api_key: str
     active_model_config_id: int | None
     agent_active_model_config_id: int | None
-    completion_mode: Literal["chat", "text"]
+    completion_mode: CompletionMode
     proxy: str
 
 
@@ -320,7 +322,7 @@ class ModelConfigRow(TypedDict):
     top_p: float
     repetition_penalty: float
     max_tokens: int
-    role: Literal["writer", "agent"]
+    role: AgentLane
     reasoning_effort: str
     reasoning_effort_param: str
     reasoning_effort_value: str

--- a/backend/database/queries/character_cards.py
+++ b/backend/database/queries/character_cards.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import base64
 import json
 import re
-from datetime import datetime, timezone
-from typing import Any, Mapping, cast
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any, cast
 
 import aiosqlite
 
@@ -164,7 +165,7 @@ def card_embedded_fragments(
 
 async def create_character_card(data: dict) -> CharacterCardRow:
     async with get_db() as db:
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         try:
             await db.execute(
                 """INSERT INTO character_cards
@@ -217,7 +218,7 @@ async def insert_alternate_greeting_swipes(cid: str, alternate_greetings: list[s
     if not alternate_greetings:
         return 0
     async with get_db() as db:
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         count = 0
         for greeting in alternate_greetings:
             if greeting and greeting.strip():
@@ -303,7 +304,7 @@ async def update_character_card(card_id: str, data: dict) -> CharacterCardRow | 
 
         if sets:
             sets.append("updated_at = ?")
-            vals.append(datetime.now(timezone.utc).isoformat())
+            vals.append(datetime.now(UTC).isoformat())
             vals.append(card_id)
             await db.execute(
                 f"UPDATE character_cards SET {', '.join(sets)} WHERE id = ?",

--- a/backend/database/queries/conversation_logs.py
+++ b/backend/database/queries/conversation_logs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import cast
 
 from ..connection import get_db
@@ -24,7 +24,7 @@ async def add_conversation_log(
     feedback: dict | None = None,
 ):
     async with get_db() as db:
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         await db.execute(
             "INSERT INTO conversation_logs (conversation_id, turn_index, agent_raw_output, tool_calls, active_moods_after, progressive_fields_after, injection_block, agent_latency_ms, created_at, message_id, reasoning_director, reasoning_writer, reasoning_editor, feedback) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (

--- a/backend/database/queries/conversations.py
+++ b/backend/database/queries/conversations.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import cast
 
 from ..connection import _build_set_clause, get_db
@@ -57,7 +57,7 @@ async def create_conversation(
     macro_seed: str = "",
 ) -> ConversationRow:
     async with get_db() as db:
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         await db.execute(
             """INSERT INTO conversations
                (id, title, character_card_id, character_name, character_scenario,
@@ -126,7 +126,7 @@ async def touch_conversation(cid: str) -> bool:
     """Mark a conversation accessed (opened/selected) — bumps last_accessed_at,
     not updated_at. updated_at means content changed; opening isn't an edit."""
     async with get_db() as db:
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         cur = await db.execute("UPDATE conversations SET last_accessed_at = ? WHERE id = ?", (now, cid))
         await db.commit()
         return cur.rowcount > 0
@@ -142,7 +142,7 @@ async def update_conversation(cid: str, data: dict) -> ConversationRow | None:
             # activity, so a persona_lock_id-only update must not bump it.
             if any(k in data for k in allowed if k != "persona_lock_id"):
                 sets.append("updated_at = ?")
-                vals.append(datetime.now(timezone.utc).isoformat())
+                vals.append(datetime.now(UTC).isoformat())
             vals.append(cid)
             await db.execute(
                 f"UPDATE conversations SET {', '.join(sets)} WHERE id = ?",

--- a/backend/database/queries/direction_notes.py
+++ b/backend/database/queries/direction_notes.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Mapping, Sequence, cast
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any, cast
 
 from ..connection import get_db
 from ..models import DirectionNoteRow
@@ -13,7 +14,7 @@ async def create_direction_notes(conversation_id: str, message_id: int, notes: S
     recorded notes key to the turn's assistant reply, a user-authored note to the message the
     Notes button sat on (user or assistant)."""
     ids: list[int] = []
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(UTC).isoformat()
     async with get_db() as db:
         for n in notes:
             cur = await db.execute(

--- a/backend/database/queries/documents.py
+++ b/backend/database/queries/documents.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import cast
 
 from ..connection import _build_set_clause, get_db
@@ -30,7 +30,7 @@ async def get_document(document_id: str) -> DocumentRow | None:
 
 async def create_document(data: dict) -> DocumentRow:
     async with get_db() as db:
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         document_id = data.get("id") or str(uuid.uuid4())
         await db.execute(
             "INSERT INTO documents (id, title, content, generated_spans, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
@@ -55,7 +55,7 @@ async def update_document(document_id: str, data: dict) -> DocumentRow | None:
         sets, vals = _build_set_clause(allowed, data, json_fields={"generated_spans"})
         if sets:
             sets.append("updated_at = ?")
-            vals.append(datetime.now(timezone.utc).isoformat())
+            vals.append(datetime.now(UTC).isoformat())
             vals.append(document_id)
             await db.execute(f"UPDATE documents SET {', '.join(sets)} WHERE id = ?", vals)  # nosec B608
             await db.commit()

--- a/backend/database/queries/messages.py
+++ b/backend/database/queries/messages.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from datetime import datetime, timezone
-from typing import Any, List, Mapping, Optional, Protocol, Sequence, cast
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any, Protocol, cast
 
+from ...core.domain_types import MessageRole
 from ..connection import get_db
 from ..models import (
     MessageRow,
@@ -33,10 +35,10 @@ class _WorkflowAttachmentPersister(Protocol):
 # Left None in DB-only contexts that never produce workflow attachments; in
 # that state a workflow attachment reaching ``add_message`` is a wiring bug, so
 # we fail loudly rather than silently dropping bytes.
-_workflow_attachment_persister: "_WorkflowAttachmentPersister | None" = None
+_workflow_attachment_persister: _WorkflowAttachmentPersister | None = None
 
 
-def register_workflow_attachment_persister(fn: "_WorkflowAttachmentPersister") -> None:
+def register_workflow_attachment_persister(fn: _WorkflowAttachmentPersister) -> None:
     """Wire the workflow-attachment persister into ``add_message``.
 
     Called once, at import of ``backend.workflows.attachment_cache``.
@@ -207,11 +209,11 @@ def user_attachment_payloads(msg: Mapping[str, Any]) -> list[dict] | None:
 
 async def add_message(
     cid: str,
-    role: str,
+    role: MessageRole,
     content: str,
     turn_index: int,
     parent_id: int | None = None,
-    attachments: Optional[Sequence[Mapping[str, Any]]] = None,
+    attachments: Sequence[Mapping[str, Any]] | None = None,
     progressive_fields: dict | None = None,
 ) -> tuple[int, list[dict]]:
     """Add a message. Returns ``(message_id, rejected_workflow_atts)``.
@@ -257,7 +259,7 @@ async def add_message(
         # message INSERT. The cache helper enforces this -- it raises
         # if its conn is not already in a transaction.
         await db.execute("BEGIN IMMEDIATE")
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         try:
             cur = await db.execute(
                 "INSERT INTO messages (conversation_id, role, content, turn_index, parent_id, progressive_fields, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
@@ -304,7 +306,7 @@ async def add_message(
     return message_id, rejected_workflow_atts
 
 
-async def get_user_attachments_for_message(message_id: int) -> List[UserAttachmentRow]:
+async def get_user_attachments_for_message(message_id: int) -> list[UserAttachmentRow]:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(
@@ -316,7 +318,7 @@ async def get_user_attachments_for_message(message_id: int) -> List[UserAttachme
         return [cast(UserAttachmentRow, dict(r)) for r in rows]
 
 
-async def get_workflow_attachments_for_message(message_id: int) -> List[WorkflowAttachmentRowBase]:
+async def get_workflow_attachments_for_message(message_id: int) -> list[WorkflowAttachmentRowBase]:
     async with get_db() as db:
         rows = list(
             await db.execute_fetchall(

--- a/backend/database/queries/stats.py
+++ b/backend/database/queries/stats.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from ..connection import get_db
 
@@ -127,7 +127,7 @@ async def get_global_stats() -> dict:
         # correctly. RANDOM() picks the candidate; the endpoint flips the coin
         # on which theme actually shows.
         fav_name = favorite_character["name"] if favorite_character else ""
-        recent_cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+        recent_cutoff = (datetime.now(UTC) - timedelta(hours=24)).isoformat()
         missed_row = list(
             await db.execute_fetchall(
                 f"""{_ACTIVE_PATH_CTE}

--- a/backend/database/queries/user_personas.py
+++ b/backend/database/queries/user_personas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import cast
 
 from ..connection import _build_set_clause, get_db
@@ -30,7 +30,7 @@ async def get_user_persona(persona_id: int) -> UserPersonaRow | None:
 
 async def create_user_persona(data: dict) -> UserPersonaRow:
     async with get_db() as db:
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         cur = await db.execute(
             "INSERT INTO user_personas (name, description, avatar_color, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
             (
@@ -55,7 +55,7 @@ async def update_user_persona(persona_id: int, data: dict) -> UserPersonaRow | N
         sets, vals = _build_set_clause(allowed, data)
         if sets:
             sets.append("updated_at = ?")
-            vals.append(datetime.now(timezone.utc).isoformat())
+            vals.append(datetime.now(UTC).isoformat())
             vals.append(persona_id)
             await db.execute(
                 f"UPDATE user_personas SET {', '.join(sets)} WHERE id = ?",

--- a/backend/database/queries/workflow_attachments.py
+++ b/backend/database/queries/workflow_attachments.py
@@ -18,7 +18,7 @@ import json
 import logging
 import os
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import cast
 
 from ...core import scrub_log
@@ -191,7 +191,7 @@ async def insert_workflow_attachment_row(
         rows = list(await conn.execute_fetchall("SELECT id FROM messages WHERE id = ?", (message_id,)))
         if not rows:
             raise LookupError(f"message_id {message_id!r} does not exist")
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         cur = await conn.execute(
             """INSERT INTO workflow_attachments
                (message_id, mime_type, data_b64, filename, created_at,

--- a/backend/database/queries/worlds.py
+++ b/backend/database/queries/worlds.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import cast
 
 from ..connection import _build_set_clause, get_db
@@ -29,7 +29,7 @@ async def get_world_by_name(name: str) -> WorldRow | None:
 
 async def create_world(data: dict) -> WorldRow:
     async with get_db() as db:
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         world_id = data.get("id") or str(uuid.uuid4())
         await db.execute(
             "INSERT INTO worlds (id, name, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
@@ -53,7 +53,7 @@ async def update_world(world_id: str, data: dict) -> WorldRow | None:
         sets, vals = _build_set_clause(allowed, data)
         if sets:
             sets.append("updated_at = ?")
-            vals.append(datetime.now(timezone.utc).isoformat())
+            vals.append(datetime.now(UTC).isoformat())
             vals.append(world_id)
             await db.execute(
                 f"UPDATE worlds SET {', '.join(sets)} WHERE id = ?",
@@ -95,7 +95,7 @@ async def get_lorebook_entry(entry_id: int) -> LorebookEntryRow | None:
 
 async def create_lorebook_entry(world_id: str, data: dict) -> LorebookEntryRow:
     async with get_db() as db:
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         cur = await db.execute(
             "INSERT INTO lorebook_entries (world_id, name, content, keywords, case_insensitive, constant, priority, enabled, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
@@ -134,7 +134,7 @@ async def update_lorebook_entry(entry_id: int, data: dict) -> LorebookEntryRow |
         sets, vals = _build_set_clause(allowed, data, json_fields={"keywords"})
         if sets:
             sets.append("updated_at = ?")
-            vals.append(datetime.now(timezone.utc).isoformat())
+            vals.append(datetime.now(UTC).isoformat())
             vals.append(entry_id)
             await db.execute(
                 f"UPDATE lorebook_entries SET {', '.join(sets)} WHERE id = ?",

--- a/backend/features/cards/parsing.py
+++ b/backend/features/cards/parsing.py
@@ -10,7 +10,7 @@ import binascii
 import io
 import json
 import logging
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Literal
 
 from PIL import Image, PngImagePlugin
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
@@ -29,31 +29,31 @@ class TavernCardV1(BaseModel):
     scenario: str = ""
     first_mes: str = ""
     mes_example: str = ""
-    fav: Optional[bool] = None
-    chat: Optional[str] = None
-    creatorcomment: Optional[str] = None
-    avatar: Optional[str] = None
-    create_date: Optional[str] = None
-    talkativeness: Optional[float] = None
+    fav: bool | None = None
+    chat: str | None = None
+    creatorcomment: str | None = None
+    avatar: str | None = None
+    create_date: str | None = None
+    talkativeness: float | None = None
 
 
-PositionType = Optional[Literal["before_char", "after_char"]]
+PositionType = Literal["before_char", "after_char"] | None
 
 
 class CharacterBookEntry(BaseModel):
-    keys: List[str] = Field(default_factory=list)
+    keys: list[str] = Field(default_factory=list)
     content: str = ""
-    extensions: Dict[str, Any] = Field(default_factory=dict)
+    extensions: dict[str, Any] = Field(default_factory=dict)
     enabled: bool = True
-    insertion_order: Union[int, float] = 0
-    case_sensitive: Optional[bool] = None
-    name: Optional[str] = None
-    priority: Optional[Union[int, float]] = None
-    id: Optional[Union[int, float]] = None
-    comment: Optional[str] = None
-    selective: Optional[bool] = None
-    secondary_keys: Optional[List[str]] = None
-    constant: Optional[bool] = None
+    insertion_order: int | float = 0
+    case_sensitive: bool | None = None
+    name: str | None = None
+    priority: int | float | None = None
+    id: int | float | None = None
+    comment: str | None = None
+    selective: bool | None = None
+    secondary_keys: list[str] | None = None
+    constant: bool | None = None
     position: PositionType = None
 
     # Runs before Literal validation so numeric/string world-info positions are
@@ -65,13 +65,13 @@ class CharacterBookEntry(BaseModel):
 
 
 class CharacterBook(BaseModel):
-    name: Optional[str] = None
-    description: Optional[str] = None
-    scan_depth: Optional[int] = None
-    token_budget: Optional[Union[int, float]] = None
-    recursive_scanning: Optional[bool] = None
-    extensions: Dict[str, Any] = Field(default_factory=dict)
-    entries: List[CharacterBookEntry] = Field(default_factory=list)
+    name: str | None = None
+    description: str | None = None
+    scan_depth: int | None = None
+    token_budget: int | float | None = None
+    recursive_scanning: bool | None = None
+    extensions: dict[str, Any] = Field(default_factory=dict)
+    entries: list[CharacterBookEntry] = Field(default_factory=list)
 
 
 class TavernCardV2Data(BaseModel):
@@ -86,18 +86,18 @@ class TavernCardV2Data(BaseModel):
     creator_notes: str = ""
     system_prompt: str = ""
     post_history_instructions: str = ""
-    alternate_greetings: List[str] = Field(default_factory=list)
-    character_book: Optional[CharacterBook] = None
-    tags: List[str] = Field(default_factory=list)
+    alternate_greetings: list[str] = Field(default_factory=list)
+    character_book: CharacterBook | None = None
+    tags: list[str] = Field(default_factory=list)
     creator: str = ""
     character_version: str = ""
-    extensions: Dict[str, Any] = Field(default_factory=dict)
-    fav: Optional[bool] = None
-    chat: Optional[str] = None
-    creatorcomment: Optional[str] = None
-    avatar: Optional[str] = None
-    create_date: Optional[str] = None
-    talkativeness: Optional[float] = None
+    extensions: dict[str, Any] = Field(default_factory=dict)
+    fav: bool | None = None
+    chat: str | None = None
+    creatorcomment: str | None = None
+    avatar: str | None = None
+    create_date: str | None = None
+    talkativeness: float | None = None
 
 
 class TavernCardV2(BaseModel):
@@ -106,7 +106,7 @@ class TavernCardV2(BaseModel):
     data: TavernCardV2Data = Field(default_factory=TavernCardV2Data)
 
 
-def extract_exif_data(image_path: str) -> Dict[str, Any]:
+def extract_exif_data(image_path: str) -> dict[str, Any]:
     img = Image.open(image_path)
     img.load()
     return {k: v for k, v in img.info.items() if isinstance(k, str)}
@@ -131,7 +131,7 @@ def position_converter(data: Any) -> Any:
     return None
 
 
-def first_chara_chunk(image_path: str) -> Optional[str]:
+def first_chara_chunk(image_path: str) -> str | None:
     """Return the first ``chara`` tEXt chunk of a PNG, or None.
 
     PIL's ``img.info`` is a plain dict, so a card carrying *several* ``chara``
@@ -154,7 +154,7 @@ def first_chara_chunk(image_path: str) -> Optional[str]:
     return None
 
 
-def parse(image_path: str) -> Union[TavernCardV2, TavernCardV1]:
+def parse(image_path: str) -> TavernCardV2 | TavernCardV1:
     """
     Parses Tavern Card data from an image file's metadata.
     Attempts to parse as V2 first, falls back to V1 if needed.
@@ -191,7 +191,7 @@ def parse(image_path: str) -> Union[TavernCardV2, TavernCardV1]:
     return from_json_obj(jobj)
 
 
-def from_json_obj(jobj: Dict[str, Any]) -> Union[TavernCardV2, TavernCardV1]:
+def from_json_obj(jobj: dict[str, Any]) -> TavernCardV2 | TavernCardV1:
     """Build a Tavern card from an already-parsed JSON object.
 
     Tries the V2 spec first and falls back to V1, mirroring :func:`parse`
@@ -285,7 +285,7 @@ def to_png(card_dict: dict, avatar_bytes: bytes | None = None) -> bytes:
     return buf.getvalue()
 
 
-def card_to_dict(card: Union[TavernCardV2, TavernCardV1]) -> dict:
+def card_to_dict(card: TavernCardV2 | TavernCardV1) -> dict:
     """Normalize a parsed card (V1 or V2) into a flat dictionary for storage."""
     if isinstance(card, TavernCardV2):
         d = card.data

--- a/backend/features/documents/audit.py
+++ b/backend/features/documents/audit.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from typing import TYPE_CHECKING, Any, Mapping
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
 
 from ...analysis import (
     AuditReport,

--- a/backend/features/documents/continuation.py
+++ b/backend/features/documents/continuation.py
@@ -20,7 +20,8 @@ Two prompting strategies, chosen per request by the ``assisted`` flag:
 from __future__ import annotations
 
 import re
-from typing import Any, AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator, Mapping
+from typing import Any
 
 from ...core import ChatMessage, extract_hyperparams
 from ...inference import LLMClient, reasoning_cfg

--- a/backend/features/summarization/summarizer.py
+++ b/backend/features/summarization/summarizer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, AsyncGenerator, Mapping, Sequence
+from collections.abc import AsyncGenerator, Mapping, Sequence
+from typing import Any
 
 from ...core import ChatMessage, Macros
 from ...inference import LLMClient, prompt_builder

--- a/backend/inference/cached_call.py
+++ b/backend/inference/cached_call.py
@@ -9,8 +9,9 @@ no runtime dependency on it.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .kv_tracker import _KVCacheTracker
@@ -23,8 +24,8 @@ async def cached_complete(
     messages: Sequence[Mapping[str, Any]],
     model: str,
     tools: list[dict] | None = None,
-    tool_choice: "dict | str | None" = None,
-    kv_tracker: "_KVCacheTracker | None" = None,
+    tool_choice: dict | str | None = None,
+    kv_tracker: _KVCacheTracker | None = None,
     record: bool = True,
     **params: Any,
 ) -> AsyncIterator[dict]:
@@ -82,8 +83,8 @@ class CachedBase:
         *,
         label: str,
         trailing: Sequence[Mapping[str, Any]],
-        tool_choice: "dict | str | None" = None,
-        kv_tracker: "_KVCacheTracker | None" = None,
+        tool_choice: dict | str | None = None,
+        kv_tracker: _KVCacheTracker | None = None,
         record: bool = True,
         **params: Any,
     ) -> AsyncIterator[dict]:

--- a/backend/inference/client.py
+++ b/backend/inference/client.py
@@ -4,7 +4,8 @@ import asyncio
 import json
 import logging
 import re
-from typing import Any, AsyncIterator, Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from typing import Any
 
 import httpx
 
@@ -309,7 +310,7 @@ class LLMClient:
         try:
             await asyncio.wait_for(self.abort_token.wait(), timeout=delay)
             return False  # abort fired within the delay
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return True  # full delay elapsed, no abort
 
     async def _complete_chat(

--- a/backend/inference/endpoint_profiles.py
+++ b/backend/inference/endpoint_profiles.py
@@ -18,14 +18,14 @@ To add a new quirk:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Callable, Optional
 
 # Body keys always sent; never subject to allowlist filtering.
 ALWAYS_ALLOWED: frozenset[str] = frozenset({"model", "messages", "stream", "tools", "tool_choice"})
 
 # Mutates body in place. Returns a log line to surface the action, or None.
-Transform = Callable[[dict], Optional[str]]
+Transform = Callable[[dict], str | None]
 
 
 def is_forced_tool_choice(tc: object) -> bool:
@@ -118,7 +118,7 @@ _DEEPSEEK_REASONER_EXTRA: frozenset[str] = _DEEPSEEK_DEFAULT_EXTRA - {
 }
 
 
-def _deepseek_coerce_tool_choice_when_thinking(body: dict) -> Optional[str]:
+def _deepseek_coerce_tool_choice_when_thinking(body: dict) -> str | None:
     """Coerce forced ``tool_choice`` to ``"auto"`` when thinking is enabled.
 
     DeepSeek routes any thinking-on request through reasoner semantics, which
@@ -141,7 +141,7 @@ def _deepseek_coerce_tool_choice_when_thinking(body: dict) -> Optional[str]:
 # -- the more specific one must come first).
 # Inner None key: endpoint default profile. Inner str keys: exact-match
 # per-model overrides (replace, not merge).
-PROFILES: dict[str, dict[Optional[str], ModelProfile]] = {
+PROFILES: dict[str, dict[str | None, ModelProfile]] = {
     "api.deepseek.com": {
         # deepseek-chat supports forced-function tool_choice in chat mode but
         # rejects it whenever the request also carries thinking=enabled (the
@@ -190,7 +190,7 @@ def supports_structured_tool_calls(endpoint_url: str, model: str = "") -> bool:
     return profile is not None and profile.structured_tool_calls
 
 
-def profile_for(endpoint_url: str, model: str = "") -> Optional[ModelProfile]:
+def profile_for(endpoint_url: str, model: str = "") -> ModelProfile | None:
     """Resolve (endpoint_url, model) to a ``ModelProfile``, or ``None`` for pass-through.
 
     A blank *model* falls through to the endpoint default. An unmatched URL
@@ -261,7 +261,7 @@ def prepare_request_body(endpoint_url: str, model: str, body: dict) -> list[str]
     return actions
 
 
-def recover_from_error(endpoint_url: str, model: str, body: dict, status: int, text: str) -> Optional[str]:
+def recover_from_error(endpoint_url: str, model: str, body: dict, status: int, text: str) -> str | None:
     """Handle a >=400 response. If a known provider quirk explains it, mutate
     *body* in place, record the quirk for the session, and return a log line
     (triggering one retry). Returns ``None`` to propagate the error.

--- a/backend/inference/kv_tracker.py
+++ b/backend/inference/kv_tracker.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/backend/inference/local_ml.py
+++ b/backend/inference/local_ml.py
@@ -20,8 +20,9 @@ import asyncio
 import math
 import os
 import sys
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 _ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/backend/inference/lorebook.py
+++ b/backend/inference/lorebook.py
@@ -17,7 +17,8 @@ so the two named entry points below (:func:`compute_lorebook_injection_block`,
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from ..core import Macros
 

--- a/backend/inference/prompt_builder.py
+++ b/backend/inference/prompt_builder.py
@@ -5,7 +5,8 @@ injections, and tool-call request messages for the pipeline passes.
 
 from __future__ import annotations
 
-from typing import Any, Collection, Mapping, MutableMapping, Sequence
+from collections.abc import Collection, Mapping, MutableMapping, Sequence
+from typing import Any
 
 from ..core import ChatMessage, ContentPart, Macros, resolve_stored_random
 from .tool_registry import TOOLS

--- a/backend/inference/text_completion.py
+++ b/backend/inference/text_completion.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 import logging
 import math
 import re
-from typing import Any, Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/backend/inference/tool_registry.py
+++ b/backend/inference/tool_registry.py
@@ -4,7 +4,8 @@ tool_registry.py — Built-in tool schemas and the tool registry.
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 # ── Agent tool definitions (OpenAI function-calling format)
 

--- a/backend/pipeline/config.py
+++ b/backend/pipeline/config.py
@@ -13,7 +13,8 @@ why the dependency-free predicates live in ``predicates.py`` rather than here.
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from ..core import ChatMessage, Macros
 from ..database.models import PhraseGroup

--- a/backend/pipeline/context.py
+++ b/backend/pipeline/context.py
@@ -18,9 +18,10 @@ patching ``backend.inference.client.LLMClient``.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any, AsyncIterator, Mapping, Optional, Sequence
+from typing import Any
 
 from .. import database as db
 from ..core import ChatMessage, Macros
@@ -55,7 +56,7 @@ from .state import LorebookTurn
 from .workflow_bridge import _iterate_pre_pipeline_hooks
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PipelineContext:
     """Per-conversation data loaded once and threaded through every entry point.
 
@@ -69,7 +70,7 @@ class PipelineContext:
 
     settings: SettingsRow
     conv: ConversationRow
-    card: Optional[CharacterCardRow]
+    card: CharacterCardRow | None
     # Seeded from director_state, then carried as mutable per-turn director state
     # (active moods, progressive fields, direction notes); not all keys are columns.
     director: dict[str, Any]
@@ -81,9 +82,9 @@ class PipelineContext:
     system_prompt: str
     char_persona: str
     mes_example: str
-    active_persona: Optional[UserPersonaRow]
-    agent_client: Optional[LLMClient]
-    agent_system_prompt: Optional[str]
+    active_persona: UserPersonaRow | None
+    agent_client: LLMClient | None
+    agent_system_prompt: str | None
 
 
 async def _load_pipeline_context(conversation_id: str, *, abort_token: AbortToken | None = None) -> PipelineContext | None:
@@ -248,7 +249,7 @@ def _build_prefixes(
     return prefix, agent_prefix
 
 
-@dataclass
+@dataclass(slots=True)
 class _TurnSetup:
     """Per-turn inputs produced by :func:`_prepare_turn`, ready for ``_run_pipeline``.
 

--- a/backend/pipeline/entrypoints.py
+++ b/backend/pipeline/entrypoints.py
@@ -18,7 +18,8 @@ message they inject.
 from __future__ import annotations
 
 import logging
-from typing import Any, AsyncIterator, Callable, List, Mapping, Optional, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from typing import Any
 
 from .. import database as db
 from ..core import resolve_inline
@@ -207,7 +208,7 @@ async def handle_turn(
     conversation_id: str,
     user_message: str,
     skip_user_persist: bool = False,
-    attachments: Optional[List[dict]] = None,
+    attachments: list[dict] | None = None,
     abort_token: AbortToken | None = None,
 ) -> AsyncIterator[dict]:
     """Save the user message, run the pipeline, and stream the reply.

--- a/backend/pipeline/orchestrator.py
+++ b/backend/pipeline/orchestrator.py
@@ -13,7 +13,8 @@ public entry points in ``entrypoints``. ``_run_pipeline`` is called by
 from __future__ import annotations
 
 import logging
-from typing import Any, AsyncIterator, Mapping, Optional, Sequence
+from collections.abc import AsyncIterator, Mapping, Sequence
+from typing import Any
 
 from ..core import ChatMessage, Macros
 from ..database.models import PhraseGroup
@@ -66,7 +67,7 @@ async def _run_pipeline(
     mood_fragments: Sequence[Mapping[str, Any]],
     interactive_fragments: Sequence[Mapping[str, Any]],
     user_message: str,
-    attachments: Optional[Sequence[Mapping[str, Any]]] = None,
+    attachments: Sequence[Mapping[str, Any]] | None = None,
     phrase_bank: list[PhraseGroup] | None = None,
     editor_audit_msgs: list[str] | None = None,
     agent_client: LLMClient | None = None,

--- a/backend/pipeline/passes/director/direction_note.py
+++ b/backend/pipeline/passes/director/direction_note.py
@@ -25,8 +25,9 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Mapping, Sequence
+from typing import Any
 
 from ....core import ChatMessage, ContentPart, extract_hyperparams
 from ....inference import (
@@ -42,7 +43,7 @@ from ....inference import (
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(slots=True)
 class DirectionNoteResult:
     """Typed result of the direction-note step, yielded as the ``done`` payload.
 
@@ -88,7 +89,7 @@ async def direction_note_step(
     placement: str,
     inj_block: str | None = None,
     reply_text: str | None = None,
-    writer_user_msg: "str | list[ContentPart] | None" = None,
+    writer_user_msg: str | list[ContentPart] | None = None,
     kv_tracker=None,
     reasoning_on: bool = False,
 ) -> AsyncIterator[dict]:

--- a/backend/pipeline/passes/director/director.py
+++ b/backend/pipeline/passes/director/director.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 import json
 import logging
 import time
+from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, AsyncIterator, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Any
 
 from ....core import (
     ChatMessage,
@@ -77,7 +78,7 @@ def _step_schema(tool_schema: dict, keep: str) -> dict | None:
     }
 
 
-@dataclass
+@dataclass(slots=True)
 class DirectorResult:
     """Typed result of the director pass, yielded as the ``done`` event payload.
 
@@ -132,7 +133,7 @@ async def director_pass(
     mood_fragments: Sequence[Mapping[str, Any]],
     interactive_fragments: Sequence[Mapping[str, Any]],
     enabled_tools: Mapping[str, bool],
-    attachments: Optional[Sequence[Mapping[str, Any]]] = None,
+    attachments: Sequence[Mapping[str, Any]] | None = None,
     kv_tracker=None,
     reasoning_on: bool = True,
     lorebook_block: str = "",
@@ -347,8 +348,8 @@ def _resolve_random_in_value(value: Any) -> Any:
 
 
 async def director_stage(
-    cfg: "_PipelineConfig",
-    state: "TurnState",
+    cfg: _PipelineConfig,
+    state: TurnState,
     *,
     settings: Mapping[str, Any],
     director: Mapping[str, Any],
@@ -356,8 +357,8 @@ async def director_stage(
     writer_fragments: Sequence[Mapping[str, Any]],
     attachments: Sequence[Mapping[str, Any]],
     kv_tracker: _KVCacheTracker,
-    lorebook: "LorebookTurn",
-    macros: "Macros",
+    lorebook: LorebookTurn,
+    macros: Macros,
 ) -> AsyncIterator[dict]:
     """Input-prep + director pass + all post-processing for the director stage.
 

--- a/backend/pipeline/passes/director/lorebook_select.py
+++ b/backend/pipeline/passes/director/lorebook_select.py
@@ -17,8 +17,8 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
-from typing import AsyncIterator, Mapping
 
 from ....core import extract_hyperparams
 from ....inference import (
@@ -33,7 +33,7 @@ from ....inference import (
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(slots=True)
 class LorebookSelectResult:
     """Typed result of the lorebook-select step, yielded as the ``done`` payload.
 

--- a/backend/pipeline/passes/director/progressive.py
+++ b/backend/pipeline/passes/director/progressive.py
@@ -15,7 +15,8 @@ branch-aware reset. Both helpers here are pure.
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 
 def select(values: Mapping[str, Any], interactive_fragments: Sequence[Mapping[str, Any]]) -> dict:

--- a/backend/pipeline/passes/editor/editor.py
+++ b/backend/pipeline/passes/editor/editor.py
@@ -9,7 +9,8 @@ import asyncio
 import json
 import logging
 import time
-from typing import TYPE_CHECKING, Any, AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 from ....analysis import (
     AuditReport,
@@ -193,8 +194,8 @@ async def editor_pass(
     kv_tracker=None,
     reasoning_on: bool = False,
     audit_context_msgs: list[str] | None = None,
-    writer_user_msg: "str | list[ContentPart] | None" = None,
-    feedback_fragments: "Sequence[Mapping[str, Any]] | None" = None,
+    writer_user_msg: str | list[ContentPart] | None = None,
+    feedback_fragments: Sequence[Mapping[str, Any]] | None = None,
 ) -> AsyncIterator[dict]:
     """Run the ReAct edit loop, then the optional feedback sub-step.
 
@@ -268,8 +269,8 @@ async def editor_pass(
 
 
 async def editor_stage(
-    cfg: "_PipelineConfig",
-    state: "TurnState",
+    cfg: _PipelineConfig,
+    state: TurnState,
     *,
     settings: Mapping[str, Any],
     phrase_bank: list[PhraseGroup] | None,
@@ -384,7 +385,9 @@ async def _run_edit_loop(
     audit_context_msgs: (
         list[str] | None
     ) = None,  # explicit previous-assistant list for repetition scanning; if None, derived from base.prefix
-    writer_user_msg: "str | list[ContentPart] | None" = None,  # writer's exact last user message; when provided replaces bare effective_msg so the editor extends the writer's KV-cached prefix
+    writer_user_msg: str
+    | list[ContentPart]
+    | None = None,  # writer's exact last user message; when provided replaces bare effective_msg so the editor extends the writer's KV-cached prefix
 ) -> AsyncIterator[dict]:
     """ReAct-style edit loop with optional audit and/or length guard.
 

--- a/backend/pipeline/passes/editor/feedback.py
+++ b/backend/pipeline/passes/editor/feedback.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Mapping, Sequence
+from typing import Any
 
 from ....core import ChatMessage, ContentPart, extract_hyperparams
 from ....inference import (
@@ -37,7 +38,7 @@ from ....inference import (
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(slots=True)
 class FeedbackResult:
     """Typed result of the feedback step, yielded as the ``done`` event payload.
 
@@ -73,7 +74,7 @@ async def feedback_step(
     settings: Mapping[str, Any],
     feedback_fragments: Sequence[Mapping[str, Any]],
     *,
-    writer_user_msg: "str | list[ContentPart]",
+    writer_user_msg: str | list[ContentPart],
     kv_tracker=None,
     reasoning_on: bool = False,
 ) -> AsyncIterator[dict]:

--- a/backend/pipeline/passes/editor/length_guard.py
+++ b/backend/pipeline/passes/editor/length_guard.py
@@ -15,7 +15,8 @@ ensures ``editor_rewrite`` is present in every pass's tool blob.
 
 from __future__ import annotations
 
-from typing import Any, Mapping, TypedDict
+from collections.abc import Mapping
+from typing import Any, TypedDict
 
 
 class LengthGuard(TypedDict):

--- a/backend/pipeline/passes/writer.py
+++ b/backend/pipeline/passes/writer.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 import json
 import logging
 import time
-from typing import TYPE_CHECKING, Any, AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 from ...core import (
     ChatMessage,
@@ -32,7 +33,7 @@ def build_writer_content(
     attachments: Sequence[Mapping[str, Any]] | None,
     length_guard: LengthGuard | None,
     text_mode: bool = False,
-) -> "str | list[ContentPart]":
+) -> str | list[ContentPart]:
     """Build the writer's user-message content (string or multimodal list).
 
     Built once and threaded into both the writer pass and the editor, which
@@ -58,7 +59,7 @@ async def writer_pass(
     client: LLMClient,
     base: CachedBase,
     settings: Mapping[str, Any],
-    content: "str | list[ContentPart]",
+    content: str | list[ContentPart],
     *,
     kv_tracker=None,
     reasoning_on: bool = True,
@@ -95,8 +96,8 @@ async def writer_pass(
 
 
 async def writer_stage(
-    cfg: "_PipelineConfig",
-    state: "TurnState",
+    cfg: _PipelineConfig,
+    state: TurnState,
     *,
     settings: Mapping[str, Any],
     attachments: Sequence[Mapping[str, Any]],

--- a/backend/pipeline/persistence.py
+++ b/backend/pipeline/persistence.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Mapping
+from typing import Any
 
 from .. import database as db
 from ..core import resolve_inline

--- a/backend/pipeline/predicates.py
+++ b/backend/pipeline/predicates.py
@@ -11,13 +11,14 @@ package can call these without pulling in the heavier pass dependencies.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ..inference import LLMClient
 
 
-def is_dual_model(agent_client: "LLMClient | None") -> bool:
+def is_dual_model(agent_client: LLMClient | None) -> bool:
     """Return True when the agent runs on a separate endpoint (dual-model mode).
 
     Single-model: writer and agent share one endpoint and KV cache.

--- a/backend/pipeline/state.py
+++ b/backend/pipeline/state.py
@@ -14,8 +14,9 @@ that dict to drive the saves.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 from ..core import ContentPart, Macros
 from ..features.lorebook import (
@@ -27,7 +28,7 @@ from ..inference import CachedBase, LLMClient
 from .passes.editor.length_guard import LengthGuard
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ModelLane:
     """One model's call surface for a turn: an LLM client paired with its
     cached base (prefix + tool blob + model name + macro resolver).
@@ -46,7 +47,7 @@ class ModelLane:
     base: CachedBase
 
 
-@dataclass
+@dataclass(slots=True)
 class _PipelineConfig:
     """Resolved per-turn flags, lanes, and prefixes for ``_run_pipeline``."""
 
@@ -110,7 +111,7 @@ _DIRECTOR_OUTPUT_FIELDS = (
 )
 
 
-@dataclass
+@dataclass(slots=True)
 class TurnState:
     """Mutable state threaded through all three pass stages, then consumed by persistence.
 
@@ -151,7 +152,7 @@ class TurnState:
 
     # --- writer / editor outputs ---
     resp_text: str = ""
-    writer_content: "str | list[ContentPart]" = ""
+    writer_content: str | list[ContentPart] = ""
     reasoning_director: str = ""
     reasoning_writer: str = ""
     reasoning_editor: str = ""
@@ -179,7 +180,7 @@ class TurnState:
         return {name: getattr(self, name) for name in _DIRECTOR_OUTPUT_FIELDS}
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class LorebookTurn:
     """The lorebook inputs for one main-pipeline turn.
 

--- a/backend/pipeline/workflow_bridge.py
+++ b/backend/pipeline/workflow_bridge.py
@@ -15,8 +15,9 @@ orchestrator path can safely import it.
 from __future__ import annotations
 
 import logging
+from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Mapping, Sequence, cast
+from typing import Any, cast
 
 from ..core import ChatMessage, workflow_character_state_lock, workflow_state_lock
 from ..inference import TOOLS, LLMClient, _KVCacheTracker
@@ -60,7 +61,7 @@ def _public_hook_event(ev: object, *, hook_type: str, workflow_id: str) -> dict 
     return cast(dict, ev)
 
 
-@dataclass
+@dataclass(slots=True)
 class _PostPipelineResult:
     """Final value of :func:`_run_post_pipeline`: the (possibly rewritten) draft
     plus any attachments and per-message state staged for persistence."""

--- a/backend/workflows/_forced_call.py
+++ b/backend/workflows/_forced_call.py
@@ -12,8 +12,9 @@ single bad LLM reply cannot crash a workflow.
 from __future__ import annotations
 
 import logging
+from collections.abc import AsyncIterator, Mapping, Sequence
 from types import MappingProxyType
-from typing import Any, AsyncIterator, Mapping, Sequence
+from typing import Any
 
 from ..inference import (
     STANDALONE_TOOLS,

--- a/backend/workflows/attachment_cache.py
+++ b/backend/workflows/attachment_cache.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from ..database.connection import get_db
 from ..database.queries.messages import register_workflow_attachment_persister

--- a/backend/workflows/contracts.py
+++ b/backend/workflows/contracts.py
@@ -16,10 +16,11 @@ and ``frozenset.add``, ``TypeError`` from tuple item assignment.
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from enum import Enum
 from types import MappingProxyType
-from typing import Any, AsyncIterator, Awaitable, Callable, Union
+from typing import Any
 
 
 def _readonly(obj: Any) -> Any:
@@ -342,7 +343,7 @@ PreHook = Callable[[PreCtx], AsyncIterator[dict]]
 PostHook = Callable[[PostCtx], AsyncIterator[dict]]
 # An on-demand hook returns either a plain JSON object (the API renders it as a
 # JSON response) or a WorkflowEventStream (the API renders it as an SSE stream).
-OnDemandResult = Union[dict, WorkflowEventStream]
+OnDemandResult = dict | WorkflowEventStream
 OnDemandHook = Callable[[OnDemandCtx, dict], Awaitable[OnDemandResult]]
 RegenHook = Callable[[RegenCtx, dict], Awaitable[list[dict]]]
 RerollGenHook = Callable[[RerollGenCtx, dict, str], Awaitable["bytes | tuple[bytes, dict | None]"]]

--- a/backend/workflows/enablement.py
+++ b/backend/workflows/enablement.py
@@ -15,7 +15,7 @@ settings-row shape.
 
 from __future__ import annotations
 
-from typing import Mapping
+from collections.abc import Mapping
 
 from .registry import list_workflows
 

--- a/backend/workflows/image_gen/composer.py
+++ b/backend/workflows/image_gen/composer.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from ..contracts import ToolSpec
 from ..toolkit import forced_tool_call

--- a/backend/workflows/image_gen/config.py
+++ b/backend/workflows/image_gen/config.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import copy
 import re
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 from urllib.parse import urlsplit
 
 WORKFLOW_ID = "image_gen"

--- a/backend/workflows/image_gen/engine/adapters/external_comfy.py
+++ b/backend/workflows/image_gen/engine/adapters/external_comfy.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from ..comfy_client import ComfyClient, ProgressCallback
 from ..contracts import (

--- a/backend/workflows/image_gen/engine/comfy_client.py
+++ b/backend/workflows/image_gen/engine/comfy_client.py
@@ -6,7 +6,8 @@ import asyncio
 import json
 import time
 import uuid
-from typing import Any, Awaitable, Callable, Mapping, Optional
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
 
 import httpx
 
@@ -14,7 +15,7 @@ from .contracts import ImageGenerationError, ImageResult
 from .display_encode import shrink_for_display
 
 MAX_IMAGE_BYTES = 20 * 1024 * 1024
-ProgressCallback = Callable[[str, Mapping[str, Any]], Optional[Awaitable[None]]]
+ProgressCallback = Callable[[str, Mapping[str, Any]], Awaitable[None] | None]
 
 # `/object_info` is the one enormous response in this contract -- a real install
 # with custom-node packs reports ~2000 node types, tens of megabytes. Readiness
@@ -35,7 +36,7 @@ def invalidate_object_info(api_url: str | None = None) -> None:
         _object_info_cache.pop(api_url.rstrip("/"), None)
 
 
-async def _emit(progress: "ProgressCallback | None", stage: str, detail: Mapping[str, Any]) -> None:
+async def _emit(progress: ProgressCallback | None, stage: str, detail: Mapping[str, Any]) -> None:
     if not progress:
         return
     maybe = progress(stage, detail)

--- a/backend/workflows/image_gen/engine/contracts.py
+++ b/backend/workflows/image_gen/engine/contracts.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping, TypedDict
+from typing import Any, TypedDict
 
 
 class ImageBackendCapabilities(TypedDict):

--- a/backend/workflows/image_gen/engine/graph.py
+++ b/backend/workflows/image_gen/engine/graph.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import copy
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from .contracts import ImageGenerationError
 

--- a/backend/workflows/image_gen/engine/render.py
+++ b/backend/workflows/image_gen/engine/render.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 from ..config import resolve_style
 from .adapters import external_comfy

--- a/backend/workflows/image_gen/hooks.py
+++ b/backend/workflows/image_gen/hooks.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import secrets
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from ..contracts import WorkflowEventStream
 from ..toolkit import (
@@ -451,7 +452,7 @@ async def _generate_response(ctx, body) -> WorkflowEventStream:
             while not task.done():
                 try:
                     label = await asyncio.wait_for(labels.get(), 0.5)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     continue
                 yield _phase(label)
             while not labels.empty():

--- a/backend/workflows/registry.py
+++ b/backend/workflows/registry.py
@@ -16,8 +16,9 @@ exception that adds behavior: it falls back to the workflow's
 from __future__ import annotations
 
 import re
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from typing import Any, Callable, Mapping, Optional
+from typing import Any
 
 from ..database import (
     get_workflow_character_state as _db_get_workflow_character_state,
@@ -74,10 +75,10 @@ class Workflow:
     display_name: str
     tools: list[ToolSpec] = field(default_factory=list)
     config_defaults: dict = field(default_factory=dict)
-    config_schema: Optional[dict] = None
+    config_schema: dict | None = None
     produces_artifacts: bool = False
-    subscriptions: list["Subscription"] = field(default_factory=list)
-    config_normalizer: Optional[Callable[[Any], dict]] = None
+    subscriptions: list[Subscription] = field(default_factory=list)
+    config_normalizer: Callable[[Any], dict] | None = None
 
 
 @dataclass(frozen=True)
@@ -223,7 +224,7 @@ def iter_subscriptions(hook_type: HookType) -> list[Subscription]:
     return subs
 
 
-def get_subscription(workflow_id: str, hook_type: HookType) -> Optional[Subscription]:
+def get_subscription(workflow_id: str, hook_type: HookType) -> Subscription | None:
     """Return the workflow's subscription for ``hook_type``, or None.
 
     Collapses "unregistered" and "no binding" into one None -- the routes
@@ -267,7 +268,7 @@ def list_workflows() -> list[Workflow]:
     return list(_WORKFLOWS_BY_ID.values())
 
 
-def get_workflow(workflow_id: str) -> Optional[Workflow]:
+def get_workflow(workflow_id: str) -> Workflow | None:
     """Look up a workflow by id, or None if not registered."""
     return _WORKFLOWS_BY_ID.get(workflow_id)
 

--- a/backend/workflows/toolkit.py
+++ b/backend/workflows/toolkit.py
@@ -20,7 +20,7 @@ through one chokepoint.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any
 
 from ..analysis import (
     FormatDriftReport,
@@ -34,6 +34,7 @@ from ..core import (
     workflow_config_lock,
     workflow_state_lock,
 )
+from ..core.domain_types import AgentLane
 from ..database import (
     get_active_lorebook_entries,
     get_character_card,
@@ -121,7 +122,7 @@ async def build_offturn_prefix(
     history,
     settings,
     *,
-    lane: Literal["writer", "agent"] = "writer",
+    lane: AgentLane = "writer",
 ) -> list[Any]:
     """Rebuild the character/persona prefix for a standalone off-turn call.
 

--- a/backend/workflows/tts/config.py
+++ b/backend/workflows/tts/config.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 CONFIG_DEFAULTS = {
     "auto_play": False,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Python 3.9+
+- Python 3.11+
 - OpenAI-compatible LLM backend with prompt-caching support
 - A model with strong tool/function calling (recommended: Gemma 4)
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["backend"],
   "typeCheckingMode": "standard",
-  "pythonVersion": "3.12",
+  "pythonVersion": "3.11",
   "reportMissingImports": "warning"
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 -r requirements.txt
-pytest==8.3.5
-pytest-asyncio==0.24.0
-pytest-mock==3.14.0
+pytest==9.1.1
+pytest-asyncio==1.4.0
+pytest-mock==3.15.1
 pytest-cov==7.1.0
-bandit==1.8.6
-pip-audit==2.9.0
-pyright==1.1.409
+bandit==1.9.4
+pip-audit==2.10.1
+pyright==1.1.411
 ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-fastapi==0.128.8
-uvicorn[standard]==0.30.6
-aiosqlite==0.20.0
-httpx[socks]==0.27.2
-pydantic==2.13.2
-Pillow==11.3.0
-python-multipart==0.0.20
-edge-tts>=6.1.0
+fastapi==0.139.2
+uvicorn[standard]==0.51.0
+aiosqlite==0.22.1
+httpx[socks]==0.28.1
+pydantic==2.13.4
+Pillow==12.3.0
+python-multipart==0.0.32
+edge-tts>=7.2.8

--- a/ruff.toml
+++ b/ruff.toml
@@ -4,7 +4,12 @@
 target-version = "py311"
 
 [lint]
+# Keep the complete lint policy here so local hooks, scripts, and CI cannot
+# silently select different rule sets. UP enforces syntax supported by the
+# Python 3.11 floor; I keeps import ordering in the same source of truth.
+select = ["E", "W", "F", "B", "I", "UP"]
+
 # Raising the target activates B905, but changing every zip() call to spell
 # strict=False is unrelated to the runtime/security upgrade and preserves no
 # additional invariant. Keep the existing truncating behavior explicitly.
-extend-ignore = ["B905"]
+ignore = ["E203", "E501", "B905"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,10 @@
-# Pin to the minimum supported Python version so version-gated lints
-# (e.g. B905 zip-without-explicit-strict, a 3.10+ feature) don't demand
-# syntax that breaks our 3.9 runtime compatibility target.
-target-version = "py39"
+# Pin to the minimum supported Python version so version-gated lints and
+# autofixes target syntax that runs on our floor — e.g. pyupgrade rewrites to
+# `X | Y` unions and builtin generics (`list[int]`), which require 3.10+.
+target-version = "py311"
+
+[lint]
+# Raising the target activates B905, but changing every zip() call to spell
+# strict=False is unrelated to the runtime/security upgrade and preserves no
+# additional invariant. Keep the existing truncating behavior explicitly.
+extend-ignore = ["B905"]

--- a/run_unix.sh
+++ b/run_unix.sh
@@ -9,8 +9,20 @@ echo "  Orb - Agentic"
 echo "═══════════════════════════════════════════"
 echo ""
 
-# Install dependencies
-if [ ! -d ".venv" ]; then
+# Create a supported virtual environment, or reject a stale one left behind by
+# an older Orb install. Activating an existing venv does not follow upgrades to
+# the system's python3 executable.
+if [ -d ".venv" ]; then
+    if [ ! -x ".venv/bin/python" ] || ! .venv/bin/python -c 'import sys; raise SystemExit(sys.version_info < (3, 11))'; then
+        echo "Error: .venv uses Python older than 3.11 or is invalid."
+        echo "Remove .venv and rerun this script with Python 3.11 or newer installed."
+        exit 1
+    fi
+else
+    if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 11))'; then
+        echo "Error: Python 3.11 or newer is required."
+        exit 1
+    fi
     echo "Creating virtual environment..."
     python3 -m venv .venv
 fi

--- a/run_windows.bat
+++ b/run_windows.bat
@@ -8,10 +8,21 @@ echo   Orb - Agentic
 echo =========================================
 echo.
 
-if not exist ".venv" (
-    echo Creating virtual environment...
-    python -m venv .venv
-)
+if exist ".venv\Scripts\python.exe" goto validate_venv
+
+python -c "import sys; raise SystemExit(sys.version_info < (3, 11))"
+if errorlevel 1 goto unsupported_python
+
+echo Creating virtual environment...
+python -m venv .venv
+if errorlevel 1 exit /b 1
+goto venv_ready
+
+:validate_venv
+".venv\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 11))"
+if errorlevel 1 goto stale_venv
+
+:venv_ready
 
 call .venv\Scripts\activate.bat
 echo Installing dependencies...
@@ -28,3 +39,13 @@ REM Wait for the server to come up in the background, then open the browser once
 start "" /b cmd /c "for /l %%i in (1,1,60) do (curl -fsS -o nul http://localhost:8899 && (start "" http://localhost:8899 & exit) || timeout /t 1 /nobreak >nul)"
 
 uvicorn backend.main:app --host 0.0.0.0 --port 8899 --reload
+exit /b %errorlevel%
+
+:unsupported_python
+echo Error: Python 3.11 or newer is required.
+exit /b 1
+
+:stale_venv
+echo Error: .venv uses Python older than 3.11 or is invalid.
+echo Remove .venv and rerun this script with Python 3.11 or newer installed.
+exit /b 1

--- a/scripts/check_resolve.sh
+++ b/scripts/check_resolve.sh
@@ -12,14 +12,14 @@
 # by pip whenever --python-version is combined with --target. A consequence is
 # that a dependency which only ships an sdist (no wheel) for the target version
 # will be reported as a failure even though it could compile from source; for
-# this project every runtime dep ships wheels, and sdist-only on 3.9 would be
+# this project every runtime dep ships wheels, and sdist-only on 3.11 would be
 # fragile anyway.
 #
 # Usage:
 #   scripts/check_resolve.sh                # checks the default version set
-#   scripts/check_resolve.sh 3.9            # checks a single version
-#   scripts/check_resolve.sh 3.9 3.14       # checks multiple versions
-#   REQ_FILE=requirements-dev.txt scripts/check_resolve.sh 3.9
+#   scripts/check_resolve.sh 3.11           # checks a single version
+#   scripts/check_resolve.sh 3.11 3.14      # checks multiple versions
+#   REQ_FILE=requirements-dev.txt scripts/check_resolve.sh 3.11
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -46,7 +46,7 @@ fi
 
 versions=("$@")
 if [[ ${#versions[@]} -eq 0 ]]; then
-    versions=("3.9" "3.14")
+    versions=("3.11" "3.14")
 fi
 
 failures=0

--- a/scripts/compatibility_test.sh
+++ b/scripts/compatibility_test.sh
@@ -54,7 +54,7 @@ test_image() {
     local version="$1"
     local tag="orb-app:$version"
     local container_name="orb-test-$version"
-    if [[ "$version" == "3.9" ]]; then
+    if [[ "$version" == "3.11" ]]; then
         local host_port=9899
     elif [[ "$version" == "3.14" ]]; then
         local host_port=9898
@@ -112,7 +112,7 @@ test_image() {
 }
 
 main() {
-    local versions=("3.9" "3.14")
+    local versions=("3.11" "3.14")
     local failures=0
 
     for version in "${versions[@]}"; do

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -15,7 +15,7 @@ echo "Installing dev dependencies..."
 pip install -q -r requirements-dev.txt
 
 echo ""
-python -m ruff check --select E,W,F,B --ignore E203,E501 --line-length 128 backend/ tests/ "$@"
+python -m ruff check --select E,W,F,B --ignore E203,E501,B905 --line-length 128 backend/ tests/ "$@"
 
 echo ""
 echo "Running Pylance type check on backend..."

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -15,7 +15,7 @@ echo "Installing dev dependencies..."
 pip install -q -r requirements-dev.txt
 
 echo ""
-python -m ruff check --select E,W,F,B --ignore E203,E501,B905 --line-length 128 backend/ tests/ "$@"
+python -m ruff check backend/ tests/ "$@"
 
 echo ""
 echo "Running Pylance type check on backend..."

--- a/tests/Dockerfile.3.11
+++ b/tests/Dockerfile.3.11
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/tests/integration/_llm_mock.py
+++ b/tests/integration/_llm_mock.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 import asyncio
 import copy
 import json
-from typing import Any, AsyncIterator
+from collections.abc import AsyncIterator
+from typing import Any
 
 from backend.inference import AbortToken
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -175,7 +175,7 @@ async def streaming_client(db_path: Path, monkeypatch):
         server.should_exit = True
         try:
             await asyncio.wait_for(serve_task, timeout=2.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             # uvicorn's force_exit path skips the connection-drain polls
             # but the trailing server.wait_closed() call is not gated by
             # it. The second bounded wait gives uvicorn's own graceful
@@ -184,7 +184,7 @@ async def streaming_client(db_path: Path, monkeypatch):
             server.force_exit = True
             try:
                 await asyncio.wait_for(serve_task, timeout=2.0)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 serve_task.cancel()
                 await asyncio.gather(serve_task, return_exceptions=True)
         # uvicorn closes the socket itself on a normal exit; cover the

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -80,6 +80,21 @@ async def test_create_model_config_persists_to_db(client, db):
     assert row["max_tokens"] == 2048
 
 
+async def test_create_model_config_rejects_unknown_role(client):
+    endpoint_resp = await client.post(
+        "/api/endpoints",
+        json={"url": "https://api.invalid-role.com", "api_key": "key"},
+    )
+    endpoint_id = endpoint_resp.json()["id"]
+
+    resp = await client.post(
+        f"/api/endpoints/{endpoint_id}/models",
+        json={"model_name": "invalid-role", "role": "critic"},
+    )
+
+    assert resp.status_code == 422
+
+
 async def test_list_model_configs_for_endpoint(client, db):
     """Test GET /api/endpoints/{id}/models returns model configs"""
     # Create an endpoint

--- a/tests/integration/test_stats.py
+++ b/tests/integration/test_stats.py
@@ -9,6 +9,7 @@ never recomputed from the messages table.
 from __future__ import annotations
 
 import uuid
+from datetime import UTC
 
 import backend.database as dbmod
 
@@ -27,7 +28,7 @@ async def _seed_character(name: str, message_count: int, *, old: bool = False) -
     Pass ``old=True`` to backdate all messages by 48 hours so they satisfy the
     "missed" spotlight query's 24-hour recency cutoff.
     """
-    from datetime import datetime, timedelta, timezone
+    from datetime import datetime, timedelta
 
     import aiosqlite
 
@@ -40,7 +41,7 @@ async def _seed_character(name: str, message_count: int, *, old: bool = False) -
     if old:
         import backend.database.connection as _db_conn
 
-        cutoff = (datetime.now(timezone.utc) - timedelta(hours=48)).isoformat()
+        cutoff = (datetime.now(UTC) - timedelta(hours=48)).isoformat()
         async with aiosqlite.connect(_db_conn.DB_PATH) as conn:
             await conn.execute(
                 "UPDATE messages SET created_at = ? WHERE conversation_id = ?",

--- a/tests/integration/workflows/_fixtures.py
+++ b/tests/integration/workflows/_fixtures.py
@@ -11,9 +11,10 @@ held by both the test and the registry (see clear at end of
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
 from contextlib import contextmanager
 from copy import deepcopy
-from typing import Any, Iterator
+from typing import Any
 
 import pytest
 

--- a/tests/integration/workflows/test_sse_workflow_rejection.py
+++ b/tests/integration/workflows/test_sse_workflow_rejection.py
@@ -9,7 +9,7 @@ reasons. This test pins the SSE event shape -- specifically the
 
 from __future__ import annotations
 
-from typing import AsyncIterator
+from collections.abc import AsyncIterator
 
 import pytest
 

--- a/tests/unit/test_audit_filtering.py
+++ b/tests/unit/test_audit_filtering.py
@@ -1,0 +1,34 @@
+from backend.analysis.audit import AuditReport
+from backend.analysis.detectors.opening_monotony import FlaggedOpener, MonotonyResult
+from backend.analysis.detectors.slop_detector import DetectionResult
+from backend.analysis.detectors.template_repetition import (
+    FlaggedTemplate,
+    TemplateResult,
+)
+from backend.analysis.patching import filter_audit_report_to_text
+
+
+def test_filter_audit_report_supports_slotted_detector_items():
+    sentences = ["She walks.", "She smiles."]
+    report = AuditReport(
+        cliche_result=DetectionResult([], [], 2, 0),
+        monotony_result=MonotonyResult(
+            [FlaggedOpener("she", 2, 2, 1.0, sentences)],
+            {"she": 2},
+            2,
+            1.0,
+        ),
+        template_result=TemplateResult(
+            [FlaggedTemplate("she", 2, 1.0, sentences)],
+            {"she": 2},
+            2,
+            1,
+            1.0,
+        ),
+    )
+
+    filtered = filter_audit_report_to_text(report, "She walks.")
+
+    assert not hasattr(report.monotony_result.flagged_openers[0], "__dict__")
+    assert filtered.monotony_result.flagged_openers == [FlaggedOpener("she", 1, 2, 0.5, ["She walks."])]
+    assert filtered.template_result.flagged_templates == [FlaggedTemplate("she", 1, 0.5, ["She walks."])]

--- a/tests/unit/test_format_consistency.py
+++ b/tests/unit/test_format_consistency.py
@@ -20,6 +20,11 @@ ASTERISKS_ONLY = "*She smiles and steps back, turning to the window.* I won't go
 FULL_MARKUP = '*He leans on the doorframe, arms crossed.* "You came back," *he murmurs.*'
 
 
+def test_axis_enums_render_as_wire_values():
+    assert str(Dialogue.QUOTED) == "quoted"
+    assert f"{Narration.ASTERISK}" == "asterisk"
+
+
 # ---------- classification ----------
 
 

--- a/tests/unit/workflows/test_forced_call.py
+++ b/tests/unit/workflows/test_forced_call.py
@@ -4,7 +4,8 @@ path."""
 
 from __future__ import annotations
 
-from typing import Any, AsyncIterator
+from collections.abc import AsyncIterator
+from typing import Any
 
 from backend.inference import STANDALONE_TOOLS, TOOLS
 from backend.workflows._forced_call import forced_tool_call


### PR DESCRIPTION
Upgrade python floor to 3.11, refresh modules to latest versions.

Python 3.9 has been EOL since 2025 and many external modules, which now have CVEs, have dropped support for it.

Real case: Pillow module (used for parsing cards) opens up attack surface, the cards are downloaded externally and may contain thing we don't expect (https://github.com/OrbFrontend/Orb/issues/129). Cannot trust logic-based validations to catch all potential issues, and even then it's not guaranteed to cover lower level vulns in the module itself.

There are also other modules with CVEs that will also benefit from this bump.

Modernize to-be-deperated syntax while we're at it.