### PR TITLE
feat: per-model arbitrary headers

### DIFF
--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -7,6 +7,8 @@ it needs and the shapes stay discoverable in one place.
 
 from __future__ import annotations
 
+import json
+import re
 from typing import Any, Literal
 from urllib.parse import urlsplit
 
@@ -120,6 +122,12 @@ class EndpointUpdate(BaseModel):
         return v
 
 
+# RFC 7230 token: the only characters a header name may contain. h11 rejects
+# anything else when the request is sent, and that exception is not retryable,
+# so an unchecked name kills every subsequent turn with an opaque error.
+_HEADER_NAME_RE = re.compile(r"[A-Za-z0-9!#$%&'*+.^_`|~-]+")
+
+
 class ModelConfigCreate(BaseModel):
     model_config = {"protected_namespaces": ()}
 
@@ -135,6 +143,50 @@ class ModelConfigCreate(BaseModel):
     reasoning_effort: str = ""
     reasoning_effort_param: str = ""
     reasoning_effort_value: str = ""
+    extra_headers: str = ""
+    extra_body: str = ""
+
+    @field_validator("extra_headers")
+    @classmethod
+    def _validate_extra_headers(cls, v: str) -> str:
+        # Blank lines and '#' comments are allowed so the field can be annotated.
+        # Name and value are checked after stripping, matching what the client
+        # parser sends -- the separator whitespace is discarded before the header
+        # exists, so a non-breaking space pasted from a docs page is harmless.
+        # Rejecting a malformed line here means a typo fails at save time rather
+        # than on every turn, where it surfaces only as a generic failure.
+        v = v.strip()
+        if not v:
+            return ""
+        for raw in v.splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            name, sep, value = line.partition(":")
+            name, value = name.strip(), value.strip()
+            if not sep or not name:
+                raise ValueError(f"each header line must be 'Name: value' (got {line!r})")
+            if not _HEADER_NAME_RE.fullmatch(name):
+                raise ValueError(f"header name must be an HTTP token (got {line!r})")
+            if not value.isascii() or any(ord(c) < 0x20 and c != "\t" for c in value):
+                raise ValueError(f"header value must be ASCII without control characters (got {line!r})")
+        return v
+
+    @field_validator("extra_body")
+    @classmethod
+    def _validate_extra_body(cls, v: str) -> str:
+        # Must be an object: it is merged into the request body, and a list or
+        # scalar has nothing to merge.
+        v = v.strip()
+        if not v:
+            return ""
+        try:
+            parsed = json.loads(v)
+        except ValueError as e:
+            raise ValueError(f"extra body must be valid JSON: {e}") from e
+        if not isinstance(parsed, dict):
+            raise ValueError(f"extra body must be a JSON object, not {type(parsed).__name__}")
+        return v
 
 
 class ModelConfigUpdate(BaseModel):
@@ -151,6 +203,54 @@ class ModelConfigUpdate(BaseModel):
     reasoning_effort: str | None = None
     reasoning_effort_param: str | None = None
     reasoning_effort_value: str | None = None
+    extra_headers: str | None = None
+    extra_body: str | None = None
+
+    @field_validator("extra_headers")
+    @classmethod
+    def _validate_extra_headers(cls, v: str | None) -> str | None:
+        # Blank lines and '#' comments are allowed so the field can be annotated.
+        # Name and value are checked after stripping, matching what the client
+        # parser sends -- the separator whitespace is discarded before the header
+        # exists, so a non-breaking space pasted from a docs page is harmless.
+        # Rejecting a malformed line here means a typo fails at save time rather
+        # than on every turn, where it surfaces only as a generic failure.
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            return ""
+        for raw in v.splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            name, sep, value = line.partition(":")
+            name, value = name.strip(), value.strip()
+            if not sep or not name:
+                raise ValueError(f"each header line must be 'Name: value' (got {line!r})")
+            if not _HEADER_NAME_RE.fullmatch(name):
+                raise ValueError(f"header name must be an HTTP token (got {line!r})")
+            if not value.isascii() or any(ord(c) < 0x20 and c != "\t" for c in value):
+                raise ValueError(f"header value must be ASCII without control characters (got {line!r})")
+        return v
+
+    @field_validator("extra_body")
+    @classmethod
+    def _validate_extra_body(cls, v: str | None) -> str | None:
+        # Must be an object: it is merged into the request body, and a list or
+        # scalar has nothing to merge.
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            return ""
+        try:
+            parsed = json.loads(v)
+        except ValueError as e:
+            raise ValueError(f"extra body must be valid JSON: {e}") from e
+        if not isinstance(parsed, dict):
+            raise ValueError(f"extra body must be a JSON object, not {type(parsed).__name__}")
+        return v
 
 
 class MoodFragmentCreate(BaseModel):

--- a/backend/database/migrations/0052_model_extra_request.py
+++ b/backend/database/migrations/0052_model_extra_request.py
@@ -1,0 +1,27 @@
+"""
+0052_model_extra_request -- add the per-model arbitrary request additions.
+
+``extra_headers`` holds ``Name: value`` lines merged into the outbound HTTP
+headers of every request, on both the chat and text-completion transports;
+``extra_body`` holds a JSON object merged into the chat-completions request
+body only. Both default to '' (send nothing), so an existing model config keeps
+behaving exactly as before.
+
+They exist so a provider knob Orb has no setting for -- a routing header like
+``X-Provider``, a body field a gateway added last week -- can be driven without
+a code change. This generalises ``reasoning_effort_param`` /
+``reasoning_effort_value``, which do the same thing but only for reasoning and
+only into the body. Validation stays at the API layer, not in the DB.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(model_configs)").fetchall()}
+    for col in ("extra_headers", "extra_body"):
+        if col not in cols:
+            conn.execute(f"ALTER TABLE model_configs ADD COLUMN {col} TEXT NOT NULL DEFAULT ''")
+            print(f"[migrations] 0052: added {col} column to model_configs")

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -159,6 +159,15 @@ class SettingsRow(_SettingsBase, total=False):
     agent_reasoning_effort: str
     agent_reasoning_effort_param: str
     agent_reasoning_effort_value: str
+    # Arbitrary per-model request additions, surfaced by the same overlay
+    # (default ''). extra_headers is "Name: value" lines merged into the
+    # outbound headers; extra_body is a JSON object merged into the chat body.
+    # The agent_* variants fall back to the writer's values when the agent
+    # shares the writer endpoint.
+    extra_headers: str
+    extra_body: str
+    agent_extra_headers: str
+    agent_extra_body: str
     # Agent-endpoint cascade overlays (present only when it resolves).
     agent_endpoint_url: str
     agent_api_key: str
@@ -327,6 +336,8 @@ class ModelConfigRow(TypedDict):
     reasoning_effort: str
     reasoning_effort_param: str
     reasoning_effort_value: str
+    extra_headers: str
+    extra_body: str
 
 
 class WorldRow(TypedDict):

--- a/backend/database/preset_schema.py
+++ b/backend/database/preset_schema.py
@@ -84,6 +84,12 @@ SECRET_COLUMNS: dict[tuple[str, str], str] = {
     ("settings", "agent_shared_system_prompt"): "",
     ("endpoints", "api_key"): "",
     ("endpoints", "proxy"): "",
+    # Free-form and user-supplied, so its contents are unknown and may be
+    # sensitive; declared secret alongside endpoints.proxy. model_configs is not
+    # a singleton table, so these rows are dropped by the cascade when configs is
+    # not exported rather than blanked in place. extra_body is deliberately not
+    # declared -- it holds routing and tuning config worth carrying across.
+    ("model_configs", "extra_headers"): "",
 }
 
 # Touch when: exporting one domain only makes sense alongside another (a product

--- a/backend/database/queries/endpoints.py
+++ b/backend/database/queries/endpoints.py
@@ -101,7 +101,7 @@ async def get_model_configs(endpoint_id: int) -> list[ModelConfigRow]:
 async def create_model_config(endpoint_id: int, data: dict) -> ModelConfigRow:
     async with get_db() as db:
         cur = await db.execute(
-            "INSERT INTO model_configs (endpoint_id, model_name, system_prompt, temperature, min_p, top_k, top_p, repetition_penalty, max_tokens, role, reasoning_effort, reasoning_effort_param, reasoning_effort_value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO model_configs (endpoint_id, model_name, system_prompt, temperature, min_p, top_k, top_p, repetition_penalty, max_tokens, role, reasoning_effort, reasoning_effort_param, reasoning_effort_value, extra_headers, extra_body) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 endpoint_id,
                 data.get("model_name", "default"),
@@ -116,6 +116,8 @@ async def create_model_config(endpoint_id: int, data: dict) -> ModelConfigRow:
                 data.get("reasoning_effort", ""),
                 data.get("reasoning_effort_param", ""),
                 data.get("reasoning_effort_value", ""),
+                data.get("extra_headers", ""),
+                data.get("extra_body", ""),
             ),
         )
         await db.commit()
@@ -137,6 +139,8 @@ async def update_model_config(config_id: int, data: dict) -> ModelConfigRow | No
             "reasoning_effort",
             "reasoning_effort_param",
             "reasoning_effort_value",
+            "extra_headers",
+            "extra_body",
         ]
         sets, vals = _build_set_clause(allowed, data)
         if sets:

--- a/backend/database/queries/settings.py
+++ b/backend/database/queries/settings.py
@@ -79,6 +79,8 @@ async def get_settings() -> SettingsRow:
                             "reasoning_effort",
                             "reasoning_effort_param",
                             "reasoning_effort_value",
+                            "extra_headers",
+                            "extra_body",
                         ):
                             if mc.get(field) is not None:
                                 s[field] = mc[field]
@@ -127,6 +129,8 @@ async def get_settings() -> SettingsRow:
                             "reasoning_effort",
                             "reasoning_effort_param",
                             "reasoning_effort_value",
+                            "extra_headers",
+                            "extra_body",
                         ):
                             if amc.get(field) is not None:
                                 s[f"agent_{field}"] = amc[field]
@@ -138,7 +142,13 @@ async def get_settings() -> SettingsRow:
         s.setdefault("agent_completion_mode", s["completion_mode"])
         s.setdefault("proxy", "")
         s.setdefault("agent_proxy", s["proxy"])
-        for field in ("reasoning_effort", "reasoning_effort_param", "reasoning_effort_value"):
+        for field in (
+            "reasoning_effort",
+            "reasoning_effort_param",
+            "reasoning_effort_value",
+            "extra_headers",
+            "extra_body",
+        ):
             s.setdefault(field, "")
             s.setdefault(f"agent_{field}", s[field])
         return cast(SettingsRow, s)

--- a/backend/database/schema.py
+++ b/backend/database/schema.py
@@ -229,7 +229,9 @@ CREATE TABLE IF NOT EXISTS model_configs (
     role TEXT NOT NULL DEFAULT 'writer' CHECK (role IN ('writer', 'agent')),
     reasoning_effort TEXT NOT NULL DEFAULT '',
     reasoning_effort_param TEXT NOT NULL DEFAULT '',
-    reasoning_effort_value TEXT NOT NULL DEFAULT ''
+    reasoning_effort_value TEXT NOT NULL DEFAULT '',
+    extra_headers TEXT NOT NULL DEFAULT '',
+    extra_body TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS worlds (

--- a/backend/inference/client.py
+++ b/backend/inference/client.py
@@ -105,6 +105,60 @@ def apply_reasoning_effort(body: dict, effort: str, param: str = "", value: str 
     body["reasoning"] = {**reasoning, "effort": effort}
 
 
+# RFC 7230 token: the only characters a header name may contain. Must stay
+# identical to the API-layer check in schemas.py, so a row saved through the API
+# is never silently dropped here.
+_HEADER_NAME_RE = re.compile(r"[A-Za-z0-9!#$%&'*+.^_`|~-]+")
+
+
+def parse_extra_headers(text: str) -> dict[str, str]:
+    """Parse ``Name: value`` lines into a header dict.
+
+    Blank lines and ``#`` comments are skipped; a malformed line is dropped with
+    a warning rather than raised on. The API layer rejects malformed input at
+    save time, so this tolerance only ever covers a row that predates that
+    validation or was edited in the DB by hand -- such a row degrades to "send
+    fewer headers" instead of killing every turn.
+    """
+    out: dict[str, str] = {}
+    for raw in (text or "").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        name, sep, value = line.partition(":")
+        name, value = name.strip(), value.strip()
+        if not sep:
+            logger.warning("Ignoring extra header line, no colon: %r", line)
+            continue
+        if not _HEADER_NAME_RE.fullmatch(name):
+            logger.warning("Ignoring extra header line, name is not an HTTP token: %r", line)
+            continue
+        if not value.isascii() or any(ord(c) < 0x20 and c != "\t" for c in value):
+            logger.warning("Ignoring extra header line, value is not printable ASCII: %r", line)
+            continue
+        out[name] = value
+    return out
+
+
+def parse_extra_body(text: str) -> dict:
+    """Parse a JSON object of extra body fields; ``{}`` when absent or unusable.
+
+    Permissive for the same reason as :func:`parse_extra_headers`.
+    """
+    text = (text or "").strip()
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+    except ValueError:
+        logger.warning("Ignoring extra body: not valid JSON")
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning("Ignoring extra body: expected a JSON object, got %s", type(parsed).__name__)
+        return {}
+    return parsed
+
+
 def strictify_schema(schema: dict) -> dict:
     """Copy *schema* into OpenAI strict-mode shape, recursively.
 
@@ -178,6 +232,8 @@ class LLMClient:
         reasoning_effort: str = "",
         reasoning_effort_param: str = "",
         reasoning_effort_value: str = "",
+        extra_headers: str = "",
+        extra_body: str = "",
     ):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
@@ -194,6 +250,9 @@ class LLMClient:
         # Empty string (the settings default = "no proxy") normalizes to None so
         # httpx connects directly; httpx rejects "" as a proxy URL.
         self.proxy = proxy or None
+        # Parsed once here rather than on every request.
+        self.extra_headers = parse_extra_headers(extra_headers)
+        self.extra_body = parse_extra_body(extra_body)
         # Shared across the turn's clients when passed in; otherwise a private
         # token so a standalone client (e.g. a workflow hook) is still abortable.
         self.abort_token = abort_token or AbortToken()
@@ -209,9 +268,17 @@ class LLMClient:
         return self.abort_token.is_aborted
 
     def _headers(self) -> dict:
+        base: dict = {}
         if self.api_key:
-            return {"Authorization": f"Bearer {self.api_key}"}
-        return {}
+            base["Authorization"] = f"Bearer {self.api_key}"
+        # HTTP header names are case-insensitive but dict keys are not, so drop a
+        # base header the configured set respells: a lowercase 'authorization'
+        # override -- the form most provider docs use -- would otherwise send the
+        # Bearer key alongside it. These ride every transport, unlike extra_body.
+        configured = {k.lower() for k in self.extra_headers}
+        headers = {k: v for k, v in base.items() if k.lower() not in configured}
+        headers.update(self.extra_headers)
+        return headers
 
     def _url(self) -> str:
         return f"{self.base_url}/chat/completions"
@@ -383,6 +450,13 @@ class LLMClient:
         body.setdefault("stream_options", {"include_usage": True})
 
         apply_reasoning_effort(body, self.reasoning_effort, self.reasoning_effort_param, self.reasoning_effort_value)
+
+        # Same ordering as apply_reasoning_effort above, for the reason its
+        # docstring gives. Chat-only by design: the text transport builds its
+        # params from an allowlist.
+        if self.extra_body:
+            body.update(self.extra_body)
+            logger.info("LLM extra body fields: %s", sorted(self.extra_body))
 
         # Provider-specific body translation (profiles + session-learned
         # workarounds) lives entirely in endpoint_profiles; the client just
@@ -908,6 +982,8 @@ def client_from_settings(settings: Mapping[str, Any], *, abort_token: AbortToken
         reasoning_effort=settings.get("reasoning_effort", ""),
         reasoning_effort_param=settings.get("reasoning_effort_param", ""),
         reasoning_effort_value=settings.get("reasoning_effort_value", ""),
+        extra_headers=settings.get("extra_headers", ""),
+        extra_body=settings.get("extra_body", ""),
     )
 
 
@@ -926,6 +1002,8 @@ def agent_client_from_settings(settings: Mapping[str, Any], *, abort_token: Abor
         reasoning_effort=settings.get("agent_reasoning_effort", settings.get("reasoning_effort", "")),
         reasoning_effort_param=settings.get("agent_reasoning_effort_param", settings.get("reasoning_effort_param", "")),
         reasoning_effort_value=settings.get("agent_reasoning_effort_value", settings.get("reasoning_effort_value", "")),
+        extra_headers=settings.get("agent_extra_headers", settings.get("extra_headers", "")),
+        extra_body=settings.get("agent_extra_body", settings.get("extra_body", "")),
     )
 
 

--- a/frontend/settings_models.js
+++ b/frontend/settings_models.js
@@ -6,7 +6,7 @@ import { api } from "./api.js";
 import { renderInspector } from "./chat.js";
 import { showConfirmModal } from "./modal.js";
 import { S } from "./state.js";
-import { $, esc, toast } from "./utils.js";
+import { $, esc, escAttr, toast } from "./utils.js";
 import { validate } from "./validate.js";
 
 const MODEL_HYPERPARAM_KEYS = [
@@ -21,6 +21,8 @@ const MODEL_HYPERPARAM_KEYS = [
   "reasoning_effort",
   "reasoning_effort_param",
   "reasoning_effort_value",
+  "extra_headers",
+  "extra_body",
 ];
 
 // Standard OpenAI reasoning_effort levels: the union across current models
@@ -55,6 +57,13 @@ const SETTING_FIELDS = [
   { k: "top_k", l: "Top K", t: "number", s: "1", mn: "0", mx: "200" },
   { k: "repetition_penalty", l: "Rep. Penalty", t: "number", s: "0.05", mn: "1", mx: "2" },
   { k: "reasoning_effort", l: "Reasoning Effort", t: "reasoning_effort" },
+  { k: "extra_headers", l: "Extra Request Headers", t: "textarea", ph: "X-Provider: deepinfra" },
+  {
+    k: "extra_body",
+    l: "Extra Request Body (JSON, chat mode only)",
+    t: "textarea",
+    ph: '{"provider": {"only": ["deepinfra"]}}',
+  },
 ];
 
 const AGENT_MODEL_HYPERPARAM_KEYS = [
@@ -65,6 +74,8 @@ const AGENT_MODEL_HYPERPARAM_KEYS = [
   "agent_reasoning_effort",
   "agent_reasoning_effort_param",
   "agent_reasoning_effort_value",
+  "agent_extra_headers",
+  "agent_extra_body",
 ];
 
 const AGENT_SETTING_FIELDS = [
@@ -86,6 +97,13 @@ const AGENT_SETTING_FIELDS = [
   { k: "agent_top_p", l: "Agent Top P", t: "number", s: "0.05", mn: "0", mx: "1" },
   { k: "agent_repetition_penalty", l: "Agent Rep. Penalty", t: "number", s: "0.05", mn: "1", mx: "2" },
   { k: "agent_reasoning_effort", l: "Agent Reasoning Effort", t: "reasoning_effort" },
+  { k: "agent_extra_headers", l: "Agent Extra Request Headers", t: "textarea", ph: "X-Provider: deepinfra" },
+  {
+    k: "agent_extra_body",
+    l: "Agent Extra Request Body (JSON, chat mode only)",
+    t: "textarea",
+    ph: '{"provider": {"only": ["deepinfra"]}}',
+  },
 ];
 
 // Descriptor objects that parameterise all writer vs. agent differences.
@@ -148,8 +166,9 @@ export function renderEndpoints() {
       const rows = f.k === "system_prompt" || f.k === "agent_system_prompt" ? ' rows="2"' : "";
       // System-prompt fields are chat-only: hidden in document mode (see document.css).
       const cls = f.k === "system_prompt" || f.k === "shared_system_prompt" ? " ep-chat-only" : "";
+      const ph = f.ph ? ` placeholder="${escAttr(f.ph)}"` : "";
       return `<div class="field${cls}"><label>${f.l}</label>
-                <textarea data-key="${f.k}"${rows} onchange="${saveFn}(this)">${v}</textarea>
+                <textarea data-key="${f.k}"${rows}${ph} onchange="${saveFn}(this)">${v}</textarea>
               </div>`;
     }
     if (f.t === "api_key") {
@@ -719,6 +738,8 @@ async function _syncModelConfigRecord(ctx, modelName, hyperparams) {
       reasoning_effort: get("reasoning_effort", ""),
       reasoning_effort_param: get("reasoning_effort_param", ""),
       reasoning_effort_value: get("reasoning_effort_value", ""),
+      extra_headers: get("extra_headers", ""),
+      extra_body: get("extra_body", ""),
     });
     S[ctx.configsKey].push(mc);
     S[ctx.configIdKey] = mc.id;

--- a/frontend/validate.js
+++ b/frontend/validate.js
@@ -482,6 +482,18 @@ export function validateSetting(key, value) {
       }
       return { valid: true };
     }
+    case "extra_headers": {
+      if (typeof value === "string") {
+        return maxLength(value, 4096, "Extra request headers");
+      }
+      return { valid: true };
+    }
+    case "extra_body": {
+      if (typeof value === "string") {
+        return maxLength(value, 4096, "Extra request body");
+      }
+      return { valid: true };
+    }
     default:
       return { valid: true };
   }

--- a/scripts/dump_diagnostic.py
+++ b/scripts/dump_diagnostic.py
@@ -119,11 +119,22 @@ def collect_endpoints(conn: sqlite3.Connection) -> list[dict]:
 
 
 def collect_model_configs(conn: sqlite3.Connection) -> list[dict]:
-    """Per-model sampling and generation configs."""
+    """Per-model sampling and generation configs, with extra headers redacted."""
     rows = conn.execute(
         "SELECT * FROM model_configs ORDER BY id"
     ).fetchall()
-    return [dict(r) for r in rows]
+    result = []
+    for r in rows:
+        mc = dict(r)
+        # Free-form and user-supplied, so its contents are unknown and may be
+        # sensitive. Blanked rather than masked: redact_api_key's
+        # first-four/last-four shape would expose the start and end of a
+        # multi-line blob while hiding the middle. An empty value is left alone
+        # so the dump still shows whether the field is set.
+        if mc.get("extra_headers"):
+            mc["extra_headers"] = SENSITIVE_PLACEHOLDER
+        result.append(mc)
+    return result
 
 
 def collect_conversation_summary(conn: sqlite3.Connection) -> dict:

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -237,6 +237,86 @@ async def test_settings_overlay_reasoning_effort(client, db):
     assert settings["agent_reasoning_effort"] == "high"
 
 
+async def test_model_config_extra_request_round_trip(client, db):
+    """extra_headers/extra_body persist through create and update."""
+    endpoint_resp = await client.post(
+        "/api/endpoints",
+        json={"url": "https://api.extra.com", "api_key": "key"},
+    )
+    endpoint_id = endpoint_resp.json()["id"]
+
+    resp = await client.post(
+        f"/api/endpoints/{endpoint_id}/models",
+        json={
+            "model_name": "routed-model",
+            "extra_headers": "X-Provider: deepinfra",
+            "extra_body": '{"provider": {"only": ["deepinfra"]}}',
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["extra_headers"] == "X-Provider: deepinfra"
+    assert data["extra_body"] == '{"provider": {"only": ["deepinfra"]}}'
+
+    update_resp = await client.put(f"/api/models/{data['id']}", json={"extra_headers": "X-Provider: together"})
+    assert update_resp.status_code == 200
+    assert update_resp.json()["extra_headers"] == "X-Provider: together"
+
+    async with db.execute(
+        "SELECT extra_headers, extra_body FROM model_configs WHERE id = ?",
+        (data["id"],),
+    ) as cur:
+        row = await cur.fetchone()
+    assert row["extra_headers"] == "X-Provider: together"
+    assert row["extra_body"] == '{"provider": {"only": ["deepinfra"]}}'
+
+
+async def test_settings_overlay_extra_request(client, db):
+    """The active model config's extra fields reach get_settings, and the agent
+    inherits them when sharing the writer endpoint."""
+    endpoint_resp = await client.post(
+        "/api/endpoints",
+        json={"url": "https://api.extraoverlay.com", "api_key": "key"},
+    )
+    endpoint_id = endpoint_resp.json()["id"]
+    model_resp = await client.post(
+        f"/api/endpoints/{endpoint_id}/models",
+        json={
+            "model_name": "overlay-routed",
+            "extra_headers": "X-Provider: deepinfra",
+            "extra_body": '{"seed": 7}',
+        },
+    )
+    config_id = model_resp.json()["id"]
+
+    await client.put("/api/settings", json={"active_endpoint_id": endpoint_id, "agent_same_as_writer": True})
+    await client.put(f"/api/endpoints/{endpoint_id}", json={"active_model_config_id": config_id})
+
+    resp = await client.get("/api/settings")
+    assert resp.status_code == 200
+    settings = resp.json()
+    assert settings["extra_headers"] == "X-Provider: deepinfra"
+    assert settings["extra_body"] == '{"seed": 7}'
+    assert settings["agent_extra_headers"] == "X-Provider: deepinfra"
+    assert settings["agent_extra_body"] == '{"seed": 7}'
+
+
+async def test_model_config_rejects_malformed_extra_body(client, db):
+    """A create payload is complete apart from the bad field, so the 422 can
+    only come from the extra_body validator."""
+    endpoint_resp = await client.post(
+        "/api/endpoints",
+        json={"url": "https://api.extrareject.com", "api_key": "key"},
+    )
+    endpoint_id = endpoint_resp.json()["id"]
+
+    resp = await client.post(
+        f"/api/endpoints/{endpoint_id}/models",
+        json={"model_name": "bad-model", "extra_body": "{nope"},
+    )
+    assert resp.status_code == 422
+
+
 async def test_endpoint_crud_workflow(client, db):
     """Test complete CRUD workflow for endpoints"""
     # 1. Create endpoint

--- a/tests/unit/test_extra_request.py
+++ b/tests/unit/test_extra_request.py
@@ -1,0 +1,243 @@
+"""Per-model extra headers/body: parsers, save-time validation, merge, factory threading."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+import backend.inference.client as llm_mod
+from backend.api.schemas import ModelConfigCreate, ModelConfigUpdate
+from backend.inference.client import (
+    LLMClient,
+    agent_client_from_settings,
+    client_from_settings,
+    parse_extra_body,
+    parse_extra_headers,
+)
+
+# Built by codepoint so the file stays byte-ASCII and the invisible characters
+# are visible in source.
+NBSP = chr(0xA0)
+ACCENT = chr(0xE9)
+
+
+# --- parsers ---------------------------------------------------------------
+
+
+def test_headers_parse_lines_and_skip_noise():
+    text = "X-Provider: deepinfra\n\n# a comment\nX-Billing-Mode: paygo"
+    assert parse_extra_headers(text) == {"X-Provider": "deepinfra", "X-Billing-Mode": "paygo"}
+
+
+def test_headers_keep_colons_in_the_value():
+    # Only the first colon separates; a URL value must survive intact.
+    assert parse_extra_headers("X-Ref: https://example.com:8443/x") == {"X-Ref": "https://example.com:8443/x"}
+
+
+def test_headers_drop_malformed_lines_without_raising():
+    # A gameplay path never dies over a parser-level issue: keep the good line.
+    assert parse_extra_headers("X-Ok: 1\nno colon here\nBad Name: v") == {"X-Ok": "1"}
+
+
+def test_headers_empty_input():
+    assert parse_extra_headers("") == {}
+    assert parse_extra_headers("   \n\n") == {}
+
+
+def test_headers_strip_the_name_before_checking_it():
+    # A space before the colon is a typo, not a bad header name.
+    assert parse_extra_headers("X-Provider : deepinfra") == {"X-Provider": "deepinfra"}
+
+
+def test_headers_drop_non_ascii_value():
+    # httpx raises UnicodeEncodeError when it builds the request, and that is
+    # not an httpx.HTTPError, so the retry loop never sees it.
+    assert parse_extra_headers(f"X-Ok: 1\nX-Bad: caf{ACCENT}") == {"X-Ok": "1"}
+
+
+def test_headers_drop_non_ascii_name():
+    assert parse_extra_headers(f"X-Ok: 1\nX-Caf{ACCENT}: v") == {"X-Ok": "1"}
+
+
+def test_headers_drop_ascii_name_outside_the_token_set():
+    # The reachable case: a header pasted the way provider docs render it in
+    # JSON. h11 rejects the quoted name on send with a non-retryable error.
+    assert parse_extra_headers('"X-Provider": "deepinfra"') == {}
+
+
+def test_headers_drop_control_character_in_value():
+    assert parse_extra_headers("X-Bad: a\x00b") == {}
+
+
+def test_headers_accept_a_non_breaking_space_separator():
+    # Copying from an HTML docs page yields U+00A0 in place of the separator
+    # space. It is discarded with the rest of the separator whitespace, so the
+    # pair that reaches httpx is pure ASCII and must not be rejected.
+    assert parse_extra_headers(f"X-Provider:{NBSP}deepinfra") == {"X-Provider": "deepinfra"}
+
+
+def test_body_parses_object_only():
+    assert parse_extra_body('{"provider": {"only": ["x"]}, "seed": 7}') == {"provider": {"only": ["x"]}, "seed": 7}
+    assert parse_extra_body("[1, 2]") == {}  # not an object: nothing to merge
+    assert parse_extra_body("{oops") == {}
+    assert parse_extra_body("") == {}
+
+
+# --- save-time validation --------------------------------------------------
+
+
+def test_update_accepts_well_formed():
+    assert ModelConfigUpdate(extra_headers="X-Provider: deepinfra").extra_headers == "X-Provider: deepinfra"
+    assert ModelConfigUpdate(extra_body='{"seed": 1}').extra_body == '{"seed": 1}'
+    assert ModelConfigUpdate(extra_headers="  ").extra_headers == ""
+
+
+def test_update_accepts_stripped_name_and_separator_whitespace():
+    assert ModelConfigUpdate(extra_headers="X-Provider : deepinfra").extra_headers == "X-Provider : deepinfra"
+    nbsp_line = f"X-Provider:{NBSP}deepinfra"
+    assert ModelConfigUpdate(extra_headers=nbsp_line).extra_headers == nbsp_line
+
+
+MALFORMED = [
+    {"extra_headers": "X-Provider deepinfra"},  # no colon
+    {"extra_headers": "Bad Name: v"},  # whitespace in the name
+    {"extra_headers": '"X-Provider": "deepinfra"'},  # ASCII, but not an HTTP token
+    {"extra_headers": f"X-Bad: caf{ACCENT}"},  # non-ASCII value
+    {"extra_body": "[1,2]"},  # not an object
+    {"extra_body": "{nope"},  # not JSON
+]
+
+
+@pytest.mark.parametrize("payload", MALFORMED)
+def test_update_rejects_malformed(payload):
+    with pytest.raises(ValidationError):
+        ModelConfigUpdate(**payload)
+
+
+@pytest.mark.parametrize("payload", MALFORMED)
+def test_create_rejects_malformed(payload):
+    # model_name is required with no default, so a partial payload would raise
+    # for the missing field whether or not the new validators exist.
+    with pytest.raises(ValidationError):
+        ModelConfigCreate(model_name="m", **payload)
+
+
+def test_create_accepts_well_formed():
+    mc = ModelConfigCreate(model_name="m", extra_headers="X-Provider : deepinfra", extra_body='{"seed": 1}')
+    assert mc.extra_headers == "X-Provider : deepinfra"
+    assert mc.extra_body == '{"seed": 1}'
+
+
+# --- client merge ----------------------------------------------------------
+
+
+def test_client_defaults_are_empty():
+    c = LLMClient("http://localhost:9999")
+    assert c.extra_headers == {}
+    assert c.extra_body == {}
+    assert c._headers() == {}
+
+
+def test_headers_merge_over_authorization():
+    c = LLMClient("http://x", api_key="sk-1", extra_headers="X-Provider: deepinfra")
+    assert c._headers() == {"Authorization": "Bearer sk-1", "X-Provider": "deepinfra"}
+
+
+def test_headers_may_replace_authorization():
+    # Deliberate: a gateway wanting a different auth scheme is exactly the kind
+    # of thing an escape hatch exists for.
+    c = LLMClient("http://x", api_key="sk-1", extra_headers="Authorization: Custom xyz")
+    assert c._headers() == {"Authorization": "Custom xyz"}
+
+
+def test_headers_replace_authorization_case_insensitively():
+    # Lowercase is the form most provider docs use. Sending both would leak the
+    # Bearer key to the gateway the override exists to hide it from.
+    c = LLMClient("http://x", api_key="sk-1", extra_headers="authorization: Custom xyz")
+    assert c._headers() == {"authorization": "Custom xyz"}
+
+
+# --- wire-level body merge -------------------------------------------------
+
+
+class _FakeStream:
+    status_code = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def aiter_lines(self):
+        yield 'data: {"choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}'
+        yield "data: [DONE]"
+
+
+class _FakeAsyncClient:
+    def __init__(self, *a, **k):
+        self.bodies = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def stream(self, method, url, json=None, headers=None):
+        self.bodies.append(dict(json or {}))
+        return _FakeStream()
+
+
+async def _wire_body(client: LLMClient, **params) -> dict:
+    fake = _FakeAsyncClient()
+    with patch.object(llm_mod.httpx, "AsyncClient", lambda *a, **k: fake):
+        async for _ in client.complete([], "m", **params):
+            pass
+    assert len(fake.bodies) == 1
+    return fake.bodies[0]
+
+
+async def test_wire_extra_body_reaches_the_request():
+    client = LLMClient("http://localhost:5000/v1", extra_body='{"provider": {"only": ["deepinfra"]}}')
+    body = await _wire_body(client)
+    assert body["provider"] == {"only": ["deepinfra"]}
+
+
+async def test_wire_extra_body_overrides_a_computed_key():
+    client = LLMClient("http://localhost:5000/v1", extra_body='{"temperature": 0.1}')
+    body = await _wire_body(client, temperature=0.9)
+    assert body["temperature"] == 0.1
+
+
+# --- settings threading ----------------------------------------------------
+
+
+def test_agent_falls_back_to_writer_values():
+    settings = {
+        "endpoint_url": "http://x",
+        "model_name": "m",
+        "extra_headers": "X-Provider: deepinfra",
+        "extra_body": '{"seed": 7}',
+    }
+    for build in (client_from_settings, agent_client_from_settings):
+        c = build(settings)
+        assert c.extra_headers == {"X-Provider": "deepinfra"}
+        assert c.extra_body == {"seed": 7}
+
+
+def test_agent_overrides_writer_values():
+    settings = {
+        "endpoint_url": "http://x",
+        "model_name": "m",
+        "extra_headers": "X-Provider: writerprov",
+        "agent_extra_headers": "X-Provider: agentprov",
+        "extra_body": '{"seed": 1}',
+        "agent_extra_body": '{"seed": 2}',
+    }
+    assert client_from_settings(settings).extra_headers == {"X-Provider": "writerprov"}
+    assert agent_client_from_settings(settings).extra_headers == {"X-Provider": "agentprov"}
+    assert client_from_settings(settings).extra_body == {"seed": 1}
+    assert agent_client_from_settings(settings).extra_body == {"seed": 2}


### PR DESCRIPTION
Use case obvious. X-Provider and such, and many more than that. Anything which is not a part of the standard OpenAI-style API spec. Should be compatible with #138 without adjustments.