### PR TITLE
Image gen - reference image workflows

### DIFF
--- a/backend/workflows/image_gen/config.py
+++ b/backend/workflows/image_gen/config.py
@@ -16,17 +16,15 @@ MAX_STYLES = 32
 MAX_USER_GRAPHS = 32
 MAX_GRAPH_BYTES = 512_000
 MAX_REFERENCE_SLOTS = 4
-# Base64 payload cap for the per-character reference image. The profile lives in a
-# JSON1 slot on `character_cards.workflow_state` that is read on every generate, so
-# an unbounded upload would be paid for on every render, not just once.
-# Sized off the picker's 10 MB raw-file cap plus base64's 4/3 inflation.
+# Base64 cap for the per-character reference image: the profile lives on
+# `character_cards.workflow_state` and is read on every generate, so an unbounded
+# upload is paid for per render. The picker's 10 MB raw cap plus base64's 4/3.
 MAX_REFERENCE_IMAGE_B64 = 13_400_000
 PROMPT_FORMATS = ("tags", "hybrid", "prose")
 DEFAULT_PROMPT_FORMAT = "hybrid"
-# Where a mapped `LoadImage` node gets its bytes from, as an ordered resolution
-# list. A pure edit graph cannot render without a reference, so a slot pinned to
-# `previous` alone hard-fails on the first Visualize of every new conversation;
-# the combined source exists so the default choice has no cold-start cliff.
+# Where a mapped `LoadImage` gets its bytes, as an ordered resolution list. The
+# combined source is the default so the choice has no cold-start cliff: a slot
+# pinned to `previous` alone hard-fails on a new conversation's first Visualize.
 REFERENCE_SOURCES: dict[str, tuple[str, ...]] = {
     "previous": ("previous",),
     "character": ("character",),
@@ -131,25 +129,13 @@ def _reference(raw: Any) -> dict | None:
 def _strip_machine_local_state(graph: dict) -> dict:
     """A deep copy of `graph` with each node's top-level `is_changed` removed.
 
-    ComfyUI's API export embeds `is_changed` -- for a `LoadImage` node, a hash of
-    the file on the *exporter's* disk. `IsChangedCache.get` returns a client-supplied
-    value verbatim and only computes the real hash when the key is absent
-    (`execution.py`), and that value is one component of the node's cache signature
-    alongside every input value (`comfy_execution/caching.py`).
-
-    So a stale hash does not mask a changed *filename* -- the filename is in the
-    signature itself. What it masks is a change of file *contents at an unchanged
-    path*, which is precisely what `LoadImage.IS_CHANGED`'s file hash exists to
-    detect: replace the file on the ComfyUI server and the render silently returns
-    the previously decoded image. Verified against ComfyUI 0.29.0, where a pinned
-    `is_changed` reproduces exactly that.
-
-    Orb's own uploads are content-addressed, so a mapped reference changes its name
-    whenever its bytes change and is safe either way. The exposure is an *unmapped*
-    loader still pointing at the exporter's filename. Stripped at import, like the
-    pinned filename it describes, so machine-local state can never reach storage or
-    a submission -- and the stored graph gets smaller before the size cap is
-    measured.
+    ComfyUI's API export embeds `is_changed` -- for a `LoadImage`, a hash of the
+    file on the *exporter's* disk. `IsChangedCache.get` returns a client-supplied
+    value verbatim (`execution.py`) as one component of the node's cache signature,
+    so a pinned hash masks a change of file *contents at an unchanged path* and the
+    render silently returns the previously decoded image (seen on ComfyUI 0.29.0).
+    Stripped at import, before the size cap is measured, so machine-local state
+    never reaches storage or a submission.
     """
     stripped = copy.deepcopy(graph)
     for node in stripped.values():
@@ -181,9 +167,8 @@ def _user_graph(raw: Any) -> dict | None:
     # rather than mapping a checkpoint slot for Orb's selection to override.
     if not all(name in slots for name in ("positive", "seed", "output")):
         return None
-    # `references` is never required, so a t2i graph normalizes exactly as before:
-    # an unmapped LoadImage is simply absent from the list, which is how "None"
-    # is encoded.
+    # Never required, so a t2i graph normalizes exactly as before: an unmapped
+    # LoadImage is simply absent from the list, which is how "Not used" is encoded.
     references_raw = slots_raw.get("references")
     references = [item for item in map(_reference, references_raw) if item] if isinstance(references_raw, list) else []
     if references:
@@ -270,10 +255,9 @@ REFERENCE_MIMES = ("image/png", "image/jpeg", "image/webp")
 
 def normalize_profile(raw: Mapping[str, Any] | None) -> dict:
     raw = raw if isinstance(raw, Mapping) else {}
-    # The per-character reference image, for graphs whose LoadImage slots resolve
-    # to `character`. Dropped rather than truncated when oversized -- half a base64
-    # payload is not a smaller image, it is a corrupt one. Both halves must survive
-    # together: bytes with no usable mime are data ComfyUI cannot be told how to read.
+    # The per-character reference image, for slots resolving to `character`. Dropped
+    # rather than truncated when oversized -- half a base64 payload is not a smaller
+    # image. Both halves ride together: bytes with no mime cannot be read by ComfyUI.
     image_raw = raw.get("reference_image_b64")
     image = image_raw.strip() if isinstance(image_raw, str) else ""
     mime = _text(raw.get("reference_mime"), 64).lower()

--- a/backend/workflows/image_gen/config.py
+++ b/backend/workflows/image_gen/config.py
@@ -15,8 +15,23 @@ WORKFLOW_ID = "image_gen"
 MAX_STYLES = 32
 MAX_USER_GRAPHS = 16
 MAX_GRAPH_BYTES = 512_000
+MAX_REFERENCE_SLOTS = 4
+# Base64 payload cap for the per-character reference image. The profile lives in a
+# JSON1 slot on `character_cards.workflow_state` that is read on every generate, so
+# an unbounded upload would be paid for on every render, not just once.
+MAX_REFERENCE_IMAGE_B64 = 4_000_000
 PROMPT_FORMATS = ("tags", "hybrid", "prose")
 DEFAULT_PROMPT_FORMAT = "hybrid"
+# Where a mapped `LoadImage` node gets its bytes from, as an ordered resolution
+# list. A pure edit graph cannot render without a reference, so a slot pinned to
+# `previous` alone hard-fails on the first Visualize of every new conversation;
+# the combined source exists so the default choice has no cold-start cliff.
+REFERENCE_SOURCES: dict[str, tuple[str, ...]] = {
+    "previous": ("previous",),
+    "character": ("character",),
+    "previous_or_character": ("previous", "character"),
+}
+DEFAULT_REFERENCE_SOURCE = "previous_or_character"
 
 CONFIG_DEFAULTS = {
     "source": "external_comfy",
@@ -100,6 +115,48 @@ def _slot(value: Any) -> list[str] | None:
     return [node_s, field_s]
 
 
+def _reference(raw: Any) -> dict | None:
+    """One `LoadImage` widget mapped to a reference source, or None to drop it."""
+    if not isinstance(raw, Mapping):
+        return None
+    slot = _slot(raw.get("slot"))
+    source = _text(raw.get("source"), 32)
+    if slot is None or source not in REFERENCE_SOURCES:
+        return None
+    label = _text(raw.get("label"), 120) or f"{slot[0]} — {slot[1]}"
+    return {"slot": slot, "source": source, "label": label}
+
+
+def _strip_machine_local_state(graph: dict) -> dict:
+    """A deep copy of `graph` with each node's top-level `is_changed` removed.
+
+    ComfyUI's API export embeds `is_changed` -- for a `LoadImage` node, a hash of
+    the file on the *exporter's* disk. `IsChangedCache.get` returns a client-supplied
+    value verbatim and only computes the real hash when the key is absent
+    (`execution.py`), and that value is one component of the node's cache signature
+    alongside every input value (`comfy_execution/caching.py`).
+
+    So a stale hash does not mask a changed *filename* -- the filename is in the
+    signature itself. What it masks is a change of file *contents at an unchanged
+    path*, which is precisely what `LoadImage.IS_CHANGED`'s file hash exists to
+    detect: replace the file on the ComfyUI server and the render silently returns
+    the previously decoded image. Verified against ComfyUI 0.29.0, where a pinned
+    `is_changed` reproduces exactly that.
+
+    Orb's own uploads are content-addressed, so a mapped reference changes its name
+    whenever its bytes change and is safe either way. The exposure is an *unmapped*
+    loader still pointing at the exporter's filename. Stripped at import, like the
+    pinned filename it describes, so machine-local state can never reach storage or
+    a submission -- and the stored graph gets smaller before the size cap is
+    measured.
+    """
+    stripped = copy.deepcopy(graph)
+    for node in stripped.values():
+        if isinstance(node, dict):
+            node.pop("is_changed", None)
+    return stripped
+
+
 def _user_graph(raw: Any) -> dict | None:
     if not isinstance(raw, Mapping):
         return None
@@ -110,9 +167,10 @@ def _user_graph(raw: Any) -> dict | None:
         return None
     import json
 
+    graph = _strip_machine_local_state(graph)
     if len(json.dumps(graph, separators=(",", ":"), ensure_ascii=False).encode("utf-8")) > MAX_GRAPH_BYTES:
         return None
-    slots: dict[str, list[str]] = {}
+    slots: dict[str, Any] = {}
     for name in ("positive", "negative", "seed", "output", "checkpoint"):
         parsed = _slot(slots_raw.get(name))
         if parsed is not None:
@@ -122,10 +180,17 @@ def _user_graph(raw: Any) -> dict | None:
     # rather than mapping a checkpoint slot for Orb's selection to override.
     if not all(name in slots for name in ("positive", "seed", "output")):
         return None
+    # `references` is never required, so a t2i graph normalizes exactly as before:
+    # an unmapped LoadImage is simply absent from the list, which is how "None"
+    # is encoded.
+    references_raw = slots_raw.get("references")
+    references = [item for item in map(_reference, references_raw) if item] if isinstance(references_raw, list) else []
+    if references:
+        slots["references"] = references[:MAX_REFERENCE_SLOTS]
     return {
         "id": gid,
         "label": _text(raw.get("label"), 100, gid) or gid,
-        "graph": copy.deepcopy(graph),
+        "graph": graph,
         "slots": slots,
     }
 
@@ -199,9 +264,25 @@ def resolve_style(config: Mapping[str, Any], style_id: str) -> dict:
     return dict(style)
 
 
+REFERENCE_MIMES = ("image/png", "image/jpeg", "image/webp")
+
+
 def normalize_profile(raw: Mapping[str, Any] | None) -> dict:
     raw = raw if isinstance(raw, Mapping) else {}
+    # The per-character reference image, for graphs whose LoadImage slots resolve
+    # to `character`. Dropped rather than truncated when oversized -- half a base64
+    # payload is not a smaller image, it is a corrupt one. Both halves must survive
+    # together: bytes with no usable mime are data ComfyUI cannot be told how to read.
+    image_raw = raw.get("reference_image_b64")
+    image = image_raw.strip() if isinstance(image_raw, str) else ""
+    mime = _text(raw.get("reference_mime"), 64).lower()
+    if len(image) > MAX_REFERENCE_IMAGE_B64 or mime not in REFERENCE_MIMES:
+        image, mime = "", ""
+    if not image:
+        mime = ""
     return {
         "appearance_prompt": _text(raw.get("appearance_prompt"), 2_000),
         "negative_prompt": _text(raw.get("negative_prompt"), 2_000),
+        "reference_image_b64": image,
+        "reference_mime": mime,
     }

--- a/backend/workflows/image_gen/config.py
+++ b/backend/workflows/image_gen/config.py
@@ -13,13 +13,14 @@ from .pov import normalize_mode as normalize_pov_mode
 
 WORKFLOW_ID = "image_gen"
 MAX_STYLES = 32
-MAX_USER_GRAPHS = 16
+MAX_USER_GRAPHS = 32
 MAX_GRAPH_BYTES = 512_000
 MAX_REFERENCE_SLOTS = 4
 # Base64 payload cap for the per-character reference image. The profile lives in a
 # JSON1 slot on `character_cards.workflow_state` that is read on every generate, so
 # an unbounded upload would be paid for on every render, not just once.
-MAX_REFERENCE_IMAGE_B64 = 4_000_000
+# Sized off the picker's 10 MB raw-file cap plus base64's 4/3 inflation.
+MAX_REFERENCE_IMAGE_B64 = 13_400_000
 PROMPT_FORMATS = ("tags", "hybrid", "prose")
 DEFAULT_PROMPT_FORMAT = "hybrid"
 # Where a mapped `LoadImage` node gets its bytes from, as an ordered resolution

--- a/backend/workflows/image_gen/engine/__init__.py
+++ b/backend/workflows/image_gen/engine/__init__.py
@@ -12,8 +12,9 @@ from .contracts import (
     ImageGenerationError,
     ImageRequest,
     ImageResult,
+    ResolvedReference,
 )
-from .graph import graph_has_negative, has_graph
+from .graph import graph_has_negative, graph_reference_slots, has_graph
 from .render import RenderTarget, resolve_and_generate, resolve_render_target
 
 __all__ = [
@@ -24,7 +25,9 @@ __all__ = [
     "ImageResult",
     "ProgressCallback",
     "RenderTarget",
+    "ResolvedReference",
     "graph_has_negative",
+    "graph_reference_slots",
     "has_graph",
     "invalidate_object_info",
     "list_models",

--- a/backend/workflows/image_gen/engine/adapters/external_comfy.py
+++ b/backend/workflows/image_gen/engine/adapters/external_comfy.py
@@ -114,46 +114,38 @@ async def list_models(config: Mapping[str, Any]) -> list[str]:
     return await _client(config).models("checkpoints")
 
 
+def _declared_inputs(info: Mapping[str, Any]) -> dict[str, Any]:
+    """Every declared input of one node class, required and optional alike."""
+    spec = info.get("input")
+    declared: dict[str, Any] = {}
+    for group in ("required", "optional"):
+        values = spec.get(group) if isinstance(spec, Mapping) else None
+        if isinstance(values, Mapping):
+            declared.update(values)
+    return declared
+
+
 def _typed_inputs(info: Mapping[str, Any], wanted: str) -> list[str]:
-    """Input names on one node class whose declared type is `wanted`.
+    """Input names whose declared type is the scalar kind `wanted`.
 
     `/object_info` declares an input as `[type, options]`, where `type` is a
     string for scalars and a list for combos. Only scalars are role candidates:
     a combo is a fixed menu, and a linked slot has no widget to patch.
     """
-    spec = info.get("input")
-    if not isinstance(spec, Mapping):
-        return []
-    declared: dict[str, Any] = {}
-    for group in ("required", "optional"):
-        values = spec.get(group)
-        if isinstance(values, Mapping):
-            declared.update(values)
-    names = []
-    for name, value in declared.items():
-        kind = value[0] if isinstance(value, (list, tuple)) and value else None
-        if kind == wanted:
-            names.append(name)
-    return names
+    return [
+        name
+        for name, value in _declared_inputs(info).items()
+        if isinstance(value, (list, tuple)) and value and value[0] == wanted
+    ]
 
 
 def _image_upload_inputs(info: Mapping[str, Any]) -> list[str]:
-    """Input names on one node class that accept an uploaded image file.
+    """Input names that accept an uploaded image file.
 
-    A sibling to `_typed_inputs` rather than a case inside it: that one types by
-    string kind, and an upload widget's declared type is the *combo* of files
-    already in the server's input directory, so no kind comparison can match it.
+    Separate from `_typed_inputs` because an upload widget's declared type is the
+    *combo* of files already on the server, so no kind comparison can match it.
     """
-    spec = info.get("input")
-    if not isinstance(spec, Mapping):
-        return []
-    names = []
-    for group in ("required", "optional"):
-        values = spec.get(group)
-        if not isinstance(values, Mapping):
-            continue
-        names.extend(name for name, value in values.items() if is_image_upload(value))
-    return names
+    return [name for name, value in _declared_inputs(info).items() if is_image_upload(value)]
 
 
 async def node_roles(config: Mapping[str, Any], class_types: Sequence[str]) -> dict:
@@ -233,18 +225,17 @@ async def generate(
             **describe_render_params(patched, slots),
             "source": "external_comfy",
             "workflow_id": graph_id,
-            # What a reroll re-fetches by. `origin` names the row or card the bytes
-            # came from, so replay reproduces the *same* reference rather than
-            # re-resolving to whatever the branch looks like now.
+            # What a reroll re-fetches by: `origin` names the row or card the bytes
+            # came from, so replay reproduces the *same* reference.
             "references": [
                 {
-                    "slot": list(reference.slot),
-                    "source": reference.source,
-                    "origin": reference.origin,
-                    "digest": reference.digest,
-                    "comfy_name": uploaded[reference.digest],
+                    "slot": list(r.slot),
+                    "source": r.source,
+                    "origin": r.origin,
+                    "digest": r.digest,
+                    "comfy_name": uploaded[r.digest],
                 }
-                for reference in request.references
+                for r in request.references
             ],
             # Record the model only when the graph actually applied it. A
             # self-contained graph (no checkpoint slot) ignores the value, and

--- a/backend/workflows/image_gen/engine/adapters/external_comfy.py
+++ b/backend/workflows/image_gen/engine/adapters/external_comfy.py
@@ -14,6 +14,7 @@ from ..contracts import (
 )
 from ..graph import (
     describe_render_params,
+    is_image_upload,
     patch_graph,
     resolve_graph,
     validate_graph_structure,
@@ -136,6 +137,25 @@ def _typed_inputs(info: Mapping[str, Any], wanted: str) -> list[str]:
     return names
 
 
+def _image_upload_inputs(info: Mapping[str, Any]) -> list[str]:
+    """Input names on one node class that accept an uploaded image file.
+
+    A sibling to `_typed_inputs` rather than a case inside it: that one types by
+    string kind, and an upload widget's declared type is the *combo* of files
+    already in the server's input directory, so no kind comparison can match it.
+    """
+    spec = info.get("input")
+    if not isinstance(spec, Mapping):
+        return []
+    names = []
+    for group in ("required", "optional"):
+        values = spec.get(group)
+        if not isinstance(values, Mapping):
+            continue
+        names.extend(name for name, value in values.items() if is_image_upload(value))
+    return names
+
+
 async def node_roles(config: Mapping[str, Any], class_types: Sequence[str]) -> dict:
     """Which inputs of the named node classes can carry which slot role.
 
@@ -156,6 +176,7 @@ async def node_roles(config: Mapping[str, Any], class_types: Sequence[str]) -> d
             "output_node": bool(entry.get("output_node")),
             "text_inputs": _typed_inputs(entry, "STRING"),
             "seed_inputs": [name for name in _typed_inputs(entry, "INT") if "seed" in name.lower()],
+            "image_inputs": _image_upload_inputs(entry),
         }
     return roles
 
@@ -175,6 +196,20 @@ async def generate(
     # the attachment rather than let the user wonder why the negation had no effect.
     if "negative" not in slots and request.negative_prompt.strip():
         notes = (*notes, "this workflow has no negative prompt input; negative prompt was not applied")
+    client = _client(config)
+    # Resolution happened above the engine (it reads conversation state); the upload
+    # belongs here, where everything else that talks to ComfyUI lives. Distinct
+    # digests only: two slots pointing at the same image are one file on the server.
+    uploaded: dict[str, str] = {}
+    for reference in request.references:
+        if reference.digest not in uploaded:
+            uploaded[reference.digest] = await client.upload_image(
+                reference.data,
+                reference.mime,
+                digest=reference.digest,
+                timeout=min(120.0, request.timeout_seconds),
+                progress=progress,
+            )
     patched, output_node = patch_graph(
         graph,
         slots,
@@ -182,8 +217,9 @@ async def generate(
         negative_prompt=request.negative_prompt,
         seed=request.seed,
         checkpoint=checkpoint,
+        references=[(reference.slot, uploaded[reference.digest]) for reference in request.references],
     )
-    result = await _client(config).generate(
+    result = await client.generate(
         patched,
         output_node,
         timeout_seconds=request.timeout_seconds,
@@ -197,6 +233,19 @@ async def generate(
             **describe_render_params(patched, slots),
             "source": "external_comfy",
             "workflow_id": graph_id,
+            # What a reroll re-fetches by. `origin` names the row or card the bytes
+            # came from, so replay reproduces the *same* reference rather than
+            # re-resolving to whatever the branch looks like now.
+            "references": [
+                {
+                    "slot": list(reference.slot),
+                    "source": reference.source,
+                    "origin": reference.origin,
+                    "digest": reference.digest,
+                    "comfy_name": uploaded[reference.digest],
+                }
+                for reference in request.references
+            ],
             # Record the model only when the graph actually applied it. A
             # self-contained graph (no checkpoint slot) ignores the value, and
             # replay reads a null here as "the graph carried its own model".

--- a/backend/workflows/image_gen/engine/comfy_client.py
+++ b/backend/workflows/image_gen/engine/comfy_client.py
@@ -17,6 +17,13 @@ from .display_encode import shrink_for_display
 MAX_IMAGE_BYTES = 20 * 1024 * 1024
 ProgressCallback = Callable[[str, Mapping[str, Any]], Awaitable[None] | None]
 
+# Every reference Orb uploads lands in this one subfolder of ComfyUI's input
+# directory, so the files it leaves behind are identifiable as Orb's. Core ComfyUI
+# exposes no delete API for input files, so the directory grows by one file per
+# distinct reference; content-addressed names keep repeats from adding to that.
+REFERENCE_SUBFOLDER = "orb"
+_UPLOAD_EXTENSIONS = {"image/png": "png", "image/jpeg": "jpg", "image/webp": "webp"}
+
 # `/object_info` is the one enormous response in this contract -- a real install
 # with custom-node packs reports ~2000 node types, tens of megabytes. Readiness
 # probes run on every Visualize modal open, so an uncached fetch would put that
@@ -140,6 +147,58 @@ class ComfyClient:
             _object_info_cache.clear()
         _object_info_cache[self.api_url] = (now + _OBJECT_INFO_TTL, result)
         return result
+
+    async def upload_image(
+        self,
+        data: bytes,
+        mime: str,
+        *,
+        digest: str,
+        timeout: float = 60.0,
+        progress: ProgressCallback | None = None,
+    ) -> str:
+        """Upload one reference image and return the widget value for `LoadImage`.
+
+        ComfyUI's ``/upload/image`` takes multipart ``image``/``subfolder``/``type``/
+        ``overwrite`` and answers ``{name, subfolder, type}``; a bare
+        ``"<subfolder>/<name>"`` is what ``folder_paths.get_annotated_filepath``
+        resolves under the input directory, so that is what the widget carries.
+
+        The name is content-addressed off `digest`: repeat renders of the same
+        reference overwrite one file instead of filling the input directory, and a
+        reroll resolves to the same name it did the first time.
+        """
+        name = f"orb_{digest[:16]}.{_UPLOAD_EXTENSIONS.get(mime, 'png')}"
+        await _emit(progress, "uploading", {"name": name, "bytes": len(data)})
+        try:
+            async with httpx.AsyncClient(
+                base_url=self.api_url,
+                headers=self.headers,
+                timeout=timeout,
+                transport=self.transport,
+            ) as client:
+                response = await client.post(
+                    "/upload/image",
+                    files={"image": (name, data, mime or "application/octet-stream")},
+                    # ComfyUI compares `overwrite` against the strings "true"/"1", so
+                    # a bool would silently mean "no" and every render would land a
+                    # new "orb_… (1).webp" beside the last.
+                    data={"subfolder": REFERENCE_SUBFOLDER, "type": "input", "overwrite": "true"},
+                )
+                if response.status_code >= 400:
+                    raise ImageGenerationError("ComfyUI rejected the reference image upload")
+                payload = response.json()
+        except ImageGenerationError:
+            raise
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError) as exc:
+            raise ImageGenerationError("Could not upload the reference image to ComfyUI") from exc
+        if not isinstance(payload, Mapping) or not isinstance(payload.get("name"), str):
+            raise ImageGenerationError("ComfyUI did not confirm the reference image upload")
+        # Trust the server's own answer over the name we sent: it renames on
+        # collision, and the widget must carry the file that actually exists.
+        subfolder = payload.get("subfolder")
+        stored = payload["name"]
+        return f"{subfolder}/{stored}" if isinstance(subfolder, str) and subfolder else stored
 
     async def models(self, folder: str = "checkpoints") -> list[str]:
         result = await self._json("GET", f"/models/{folder}")

--- a/backend/workflows/image_gen/engine/comfy_client.py
+++ b/backend/workflows/image_gen/engine/comfy_client.py
@@ -17,9 +17,8 @@ from .display_encode import shrink_for_display
 MAX_IMAGE_BYTES = 20 * 1024 * 1024
 ProgressCallback = Callable[[str, Mapping[str, Any]], Awaitable[None] | None]
 
-# Every reference Orb uploads lands in this one subfolder of ComfyUI's input
-# directory, so the files it leaves behind are identifiable as Orb's. Core ComfyUI
-# exposes no delete API for input files, so the directory grows by one file per
+# One subfolder of ComfyUI's input directory, so Orb's leftovers are identifiable.
+# Core ComfyUI exposes no delete API for input files, so it grows by one file per
 # distinct reference; content-addressed names keep repeats from adding to that.
 REFERENCE_SUBFOLDER = "orb"
 _UPLOAD_EXTENSIONS = {"image/png": "png", "image/jpeg": "jpg", "image/webp": "webp"}
@@ -102,14 +101,12 @@ class ComfyClient:
         self.headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
         self.transport = transport
 
+    def _http(self, timeout: float) -> httpx.AsyncClient:
+        return httpx.AsyncClient(base_url=self.api_url, headers=self.headers, timeout=timeout, transport=self.transport)
+
     async def _json(self, method: str, path: str, *, timeout: float = 15.0, json_body: Any = None) -> Any:
         try:
-            async with httpx.AsyncClient(
-                base_url=self.api_url,
-                headers=self.headers,
-                timeout=timeout,
-                transport=self.transport,
-            ) as client:
+            async with self._http(timeout) as client:
                 response = await client.request(method, path, json=json_body)
                 if response.status_code >= 400:
                     try:
@@ -159,24 +156,16 @@ class ComfyClient:
     ) -> str:
         """Upload one reference image and return the widget value for `LoadImage`.
 
-        ComfyUI's ``/upload/image`` takes multipart ``image``/``subfolder``/``type``/
-        ``overwrite`` and answers ``{name, subfolder, type}``; a bare
-        ``"<subfolder>/<name>"`` is what ``folder_paths.get_annotated_filepath``
-        resolves under the input directory, so that is what the widget carries.
-
-        The name is content-addressed off `digest`: repeat renders of the same
-        reference overwrite one file instead of filling the input directory, and a
-        reroll resolves to the same name it did the first time.
+        ``/upload/image`` takes multipart ``image``/``subfolder``/``type``/``overwrite``
+        and answers ``{name, subfolder, type}``; a bare ``"<subfolder>/<name>"`` is what
+        ``folder_paths.get_annotated_filepath`` resolves under the input directory, so
+        that is what the widget carries. The name is content-addressed off `digest`, so
+        repeat renders overwrite one file and a reroll resolves to the same name.
         """
         name = f"orb_{digest[:16]}.{_UPLOAD_EXTENSIONS.get(mime, 'png')}"
         await _emit(progress, "uploading", {"name": name, "bytes": len(data)})
         try:
-            async with httpx.AsyncClient(
-                base_url=self.api_url,
-                headers=self.headers,
-                timeout=timeout,
-                transport=self.transport,
-            ) as client:
+            async with self._http(timeout) as client:
                 response = await client.post(
                     "/upload/image",
                     files={"image": (name, data, mime or "application/octet-stream")},
@@ -291,12 +280,7 @@ class ComfyClient:
         if not image or not all(isinstance(image.get(k), str) for k in ("filename", "subfolder", "type")):
             raise ImageGenerationError("ComfyUI completed without the configured image output")
         try:
-            async with httpx.AsyncClient(
-                base_url=self.api_url,
-                headers=self.headers,
-                timeout=min(60.0, timeout_seconds),
-                transport=self.transport,
-            ) as client:
+            async with self._http(min(60.0, timeout_seconds)) as client:
                 response = await client.get(
                     "/view",
                     params={k: image[k] for k in ("filename", "subfolder", "type")},

--- a/backend/workflows/image_gen/engine/contracts.py
+++ b/backend/workflows/image_gen/engine/contracts.py
@@ -15,6 +15,25 @@ class ImageBackendCapabilities(TypedDict):
 
 
 @dataclass(frozen=True)
+class ResolvedReference:
+    """One reference image, already fetched, for one mapped `LoadImage` widget.
+
+    Resolution happens above the engine (it reads conversation state); uploading
+    and patching happen inside it. `origin` names *where the bytes came from* in
+    a form a later replay can re-fetch by -- ``"attachment:<id>"`` or
+    ``"character:<card id>"`` -- and `digest` identifies the bytes themselves, so
+    two slots resolving to the same image upload once.
+    """
+
+    slot: tuple[str, str]
+    source: str
+    data: bytes
+    mime: str
+    origin: str
+    digest: str
+
+
+@dataclass(frozen=True)
 class ImageRequest:
     prompt: str
     negative_prompt: str
@@ -24,6 +43,7 @@ class ImageRequest:
     width: int | None = None
     height: int | None = None
     timeout_seconds: float = 180.0
+    references: tuple[ResolvedReference, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/backend/workflows/image_gen/engine/contracts.py
+++ b/backend/workflows/image_gen/engine/contracts.py
@@ -18,11 +18,9 @@ class ImageBackendCapabilities(TypedDict):
 class ResolvedReference:
     """One reference image, already fetched, for one mapped `LoadImage` widget.
 
-    Resolution happens above the engine (it reads conversation state); uploading
-    and patching happen inside it. `origin` names *where the bytes came from* in
-    a form a later replay can re-fetch by -- ``"attachment:<id>"`` or
-    ``"character:<card id>"`` -- and `digest` identifies the bytes themselves, so
-    two slots resolving to the same image upload once.
+    `origin` names *where the bytes came from* in a form a later replay can
+    re-fetch by (``"attachment:<id>"``, ``"character:<card id>"``); `digest`
+    identifies the bytes, so two slots resolving to the same image upload once.
     """
 
     slot: tuple[str, str]

--- a/backend/workflows/image_gen/engine/display_encode.py
+++ b/backend/workflows/image_gen/engine/display_encode.py
@@ -21,26 +21,26 @@ import io
 from PIL import Image
 
 _WEBP_QUALITY = 95
-# Above either of these a reference is re-encoded before upload. Both are ceilings
-# on a *phone-sized* upload, not a target size: identity-edit workflows are exactly
-# the ones that lose face detail to a downscale, and a graph that wants a specific
-# size already carries a scale node (ImageScaleToTotalPixels, GetImageSize).
+# Ceilings on a *phone-sized* reference upload, not a target size: identity-edit
+# workflows are the ones that lose face detail to a downscale, and a graph wanting
+# a specific size already carries a scale node (ImageScaleToTotalPixels).
 _REFERENCE_MAX_EDGE = 4096
 _REFERENCE_MAX_BYTES = 8 * 1024 * 1024
 
 
-def shrink_for_display(data: bytes, mime: str) -> tuple[bytes, str]:
-    """Re-encode to WebP at full resolution.
+def _to_webp(data: bytes, mime: str, max_edge: int | None = None) -> tuple[bytes, str]:
+    """Re-encode to WebP, optionally bounded to `max_edge`.
 
-    Returns ``(webp_bytes, "image/webp")``, or the input ``(data, mime)`` unchanged
-    when re-encoding would not help or fails. Never raises: a display optimization
-    must not sink a generation that already cost a minute of GPU time.
+    Never raises: re-encoding is an optimization, and returning the input
+    unchanged is always a correct answer.
     """
     try:
         with Image.open(io.BytesIO(data)) as img:
             img.load()
             if img.mode not in ("RGB", "RGBA"):
                 img = img.convert("RGB")
+            if max_edge:
+                img.thumbnail((max_edge, max_edge), Image.Resampling.LANCZOS)
             buf = io.BytesIO()
             img.save(buf, format="WEBP", quality=_WEBP_QUALITY, method=4)
     except Exception:
@@ -50,14 +50,15 @@ def shrink_for_display(data: bytes, mime: str) -> tuple[bytes, str]:
     return (out, "image/webp") if len(out) < len(data) else (data, mime)
 
 
+def shrink_for_display(data: bytes, mime: str) -> tuple[bytes, str]:
+    """Re-encode a render to WebP at full resolution, for storage and inlining."""
+    return _to_webp(data, mime)
+
+
 def normalize_reference(data: bytes, mime: str) -> tuple[bytes, str]:
     """Bound a reference image before it is uploaded to ComfyUI.
 
-    Returns the input unchanged unless the image is genuinely oversized -- a
-    12 MP camera upload, not a render. Same never-raises discipline as
-    ``shrink_for_display``: a reference Orb cannot re-encode is still a reference
-    ComfyUI can probably load, so a failure here degrades to sending the original
-    rather than sinking the generation.
+    Untouched unless genuinely oversized -- a 12 MP camera upload, not a render.
     """
     if len(data) <= _REFERENCE_MAX_BYTES:
         try:
@@ -66,15 +67,4 @@ def normalize_reference(data: bytes, mime: str) -> tuple[bytes, str]:
                     return data, mime
         except Exception:
             return data, mime
-    try:
-        with Image.open(io.BytesIO(data)) as img:
-            img.load()
-            if img.mode not in ("RGB", "RGBA"):
-                img = img.convert("RGB")
-            img.thumbnail((_REFERENCE_MAX_EDGE, _REFERENCE_MAX_EDGE), Image.Resampling.LANCZOS)
-            buf = io.BytesIO()
-            img.save(buf, format="WEBP", quality=_WEBP_QUALITY, method=4)
-    except Exception:
-        return data, mime
-    out = buf.getvalue()
-    return (out, "image/webp") if len(out) < len(data) else (data, mime)
+    return _to_webp(data, mime, _REFERENCE_MAX_EDGE)

--- a/backend/workflows/image_gen/engine/display_encode.py
+++ b/backend/workflows/image_gen/engine/display_encode.py
@@ -21,6 +21,12 @@ import io
 from PIL import Image
 
 _WEBP_QUALITY = 95
+# Above either of these a reference is re-encoded before upload. Both are ceilings
+# on a *phone-sized* upload, not a target size: identity-edit workflows are exactly
+# the ones that lose face detail to a downscale, and a graph that wants a specific
+# size already carries a scale node (ImageScaleToTotalPixels, GetImageSize).
+_REFERENCE_MAX_EDGE = 4096
+_REFERENCE_MAX_BYTES = 8 * 1024 * 1024
 
 
 def shrink_for_display(data: bytes, mime: str) -> tuple[bytes, str]:
@@ -41,4 +47,34 @@ def shrink_for_display(data: bytes, mime: str) -> tuple[bytes, str]:
         return data, mime
     out = buf.getvalue()
     # An already-small source can encode larger as WebP -- keep whichever is smaller.
+    return (out, "image/webp") if len(out) < len(data) else (data, mime)
+
+
+def normalize_reference(data: bytes, mime: str) -> tuple[bytes, str]:
+    """Bound a reference image before it is uploaded to ComfyUI.
+
+    Returns the input unchanged unless the image is genuinely oversized -- a
+    12 MP camera upload, not a render. Same never-raises discipline as
+    ``shrink_for_display``: a reference Orb cannot re-encode is still a reference
+    ComfyUI can probably load, so a failure here degrades to sending the original
+    rather than sinking the generation.
+    """
+    if len(data) <= _REFERENCE_MAX_BYTES:
+        try:
+            with Image.open(io.BytesIO(data)) as probe:
+                if max(probe.size) <= _REFERENCE_MAX_EDGE:
+                    return data, mime
+        except Exception:
+            return data, mime
+    try:
+        with Image.open(io.BytesIO(data)) as img:
+            img.load()
+            if img.mode not in ("RGB", "RGBA"):
+                img = img.convert("RGB")
+            img.thumbnail((_REFERENCE_MAX_EDGE, _REFERENCE_MAX_EDGE), Image.Resampling.LANCZOS)
+            buf = io.BytesIO()
+            img.save(buf, format="WEBP", quality=_WEBP_QUALITY, method=4)
+    except Exception:
+        return data, mime
+    out = buf.getvalue()
     return (out, "image/webp") if len(out) < len(data) else (data, mime)

--- a/backend/workflows/image_gen/engine/graph.py
+++ b/backend/workflows/image_gen/engine/graph.py
@@ -55,11 +55,8 @@ def reference_slots(slots: Mapping[str, Any]) -> list[Mapping[str, Any]]:
 
 
 def graph_reference_slots(config: Mapping[str, Any], graph_id: str) -> list[Mapping[str, Any]]:
-    """The reference slots the workflow `graph_id` maps, or [] for anything else.
-
-    The config-level read, so the hook can resolve conversation images before the
-    engine is entered without deep-copying a whole graph it will not patch.
-    """
+    """The reference slots `graph_id` maps, config-level so the hook can resolve
+    conversation images without deep-copying a graph it will not patch."""
     for item in config["external_comfy"]["user_graphs"]:
         if item["id"] == graph_id:
             return copy.deepcopy(reference_slots(item["slots"]))
@@ -170,10 +167,9 @@ def patch_graph(
 def is_image_upload(spec: Any) -> bool:
     """Whether an `/object_info` input spec is an upload widget.
 
-    `/object_info` marks these as ``[[...files...], {"image_upload": true}]`` --
-    the combo lists the server's input directory, and the flag says the widget
-    accepts a file the client uploads. That flag is the typing rule for a
-    reference slot, exactly as a STRING/INT kind is the rule for the others.
+    Marked as ``[[...files...], {"image_upload": true}]`` -- the combo lists the
+    server's input directory. That flag is the typing rule for a reference slot,
+    exactly as a STRING/INT kind is the rule for the others.
     """
     if not isinstance(spec, (list, tuple)) or len(spec) < 2 or not isinstance(spec[0], list):
         return False
@@ -184,9 +180,8 @@ def validate_graph_structure(graph: Mapping[str, Any], slots: Mapping[str, Any],
     if not graph:
         raise ImageGenerationError("The selected workflow is empty")
     # A mapped reference's widget value is replaced per render with a file this
-    # server does not have yet, so its combo membership says nothing about whether
-    # the graph can run. Without this exemption Test connection rejects every edit
-    # workflow, naming the exporter's filename as "no longer available".
+    # server does not have yet, so its combo membership says nothing. Without the
+    # exemption, Test connection rejects every edit workflow.
     mapped = {(str(entry["slot"][0]), str(entry["slot"][1])) for entry in reference_slots(slots) if entry.get("slot")}
     for node_id, node in graph.items():
         if (
@@ -210,10 +205,9 @@ def validate_graph_structure(graph: Mapping[str, Any], slots: Mapping[str, Any],
             if isinstance(spec, (list, tuple)) and spec and isinstance(spec[0], list) and not isinstance(value, list):
                 if (str(node_id), name) in mapped or value in spec[0]:
                     continue
-                # An unmapped upload widget carries a filename from whatever machine
-                # exported the graph. "No longer available on this server" reads as a
-                # broken install; the actionable answer is that it is either missing
-                # there or belongs on a reference slot.
+                # An unmapped upload widget carries the exporting machine's filename.
+                # "No longer available" reads as a broken install; the actionable
+                # answer is to upload it there or map the slot.
                 if is_image_upload(spec):
                     raise ImageGenerationError(
                         f"Node {node_id} needs image {value!r} on the ComfyUI server, or map it as a reference image"
@@ -225,8 +219,8 @@ def validate_graph_structure(graph: Mapping[str, Any], slots: Mapping[str, Any],
         _input_slot(graph, slots.get(role), role)
     if "checkpoint" in slots:
         _input_slot(graph, slots["checkpoint"], "checkpoint")
-    # A reference pointing at a node the graph no longer has would otherwise only
-    # surface mid-render, after the upload and a minute of queue time.
+    # A dangling reference would otherwise only surface mid-render, after the
+    # upload and a minute of queue time.
     for entry in reference_slots(slots):
         _input_slot(graph, entry.get("slot"), "reference image")
     output = slots.get("output")

--- a/backend/workflows/image_gen/engine/graph.py
+++ b/backend/workflows/image_gen/engine/graph.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from .contracts import ImageGenerationError
@@ -42,6 +42,28 @@ def graph_has_negative(config: Mapping[str, Any], graph_id: str) -> bool:
     spending the model's effort on a negation the workflow throws away.
     """
     return any(item["id"] == graph_id and "negative" in item["slots"] for item in config["external_comfy"]["user_graphs"])
+
+
+def reference_slots(slots: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    """The mapped reference entries, as normalization stored them.
+
+    A graph with no mapped `LoadImage` has no `references` key at all, so every
+    caller can treat "no references" and "not an edit workflow" as one case.
+    """
+    entries = slots.get("references")
+    return [entry for entry in entries if isinstance(entry, Mapping)] if isinstance(entries, list) else []
+
+
+def graph_reference_slots(config: Mapping[str, Any], graph_id: str) -> list[Mapping[str, Any]]:
+    """The reference slots the workflow `graph_id` maps, or [] for anything else.
+
+    The config-level read, so the hook can resolve conversation images before the
+    engine is entered without deep-copying a whole graph it will not patch.
+    """
+    for item in config["external_comfy"]["user_graphs"]:
+        if item["id"] == graph_id:
+            return copy.deepcopy(reference_slots(item["slots"]))
+    return []
 
 
 def _scalar(inputs: Mapping[str, Any], name: str, kinds: tuple[type, ...]) -> Any:
@@ -106,6 +128,7 @@ def patch_graph(
     negative_prompt: str,
     seed: int,
     checkpoint: str,
+    references: Sequence[tuple[tuple[str, str], str]] = (),
 ) -> tuple[dict, str]:
     patched = copy.deepcopy(dict(graph))
     for role, value in (
@@ -125,6 +148,11 @@ def patch_graph(
         if not checkpoint:
             raise ImageGenerationError("Select a checkpoint before generating")
         inputs[name] = checkpoint
+    # Each reference is the widget value the caller already uploaded ("orb/<name>"),
+    # written through the same slot helper the checkpoint override uses.
+    for slot, value in references:
+        inputs, name = _input_slot(patched, slot, "reference image")
+        inputs[name] = value
     # Imported graphs often wire the prompt text into a save node's filename_prefix
     # ("name files by prompt"). Orb's long scene prompts overflow the OS 255-byte
     # filename limit (OSError 36). Orb fetches the image by the name ComfyUI reports,
@@ -139,9 +167,27 @@ def patch_graph(
     return patched, str(output[0])
 
 
+def is_image_upload(spec: Any) -> bool:
+    """Whether an `/object_info` input spec is an upload widget.
+
+    `/object_info` marks these as ``[[...files...], {"image_upload": true}]`` --
+    the combo lists the server's input directory, and the flag says the widget
+    accepts a file the client uploads. That flag is the typing rule for a
+    reference slot, exactly as a STRING/INT kind is the rule for the others.
+    """
+    if not isinstance(spec, (list, tuple)) or len(spec) < 2 or not isinstance(spec[0], list):
+        return False
+    return isinstance(spec[1], Mapping) and spec[1].get("image_upload") is True
+
+
 def validate_graph_structure(graph: Mapping[str, Any], slots: Mapping[str, Any], object_info: Mapping[str, Any]) -> None:
     if not graph:
         raise ImageGenerationError("The selected workflow is empty")
+    # A mapped reference's widget value is replaced per render with a file this
+    # server does not have yet, so its combo membership says nothing about whether
+    # the graph can run. Without this exemption Test connection rejects every edit
+    # workflow, naming the exporter's filename as "no longer available".
+    mapped = {(str(entry["slot"][0]), str(entry["slot"][1])) for entry in reference_slots(slots) if entry.get("slot")}
     for node_id, node in graph.items():
         if (
             not isinstance(node, Mapping)
@@ -162,14 +208,27 @@ def validate_graph_structure(graph: Mapping[str, Any], slots: Mapping[str, Any],
         for name, value in node["inputs"].items():
             spec = declared.get(name)
             if isinstance(spec, (list, tuple)) and spec and isinstance(spec[0], list) and not isinstance(value, list):
-                if value not in spec[0]:
-                    raise ImageGenerationError(f"Node {node_id} input {name!r} is no longer available on this server")
+                if (str(node_id), name) in mapped or value in spec[0]:
+                    continue
+                # An unmapped upload widget carries a filename from whatever machine
+                # exported the graph. "No longer available on this server" reads as a
+                # broken install; the actionable answer is that it is either missing
+                # there or belongs on a reference slot.
+                if is_image_upload(spec):
+                    raise ImageGenerationError(
+                        f"Node {node_id} needs image {value!r} on the ComfyUI server, or map it as a reference image"
+                    )
+                raise ImageGenerationError(f"Node {node_id} input {name!r} is no longer available on this server")
     for role in ("positive", "negative", "seed"):
         if role == "negative" and "negative" not in slots:
             continue
         _input_slot(graph, slots.get(role), role)
     if "checkpoint" in slots:
         _input_slot(graph, slots["checkpoint"], "checkpoint")
+    # A reference pointing at a node the graph no longer has would otherwise only
+    # surface mid-render, after the upload and a minute of queue time.
+    for entry in reference_slots(slots):
+        _input_slot(graph, entry.get("slot"), "reference image")
     output = slots.get("output")
     if not isinstance(output, (list, tuple)) or len(output) != 2 or str(output[0]) not in graph:
         raise ImageGenerationError("The workflow has no configured output node")

--- a/backend/workflows/image_gen/hooks.py
+++ b/backend/workflows/image_gen/hooks.py
@@ -164,8 +164,7 @@ def _metadata(
         "prompt": prompt,
         "negative_prompt": negative_prompt,
         # Which reference images went in, and where each came from. A reroll
-        # re-fetches strictly by these origins, so the picture keeps its subject
-        # and only the seed moves.
+        # re-fetches strictly by these origins, so only the seed moves.
         "references": info.get("references") or [],
         # Read back off the graph that executed, so replay can compare what an
         # image was actually rendered with rather than what its ids imply.
@@ -185,10 +184,10 @@ def _consumption(
         "negative_prompt": negative_prompt,
     }
     # The camera and the references ride both halves. generation_metadata is the
-    # replay record the UI never reads; a wrong POV or a wrong reference is exactly
-    # the failure a user needs traced, so both belong where they are looking at the
-    # bad image. *record* is whichever dict already carries them -- the fresh
-    # metadata on a generate, the stored parameters on a reroll.
+    # replay record the UI never reads; a wrong POV or reference is exactly the
+    # failure a user needs traced, so both belong where they are looking at the bad
+    # image. *record* is whichever dict already carries them -- the fresh metadata
+    # on a generate, the stored parameters on a reroll.
     for key in ("pov", "pov_source"):
         value = (record or {}).get(key)
         if value:
@@ -264,7 +263,7 @@ async def _generate_fresh(
     # with nothing to reference fails loudly -- rendering it without one would
     # produce a picture of whatever the graph's stale filename pointed at.
     references = await resolve_references(
-        {"references": graph_reference_slots(config, selected_style["workflow"])},
+        graph_reference_slots(config, selected_style["workflow"]),
         history=history,
         anchor_id=int(message["id"]),
         character_id=getattr(ctx, "character_id", None),
@@ -579,8 +578,7 @@ class _RegenCompositionCtx:
         self.agent_client = ctx.agent_client
         self.agent_model_name = ctx.agent_model_name
         self.character = ctx.character
-        # Carried for reference resolution: the `character` source reads the card's
-        # reference image (and its avatar) by id.
+        # Carried for reference resolution: `character` reads the card by id.
         self.character_id = ctx.character_id
 
 
@@ -608,19 +606,17 @@ async def reroll_gen(ctx, params, seed):
     if style_changed:
         params.pop("workflow_id", None)
         params.pop("backend_model", None)
-        # The recorded references name node ids in the OLD graph, so they cannot be
-        # replayed onto a different one. There is no history on this ctx to
-        # re-resolve from, so a new graph that needs references has to be refused
-        # here rather than submitted with its exporter's filenames still pinned.
+        # The recorded references name node ids in the OLD graph, and this ctx has
+        # no history to re-resolve from -- so a new graph that needs references is
+        # refused rather than submitted with its exporter's filenames still pinned.
         params.pop("references", None)
         if graph_reference_slots(config, style["workflow"]):
             raise ImageGenerationError(
                 f"{style['label']} uses reference images, which a reroll cannot carry over from another style. "
                 "Regenerate the image under this style instead."
             )
-    # Strictly by recorded origin -- a reroll promises that only the seed changes,
-    # so re-resolving from the branch (which may have moved on) is exactly what
-    # must not happen here.
+    # Strictly by recorded origin: a reroll promises only the seed changes, so
+    # re-resolving from a branch that may have moved on is what must not happen.
     references = await refetch_references(params.get("references"))
     resolved_seed = fold_seed(seed)
     result = await resolve_and_generate(

--- a/backend/workflows/image_gen/hooks.py
+++ b/backend/workflows/image_gen/hooks.py
@@ -31,11 +31,13 @@ from .engine import (
     ImageRequest,
     ProgressCallback,
     graph_has_negative,
+    graph_reference_slots,
     list_models,
     node_roles,
     resolve_and_generate,
     validate_connection,
 )
+from .references import refetch_references, resolve_references
 
 logger = logging.getLogger(__name__)
 SEED_MODULUS = 2**64
@@ -105,6 +107,8 @@ def _failed_stream(message: str) -> WorkflowEventStream:
 
 def _progress_label(stage: str, detail: Mapping[str, Any]) -> str | None:
     """Render an adapter progress event as a user-facing phase label."""
+    if stage == "uploading":
+        return "Uploading reference image..."
     if stage == "rendering":
         return "Rendering in ComfyUI..."
     if stage == "queued":
@@ -159,6 +163,10 @@ def _metadata(
         "pov_source": pov_source,
         "prompt": prompt,
         "negative_prompt": negative_prompt,
+        # Which reference images went in, and where each came from. A reroll
+        # re-fetches strictly by these origins, so the picture keeps its subject
+        # and only the seed moves.
+        "references": info.get("references") or [],
         # Read back off the graph that executed, so replay can compare what an
         # image was actually rendered with rather than what its ids imply.
         **{key: info.get(key) for key in ("width", "height", "steps", "cfg", "sampler", "scheduler")},
@@ -166,7 +174,7 @@ def _metadata(
 
 
 def _consumption(
-    style: Mapping[str, Any], prompt: str, negative_prompt: str, result=None, camera: Mapping[str, Any] | None = None
+    style: Mapping[str, Any], prompt: str, negative_prompt: str, result=None, record: Mapping[str, Any] | None = None
 ) -> dict:
     notes = list(getattr(result, "backend_info", {}).get("notes") or []) if result is not None else []
     payload = {
@@ -176,15 +184,20 @@ def _consumption(
         "prompt": prompt,
         "negative_prompt": negative_prompt,
     }
-    # The camera rides both halves. generation_metadata is the replay record the
-    # UI never reads; a wrong POV is the failure this feature exists to fix, so
-    # which camera ran and which lever chose it belong where the user is looking
-    # at the bad image. *camera* is whichever dict already carries them -- the
-    # fresh metadata on a generate, the stored parameters on a reroll.
+    # The camera and the references ride both halves. generation_metadata is the
+    # replay record the UI never reads; a wrong POV or a wrong reference is exactly
+    # the failure a user needs traced, so both belong where they are looking at the
+    # bad image. *record* is whichever dict already carries them -- the fresh
+    # metadata on a generate, the stored parameters on a reroll.
     for key in ("pov", "pov_source"):
-        value = (camera or {}).get(key)
+        value = (record or {}).get(key)
         if value:
             payload[key] = value
+    references = (record or {}).get("references")
+    if isinstance(references, (list, tuple)) and references:
+        payload["references"] = [
+            {key: entry.get(key) for key in ("slot", "source", "origin")} for entry in references if isinstance(entry, Mapping)
+        ]
     # Disclosure lives in the display-safe half: a replay that could not be
     # honoured exactly says so on the attachment the user is looking at.
     if notes:
@@ -246,6 +259,17 @@ async def _generate_fresh(
     )
     prompt, negative, style = assemble_prompts(config, style_id, profile, scene, avoid)
     seed = _fresh_seed()
+    # Resolved from the branch as it stands, here rather than in the engine: this
+    # is conversation state, and `engine/` stays ComfyUI-only. An edit workflow
+    # with nothing to reference fails loudly -- rendering it without one would
+    # produce a picture of whatever the graph's stale filename pointed at.
+    references = await resolve_references(
+        {"references": graph_reference_slots(config, selected_style["workflow"])},
+        history=history,
+        anchor_id=int(message["id"]),
+        character_id=getattr(ctx, "character_id", None),
+        profile=profile,
+    )
     result = await resolve_and_generate(
         config,
         ImageRequest(
@@ -254,6 +278,7 @@ async def _generate_fresh(
             seed=seed,
             style_id=style_id,
             timeout_seconds=config["timeout_seconds"],
+            references=references,
         ),
         progress=progress,
     )
@@ -267,7 +292,7 @@ async def _generate_fresh(
         pov=pov,
         pov_source=pov_source,
     )
-    return _attachment(seed, result, md, _consumption(style, prompt, negative, result, camera=md))
+    return _attachment(seed, result, md, _consumption(style, prompt, negative, result, record=md))
 
 
 async def on_demand(ctx, body):
@@ -554,6 +579,9 @@ class _RegenCompositionCtx:
         self.agent_client = ctx.agent_client
         self.agent_model_name = ctx.agent_model_name
         self.character = ctx.character
+        # Carried for reference resolution: the `character` source reads the card's
+        # reference image (and its avatar) by id.
+        self.character_id = ctx.character_id
 
 
 async def reroll_gen(ctx, params, seed):
@@ -580,6 +608,20 @@ async def reroll_gen(ctx, params, seed):
     if style_changed:
         params.pop("workflow_id", None)
         params.pop("backend_model", None)
+        # The recorded references name node ids in the OLD graph, so they cannot be
+        # replayed onto a different one. There is no history on this ctx to
+        # re-resolve from, so a new graph that needs references has to be refused
+        # here rather than submitted with its exporter's filenames still pinned.
+        params.pop("references", None)
+        if graph_reference_slots(config, style["workflow"]):
+            raise ImageGenerationError(
+                f"{style['label']} uses reference images, which a reroll cannot carry over from another style. "
+                "Regenerate the image under this style instead."
+            )
+    # Strictly by recorded origin -- a reroll promises that only the seed changes,
+    # so re-resolving from the branch (which may have moved on) is exactly what
+    # must not happen here.
+    references = await refetch_references(params.get("references"))
     resolved_seed = fold_seed(seed)
     result = await resolve_and_generate(
         config,
@@ -589,6 +631,7 @@ async def reroll_gen(ctx, params, seed):
             seed=resolved_seed,
             style_id=style_id,
             timeout_seconds=config["timeout_seconds"],
+            references=references,
         ),
         # Reroll and rehydrate reproduce a stored image's parameters. Routing
         # them through the style would re-render an old attachment on whatever
@@ -598,7 +641,7 @@ async def reroll_gen(ctx, params, seed):
     )
     # A reroll re-renders the stored prompt under a new seed, so the camera cannot
     # have changed: carry the one `params` already records rather than re-resolving.
-    consumption = _consumption(style, prompt, negative, result, camera=params)
+    consumption = _consumption(style, prompt, negative, result, record=params)
     if style_changed:
         # Only the assembled prompt is stored, never the scene/avoid halves it was built
         # from, so a style swap cannot re-word it -- say so rather than substitute silently.

--- a/backend/workflows/image_gen/references.py
+++ b/backend/workflows/image_gen/references.py
@@ -1,0 +1,287 @@
+"""Resolve a workflow's mapped `LoadImage` slots to actual reference bytes.
+
+Sits at the `image_gen` top level rather than under `engine/`: this reads
+conversation state through the workflow toolkit, while `engine/` stays
+ComfyUI-only. The engine consumes the resolved bytes -- uploading and patching
+are its half of the split.
+
+Two entry points, because the two replay routes have genuinely different
+promises. `resolve_references` picks the reference a *fresh* render should use
+from the branch as it stands. `refetch_references` re-fetches strictly by the
+origin a stored render recorded, so a reroll changes only the seed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ..toolkit import (
+    EVICTED_MARKER,
+    get_character_avatar,
+    get_user_attachments_for_message,
+    get_workflow_attachment_by_id,
+    get_workflow_character_state,
+)
+from .config import REFERENCE_SOURCES, WORKFLOW_ID, normalize_profile
+from .engine import ImageGenerationError
+from .engine.contracts import ResolvedReference
+from .engine.display_encode import normalize_reference
+from .engine.graph import reference_slots
+
+# How each source reads in an error message and in Render details. The names are
+# the ones the import picker uses, not the internal keys.
+SOURCE_LABELS = {
+    "previous": "the previous image in the chat",
+    "character": "the character reference image",
+}
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _bytes_from_row(row: Mapping[str, Any]) -> tuple[bytes, str] | None:
+    """Decoded image bytes off an attachment row, or None when unusable.
+
+    An evicted row holds the sentinel rather than base64, and a row whose bytes
+    do not decode is not a reference -- both fall through to the next candidate
+    rather than raising, so one bad row cannot block a walk-back that has other
+    images to offer.
+    """
+    payload = row.get("data_b64")
+    mime = row.get("mime_type")
+    if not isinstance(payload, str) or not payload or payload == EVICTED_MARKER:
+        return None
+    if not isinstance(mime, str) or not mime.startswith("image/"):
+        return None
+    try:
+        data = base64.b64decode(payload, validate=True)
+    except (ValueError, TypeError):
+        return None
+    return (data, mime) if data else None
+
+
+def _active_generated_image(message: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """The image_gen attachment this message is actually *showing*.
+
+    Reroll siblings share a group root; the root's `active_sibling_id` names the
+    one on screen (NULL means the newest). Same rule the chat renderer uses, so a
+    reference is the image the user is looking at rather than the first variant
+    that happened to be generated.
+    """
+    attachments = message.get("workflow_attachments")
+    if not isinstance(attachments, (list, tuple)):
+        return None
+    ours = [a for a in attachments if isinstance(a, Mapping) and a.get("workflow_id") == WORKFLOW_ID]
+    if not ours:
+        return None
+    by_id = {a.get("id"): a for a in ours}
+    groups: dict[Any, list[Mapping[str, Any]]] = {}
+    for attachment in ours:
+        parent = attachment.get("parent_attachment_id")
+        root_id = parent if parent is not None and parent in by_id else attachment.get("id")
+        groups.setdefault(root_id, []).append(attachment)
+    # Latest group first: the most recent image on the message is the one "the
+    # previous image" means.
+    root_id = max(groups, key=lambda key: (key is not None, key))
+    siblings = sorted(groups[root_id], key=lambda a: a.get("id") or 0)
+    active_id = (by_id.get(root_id) or {}).get("active_sibling_id")
+    if active_id is not None:
+        for sibling in siblings:
+            if sibling.get("id") == active_id:
+                return sibling
+    return siblings[-1]
+
+
+def _uploaded_image(message: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    attachments = message.get("user_attachments")
+    for attachment in reversed(attachments if isinstance(attachments, (list, tuple)) else []):
+        if isinstance(attachment, Mapping) and str(attachment.get("mime_type") or "").startswith("image/"):
+            return attachment
+    return None
+
+
+def _previous_image(history: Sequence[Mapping[str, Any]], anchor_id: int) -> tuple[bytes, str, str] | None:
+    """The newest usable image on this branch before the anchor.
+
+    The anchor itself is excluded: a regenerate would otherwise feed the image
+    already attached to the message back in as its own reference, so every reroll
+    would edit the previous render instead of the scene. `history` is already
+    sliced through the anchor by the caller, so "before" is just "earlier in this
+    list".
+
+    A user's own upload counts as a previous image -- "edit this photo of me" is
+    the same request as "edit that render", and refusing it would send the walk
+    past the very image the user just attached. The `upload:` origin carries the
+    message id too, since user attachments are only readable per-message.
+    """
+    for message in reversed(list(history)):
+        if message.get("id") == anchor_id:
+            continue
+        generated = _active_generated_image(message)
+        if generated is not None:
+            resolved = _bytes_from_row(generated)
+            if resolved is not None:
+                return resolved[0], resolved[1], f"attachment:{generated.get('id')}"
+        uploaded = _uploaded_image(message)
+        if uploaded is not None:
+            resolved = _bytes_from_row(uploaded)
+            if resolved is not None:
+                return resolved[0], resolved[1], f"upload:{message.get('id')}:{uploaded.get('id')}"
+    return None
+
+
+async def _character_image(character_id: str | None, profile: Mapping[str, Any]) -> tuple[bytes, str, str] | None:
+    """The per-character reference, falling back to the card avatar.
+
+    The avatar is a genuine likeness of the character and is always present on an
+    imported card, so it makes the character source useful before the user has
+    uploaded anything dedicated.
+    """
+    if not character_id:
+        return None
+    payload = profile.get("reference_image_b64")
+    mime = profile.get("reference_mime")
+    if isinstance(payload, str) and payload and isinstance(mime, str) and mime:
+        try:
+            data = base64.b64decode(payload, validate=True)
+        except (ValueError, TypeError):
+            data = b""
+        if data:
+            return data, mime, f"character:{character_id}"
+    avatar = await get_character_avatar(character_id)
+    if avatar and avatar[0]:
+        return avatar[0], avatar[1] or "image/png", f"character:{character_id}"
+    return None
+
+
+def _sources(source: str) -> tuple[str, ...]:
+    return REFERENCE_SOURCES.get(source, ())
+
+
+def _unresolved(label: str, source: str) -> ImageGenerationError:
+    tried = " or ".join(SOURCE_LABELS[name] for name in _sources(source)) or "any configured source"
+    return ImageGenerationError(
+        f"This workflow needs a reference image for {label}, but {tried} is not available. "
+        "Generate or upload an image in this chat first, or set a character reference image in settings."
+    )
+
+
+async def resolve_references(
+    slots: Mapping[str, Any],
+    *,
+    history: Sequence[Mapping[str, Any]],
+    anchor_id: int,
+    character_id: str | None,
+    profile: Mapping[str, Any] | None = None,
+) -> tuple[ResolvedReference, ...]:
+    """Bytes for every mapped `LoadImage` slot, for a fresh render.
+
+    An unresolvable slot is a hard failure with a specific message rather than a
+    silent substitution: a graph built around a reference produces nonsense
+    without one, and "clear failure over silent substitution" is the stance the
+    rest of this workflow already takes.
+    """
+    entries = reference_slots(slots)
+    if not entries:
+        return ()
+    normalized_profile = normalize_profile(profile)
+    # Each source is resolved at most once per render even when several slots
+    # share it, so a two-slot graph reads the branch once.
+    found_by_source: dict[str, tuple[bytes, str, str] | None] = {}
+    resolved: list[ResolvedReference] = []
+    for entry in entries:
+        slot = entry.get("slot")
+        source = str(entry.get("source") or "")
+        label = str(entry.get("label") or (slot[0] if slot else "this workflow"))
+        found: tuple[bytes, str, str] | None = None
+        for name in _sources(source):
+            if name not in found_by_source:
+                found_by_source[name] = (
+                    _previous_image(history, anchor_id)
+                    if name == "previous"
+                    else await _character_image(character_id, normalized_profile)
+                )
+            found = found_by_source[name]
+            if found is not None:
+                break
+        if found is None:
+            raise _unresolved(label, source)
+        data, mime, origin = found
+        resolved.append(await _resolved(slot, source, data, mime, origin))
+    return tuple(resolved)
+
+
+async def _resolved(slot: Any, source: str, data: bytes, mime: str, origin: str) -> ResolvedReference:
+    # Bounding is PIL work, so it goes off-thread like the display re-encode does.
+    data, mime = await asyncio.to_thread(normalize_reference, data, mime)
+    return ResolvedReference(
+        slot=(str(slot[0]), str(slot[1])),
+        source=source,
+        data=data,
+        mime=mime,
+        origin=origin,
+        digest=_digest(data),
+    )
+
+
+async def _origin_bytes(origin: str) -> tuple[bytes, str] | None:
+    kind, _, ident = origin.partition(":")
+    if kind == "attachment" and ident.isdigit():
+        row = await get_workflow_attachment_by_id(int(ident))
+        return _bytes_from_row(row) if row else None
+    if kind == "upload":
+        # "upload:<message id>:<attachment id>" -- user attachments are only
+        # readable per-message, so the origin has to carry both.
+        message_id, _, attachment_id = ident.partition(":")
+        if message_id.isdigit() and attachment_id.isdigit():
+            for row in await get_user_attachments_for_message(int(message_id)):
+                if row.get("id") == int(attachment_id):
+                    return _bytes_from_row(row)
+        return None
+    if kind == "character" and ident:
+        # The card's profile, not a snapshot: the origin addresses a setting, and
+        # re-reading it is what makes "change the character reference, then reroll"
+        # do what it says.
+        profile = normalize_profile(await get_workflow_character_state(ident, WORKFLOW_ID))
+        current = await _character_image(ident, profile)
+        return (current[0], current[1]) if current else None
+    return None
+
+
+async def refetch_references(recorded: Any) -> tuple[ResolvedReference, ...]:
+    """Re-fetch a stored render's references strictly by recorded origin.
+
+    Reroll promises that only the seed changes, so this never re-resolves: a
+    deleted or byte-evicted origin fails loudly instead of substituting a
+    different image that would silently change the subject of the picture. The
+    origin carries everything needed, which is what lets this run on the reroll
+    ctx -- deliberately history-free.
+
+    A `character:` origin re-reads that card's *current* reference image rather
+    than a snapshot, because it addresses a setting rather than a chat message:
+    changing the character reference and rerolling is a coherent request, where
+    "reroll onto whatever image the branch has now" is not.
+    """
+    if not isinstance(recorded, (list, tuple)) or not recorded:
+        return ()
+    resolved: list[ResolvedReference] = []
+    for entry in recorded:
+        if not isinstance(entry, Mapping):
+            continue
+        slot = entry.get("slot")
+        origin = str(entry.get("origin") or "")
+        if not isinstance(slot, (list, tuple)) or len(slot) != 2 or not origin:
+            raise ImageGenerationError("This image's reference is no longer recorded; regenerate it instead of rerolling")
+        found = await _origin_bytes(origin)
+        if found is None:
+            raise ImageGenerationError(
+                "The reference image this render used is gone, so it cannot be reproduced exactly. "
+                "Regenerate the image instead of rerolling it."
+            )
+        resolved.append(await _resolved(slot, str(entry.get("source") or ""), found[0], found[1], origin))
+    return tuple(resolved)

--- a/backend/workflows/image_gen/references.py
+++ b/backend/workflows/image_gen/references.py
@@ -2,13 +2,12 @@
 
 Sits at the `image_gen` top level rather than under `engine/`: this reads
 conversation state through the workflow toolkit, while `engine/` stays
-ComfyUI-only. The engine consumes the resolved bytes -- uploading and patching
-are its half of the split.
+ComfyUI-only. Uploading and patching are the engine's half of the split.
 
-Two entry points, because the two replay routes have genuinely different
-promises. `resolve_references` picks the reference a *fresh* render should use
-from the branch as it stands. `refetch_references` re-fetches strictly by the
-origin a stored render recorded, so a reroll changes only the seed.
+Two entry points, because the two render routes make different promises.
+`resolve_references` picks what a *fresh* render should use from the branch as it
+stands; `refetch_references` re-fetches strictly by recorded origin, so a reroll
+changes only the seed.
 """
 
 from __future__ import annotations
@@ -30,30 +29,23 @@ from .config import REFERENCE_SOURCES, WORKFLOW_ID, normalize_profile
 from .engine import ImageGenerationError
 from .engine.contracts import ResolvedReference
 from .engine.display_encode import normalize_reference
-from .engine.graph import reference_slots
 
-# How each source reads in an error message and in Render details. The names are
-# the ones the import picker uses, not the internal keys.
+# How each source reads in an error message. The names the import picker uses.
 SOURCE_LABELS = {
     "previous": "the previous image in the chat",
     "character": "the character reference image",
 }
 
 
-def _digest(data: bytes) -> str:
-    return hashlib.sha256(data).hexdigest()
-
-
-def _bytes_from_row(row: Mapping[str, Any]) -> tuple[bytes, str] | None:
+def _bytes_from_row(row: Mapping[str, Any] | None) -> tuple[bytes, str] | None:
     """Decoded image bytes off an attachment row, or None when unusable.
 
-    An evicted row holds the sentinel rather than base64, and a row whose bytes
-    do not decode is not a reference -- both fall through to the next candidate
-    rather than raising, so one bad row cannot block a walk-back that has other
-    images to offer.
+    An evicted row holds the sentinel rather than base64; both that and a row
+    that does not decode fall through to the next candidate rather than raising,
+    so one bad row cannot block a walk-back with images left to try.
     """
-    payload = row.get("data_b64")
-    mime = row.get("mime_type")
+    payload = (row or {}).get("data_b64")
+    mime = (row or {}).get("mime_type")
     if not isinstance(payload, str) or not payload or payload == EVICTED_MARKER:
         return None
     if not isinstance(mime, str) or not mime.startswith("image/"):
@@ -65,87 +57,66 @@ def _bytes_from_row(row: Mapping[str, Any]) -> tuple[bytes, str] | None:
     return (data, mime) if data else None
 
 
+def _rows(message: Mapping[str, Any], key: str) -> list[Mapping[str, Any]]:
+    rows = message.get(key)
+    return [row for row in (rows if isinstance(rows, (list, tuple)) else []) if isinstance(row, Mapping)]
+
+
 def _active_generated_image(message: Mapping[str, Any]) -> Mapping[str, Any] | None:
     """The image_gen attachment this message is actually *showing*.
 
-    Reroll siblings share a group root; the root's `active_sibling_id` names the
-    one on screen (NULL means the newest). Same rule the chat renderer uses, so a
-    reference is the image the user is looking at rather than the first variant
-    that happened to be generated.
+    Reroll siblings share a group root whose `active_sibling_id` names the one on
+    screen (NULL means the newest), and the latest group wins. Same rule the chat
+    renderer uses, so a reference is the image the user is looking at.
     """
-    attachments = message.get("workflow_attachments")
-    if not isinstance(attachments, (list, tuple)):
-        return None
-    ours = [a for a in attachments if isinstance(a, Mapping) and a.get("workflow_id") == WORKFLOW_ID]
+    ours = [a for a in _rows(message, "workflow_attachments") if a.get("workflow_id") == WORKFLOW_ID]
     if not ours:
         return None
     by_id = {a.get("id"): a for a in ours}
-    groups: dict[Any, list[Mapping[str, Any]]] = {}
-    for attachment in ours:
+
+    def root(attachment: Mapping[str, Any]) -> Any:
         parent = attachment.get("parent_attachment_id")
-        root_id = parent if parent is not None and parent in by_id else attachment.get("id")
-        groups.setdefault(root_id, []).append(attachment)
-    # Latest group first: the most recent image on the message is the one "the
-    # previous image" means.
-    root_id = max(groups, key=lambda key: (key is not None, key))
-    siblings = sorted(groups[root_id], key=lambda a: a.get("id") or 0)
-    active_id = (by_id.get(root_id) or {}).get("active_sibling_id")
-    if active_id is not None:
-        for sibling in siblings:
-            if sibling.get("id") == active_id:
-                return sibling
-    return siblings[-1]
+        return parent if parent is not None and parent in by_id else attachment.get("id")
+
+    newest = max((root(a) for a in ours), key=lambda key: (key is not None, key))
+    siblings = sorted((a for a in ours if root(a) == newest), key=lambda a: a.get("id") or 0)
+    active_id = (by_id.get(newest) or {}).get("active_sibling_id")
+    return next((s for s in siblings if s.get("id") == active_id), siblings[-1])
 
 
 def _uploaded_image(message: Mapping[str, Any]) -> Mapping[str, Any] | None:
-    attachments = message.get("user_attachments")
-    for attachment in reversed(attachments if isinstance(attachments, (list, tuple)) else []):
-        if isinstance(attachment, Mapping) and str(attachment.get("mime_type") or "").startswith("image/"):
-            return attachment
-    return None
+    uploads = [a for a in _rows(message, "user_attachments") if str(a.get("mime_type") or "").startswith("image/")]
+    return uploads[-1] if uploads else None
 
 
 def _previous_image(history: Sequence[Mapping[str, Any]], anchor_id: int) -> tuple[bytes, str, str] | None:
     """The newest usable image on this branch before the anchor.
 
-    The anchor itself is excluded: a regenerate would otherwise feed the image
-    already attached to the message back in as its own reference, so every reroll
-    would edit the previous render instead of the scene. `history` is already
-    sliced through the anchor by the caller, so "before" is just "earlier in this
-    list".
-
-    A user's own upload counts as a previous image -- "edit this photo of me" is
-    the same request as "edit that render", and refusing it would send the walk
-    past the very image the user just attached. The `upload:` origin carries the
-    message id too, since user attachments are only readable per-message.
+    The anchor is excluded: a regenerate would otherwise feed the image already
+    attached to the message back in as its own reference, editing the previous
+    render instead of the scene. A user's own upload counts -- "edit this photo
+    of me" is the same request -- and its origin carries the message id too,
+    since user attachments are only readable per-message.
     """
     for message in reversed(list(history)):
         if message.get("id") == anchor_id:
             continue
-        generated = _active_generated_image(message)
-        if generated is not None:
-            resolved = _bytes_from_row(generated)
+        for row, prefix in (
+            (_active_generated_image(message), "attachment"),
+            (_uploaded_image(message), f"upload:{message.get('id')}"),
+        ):
+            resolved = _bytes_from_row(row)
             if resolved is not None:
-                return resolved[0], resolved[1], f"attachment:{generated.get('id')}"
-        uploaded = _uploaded_image(message)
-        if uploaded is not None:
-            resolved = _bytes_from_row(uploaded)
-            if resolved is not None:
-                return resolved[0], resolved[1], f"upload:{message.get('id')}:{uploaded.get('id')}"
+                return resolved[0], resolved[1], f"{prefix}:{(row or {}).get('id')}"
     return None
 
 
 async def _character_image(character_id: str | None, profile: Mapping[str, Any]) -> tuple[bytes, str, str] | None:
-    """The per-character reference, falling back to the card avatar.
-
-    The avatar is a genuine likeness of the character and is always present on an
-    imported card, so it makes the character source useful before the user has
-    uploaded anything dedicated.
-    """
+    """The per-character reference, falling back to the card avatar -- a genuine
+    likeness, always present, so this source works before anything is uploaded."""
     if not character_id:
         return None
-    payload = profile.get("reference_image_b64")
-    mime = profile.get("reference_mime")
+    payload, mime = profile.get("reference_image_b64"), profile.get("reference_mime")
     if isinstance(payload, str) and payload and isinstance(mime, str) and mime:
         try:
             data = base64.b64decode(payload, validate=True)
@@ -159,12 +130,21 @@ async def _character_image(character_id: str | None, profile: Mapping[str, Any])
     return None
 
 
-def _sources(source: str) -> tuple[str, ...]:
-    return REFERENCE_SOURCES.get(source, ())
+async def _resolved(slot: Any, source: str, data: bytes, mime: str, origin: str) -> ResolvedReference:
+    # Bounding is PIL work, so it goes off-thread like the display re-encode does.
+    data, mime = await asyncio.to_thread(normalize_reference, data, mime)
+    return ResolvedReference(
+        slot=(str(slot[0]), str(slot[1])),
+        source=source,
+        data=data,
+        mime=mime,
+        origin=origin,
+        digest=hashlib.sha256(data).hexdigest(),
+    )
 
 
 def _unresolved(label: str, source: str) -> ImageGenerationError:
-    tried = " or ".join(SOURCE_LABELS[name] for name in _sources(source)) or "any configured source"
+    tried = " or ".join(SOURCE_LABELS[name] for name in REFERENCE_SOURCES.get(source, ())) or "any configured source"
     return ImageGenerationError(
         f"This workflow needs a reference image for {label}, but {tried} is not available. "
         "Generate or upload an image in this chat first, or set a character reference image in settings."
@@ -172,7 +152,7 @@ def _unresolved(label: str, source: str) -> ImageGenerationError:
 
 
 async def resolve_references(
-    slots: Mapping[str, Any],
+    entries: Sequence[Mapping[str, Any]],
     *,
     history: Sequence[Mapping[str, Any]],
     anchor_id: int,
@@ -183,57 +163,39 @@ async def resolve_references(
 
     An unresolvable slot is a hard failure with a specific message rather than a
     silent substitution: a graph built around a reference produces nonsense
-    without one, and "clear failure over silent substitution" is the stance the
-    rest of this workflow already takes.
+    without one.
     """
-    entries = reference_slots(slots)
     if not entries:
         return ()
     normalized_profile = normalize_profile(profile)
     # Each source is resolved at most once per render even when several slots
     # share it, so a two-slot graph reads the branch once.
-    found_by_source: dict[str, tuple[bytes, str, str] | None] = {}
+    cache: dict[str, tuple[bytes, str, str] | None] = {}
     resolved: list[ResolvedReference] = []
     for entry in entries:
         slot = entry.get("slot")
         source = str(entry.get("source") or "")
-        label = str(entry.get("label") or (slot[0] if slot else "this workflow"))
         found: tuple[bytes, str, str] | None = None
-        for name in _sources(source):
-            if name not in found_by_source:
-                found_by_source[name] = (
+        for name in REFERENCE_SOURCES.get(source, ()):
+            if name not in cache:
+                cache[name] = (
                     _previous_image(history, anchor_id)
                     if name == "previous"
                     else await _character_image(character_id, normalized_profile)
                 )
-            found = found_by_source[name]
+            found = cache[name]
             if found is not None:
                 break
         if found is None:
-            raise _unresolved(label, source)
-        data, mime, origin = found
-        resolved.append(await _resolved(slot, source, data, mime, origin))
+            raise _unresolved(str(entry.get("label") or (slot[0] if slot else "this workflow")), source)
+        resolved.append(await _resolved(slot, source, *found))
     return tuple(resolved)
-
-
-async def _resolved(slot: Any, source: str, data: bytes, mime: str, origin: str) -> ResolvedReference:
-    # Bounding is PIL work, so it goes off-thread like the display re-encode does.
-    data, mime = await asyncio.to_thread(normalize_reference, data, mime)
-    return ResolvedReference(
-        slot=(str(slot[0]), str(slot[1])),
-        source=source,
-        data=data,
-        mime=mime,
-        origin=origin,
-        digest=_digest(data),
-    )
 
 
 async def _origin_bytes(origin: str) -> tuple[bytes, str] | None:
     kind, _, ident = origin.partition(":")
     if kind == "attachment" and ident.isdigit():
-        row = await get_workflow_attachment_by_id(int(ident))
-        return _bytes_from_row(row) if row else None
+        return _bytes_from_row(await get_workflow_attachment_by_id(int(ident)))
     if kind == "upload":
         # "upload:<message id>:<attachment id>" -- user attachments are only
         # readable per-message, so the origin has to carry both.
@@ -244,11 +206,9 @@ async def _origin_bytes(origin: str) -> tuple[bytes, str] | None:
                     return _bytes_from_row(row)
         return None
     if kind == "character" and ident:
-        # The card's profile, not a snapshot: the origin addresses a setting, and
-        # re-reading it is what makes "change the character reference, then reroll"
-        # do what it says.
-        profile = normalize_profile(await get_workflow_character_state(ident, WORKFLOW_ID))
-        current = await _character_image(ident, profile)
+        # The card's *current* image, not a snapshot: this origin addresses a
+        # setting rather than a chat message, so changing it and rerolling applies.
+        current = await _character_image(ident, normalize_profile(await get_workflow_character_state(ident, WORKFLOW_ID)))
         return (current[0], current[1]) if current else None
     return None
 
@@ -257,15 +217,9 @@ async def refetch_references(recorded: Any) -> tuple[ResolvedReference, ...]:
     """Re-fetch a stored render's references strictly by recorded origin.
 
     Reroll promises that only the seed changes, so this never re-resolves: a
-    deleted or byte-evicted origin fails loudly instead of substituting a
-    different image that would silently change the subject of the picture. The
-    origin carries everything needed, which is what lets this run on the reroll
-    ctx -- deliberately history-free.
-
-    A `character:` origin re-reads that card's *current* reference image rather
-    than a snapshot, because it addresses a setting rather than a chat message:
-    changing the character reference and rerolling is a coherent request, where
-    "reroll onto whatever image the branch has now" is not.
+    deleted or byte-evicted origin fails loudly instead of silently changing the
+    subject. The origin carries everything needed, which is what lets this run on
+    the history-free reroll ctx.
     """
     if not isinstance(recorded, (list, tuple)) or not recorded:
         return ()

--- a/backend/workflows/toolkit.py
+++ b/backend/workflows/toolkit.py
@@ -4,7 +4,9 @@ Workflows import from this module rather than reaching directly into
 ``backend.inference.client``, ``backend.inference.prompt_builder``, etc. The set of
 re-exports is the workflow author's API: LLM client, tool-schema
 assembly, prompt assembly, macro resolution, read-only DB helpers for
-core state, workflow-scoped storage wrappers, the locks guarding
+core state (including the character avatar and the single-attachment
+reader, for workflows that consume prior artifacts as input),
+workflow-scoped storage wrappers, the locks guarding
 read-modify-write on that storage, the forced-call helper,
 the tool-overlay helper, the ``local_ml`` scaffold (for workflows that
 run a small in-process classifier alongside their LLM calls), and the
@@ -38,6 +40,7 @@ from ..core import (
 from ..core.domain_types import AgentLane
 from ..database import (
     get_active_lorebook_entries,
+    get_character_avatar,
     get_character_card,
     get_conversation,
     get_director_state,
@@ -47,8 +50,10 @@ from ..database import (
     get_mood_fragments,
     get_phrase_bank,
     get_settings,
+    get_user_attachments_for_message,
     get_user_persona,
     get_user_personas,
+    get_workflow_attachment_by_id,
     resolve_char_context,
 )
 from ..inference import (
@@ -65,7 +70,7 @@ from ..inference import (
     separate_agent_lane_configured,
 )
 from ._forced_call import forced_tool_call
-from .attachment_cache import insert_workflow_attachment
+from .attachment_cache import EVICTED_MARKER, insert_workflow_attachment
 from .registry import (
     get_workflow_character_state,
     get_workflow_config,
@@ -79,6 +84,7 @@ from .registry import (
 )
 
 __all__ = [
+    "EVICTED_MARKER",
     "FormatDriftReport",
     "LLMClient",
     "Macros",
@@ -89,6 +95,7 @@ __all__ = [
     "forced_tool_call",
     "format_message_with_attachments",
     "format_report",
+    "get_character_avatar",
     "get_character_card",
     "get_conversation",
     "get_interactive_fragments",
@@ -98,8 +105,10 @@ __all__ = [
     "get_mood_fragments",
     "get_phrase_bank",
     "get_settings",
+    "get_user_attachments_for_message",
     "get_user_personas",
     "get_user_persona",
+    "get_workflow_attachment_by_id",
     "get_workflow_character_state",
     "get_workflow_config",
     "get_workflow_message_state",

--- a/docs/features/image-generation.md
+++ b/docs/features/image-generation.md
@@ -142,7 +142,7 @@ substitute a different image.
 1. Open a conversation with the character.
 2. Open **Image Generation** settings.
 3. Find **This Character Only**.
-4. Under **Reference image**, select an image file. The limit is 3 MB.
+4. Under **Reference image**, select an image file. The limit is 10 MB.
 5. Select **Save**.
 
 When you set no reference image, Orb sends the character card's avatar.

--- a/docs/features/image-generation.md
+++ b/docs/features/image-generation.md
@@ -92,15 +92,79 @@ To import the workflow, do these steps:
 3. Select the API-format JSON file or the ComfyUI PNG file.
 4. Enter a name for the workflow.
 5. Check the selected prompt, seed, image output, and model slots.
-6. Select **Confirm slots and add workflow**.
-7. In a style, select the imported workflow.
-8. If your workflow is complex, review the nodes - make sure Orb points to the right node numbers.
-9. Select a checkpoint if Orb must replace the model in the workflow.
-10. Select **Test connection** to validate everything works.
-11. Select **Save**.
+6. If the workflow loads images, set each row under **Reference images**. See
+   [Reference images](#reference-images) below. Leave a row as **Not used** to
+   keep the file the workflow was exported with.
+7. Select **Confirm slots and add workflow**.
+8. In a style, select the imported workflow.
+9. If your workflow is complex, review the nodes - make sure Orb points to the right node numbers.
+10. Select a checkpoint if Orb must replace the model in the workflow.
+11. Select **Test connection** to validate everything works.
+12. Select **Save**.
 
 If a PNG does not contain workflow metadata, export an API-format JSON file
 from ComfyUI instead.
+
+## Reference images
+
+Edit workflows - Qwen-Image-Edit, Flux Kontext, Krea Identity Edit, IPAdapter -
+take one or more input images through **Load Image** nodes. Orb can fill those
+nodes for you. Each render uploads the image to ComfyUI and points the node at
+the uploaded file.
+
+Orb fills only the **Load Image** nodes that the workflow already contains. Orb
+never adds nodes. To use two reference images, export the workflow with two
+**Load Image** nodes.
+
+Each reference row offers these sources:
+
+| Source | What Orb sends |
+|--------|----------------|
+| **Previous image, else character reference** | The most recent image in the chat. If the chat has none, the character reference image. |
+| **Previous image in the chat** | The most recent image in the chat. |
+| **Character reference image** | The character reference image. |
+
+The previous image is the most recent generated image or uploaded image before
+the reply you are visualizing. If a reply has image variants, Orb sends the
+variant that is currently shown. Orb never sends the image already attached to
+the reply you are visualizing.
+
+When no source resolves, the render fails and names the slot. Orb does not
+substitute a different image.
+
+!!! note
+    These workflows take the output size from the reference image or from a
+    resolution node. **Render details** shows no width or height for them, and
+    the output aspect ratio follows the reference image.
+
+### Set the character reference image
+
+1. Open a conversation with the character.
+2. Open **Image Generation** settings.
+3. Find **Per-character Prompt**.
+4. Under **Reference image**, select an image file. The limit is 3 MB.
+5. Select **Save**.
+
+When you set no reference image, Orb sends the character card's avatar.
+
+### Reference images and reroll
+
+Reroll changes the seed only. Orb records where each reference came from and
+fetches the same image again, so the picture keeps its subject.
+
+- If the source image was deleted, or its bytes were evicted, the reroll fails.
+  Use **Regenerate** instead.
+- A character reference is read again from the character profile. Change the
+  reference image and reroll to apply it.
+- You cannot reroll onto a different style whose workflow uses reference
+  images. Use **Regenerate**.
+
+!!! warning
+    A ComfyUI server that is not on this machine receives your conversation
+    images and your character reference image, not only your prompts. Orb asks
+    you to confirm this the first time you save a remote server with a workflow
+    that uses reference images. Uploaded files stay in that server's
+    `input/orb/` directory - ComfyUI has no delete API for them.
 
 ## Make an image
 
@@ -178,6 +242,9 @@ character count from the scene.
 
 Negative tags apply only to this character profile. Style and scene negative
 tags are separate.
+
+This section also holds the character's reference image. See
+[Set the character reference image](#set-the-character-reference-image).
 
 ## Change a style
 
@@ -290,6 +357,9 @@ guaranteed.
 | Orb cannot find a checkpoint. | Add the checkpoint to ComfyUI. Restart or refresh ComfyUI. Test the connection again. |
 | ComfyUI rejects the workflow. | Check that the server has all required nodes. Check the selected checkpoint and imported slots. |
 | The render times out. | Check the ComfyUI queue. Increase **Render timeout**. The allowed range is 10 to 900 seconds. |
+| A render says it needs a reference image. | Generate or upload an image in the chat first. Or set a character reference image, and set the slot to a source that includes it. |
+| A reroll says the reference image is gone. | The source image was deleted or its bytes were evicted. Select **Regenerate**. |
+| The connection test says a node needs an image on the server. | Map that node under **Reference images**, or put the file in ComfyUI's `input` directory. |
 | ComfyUI completes without an image. | Select a valid image-output node in the imported workflow. |
 | Orb cannot write an image prompt. | Check the Orb LLM endpoint. Use a model that can make tool calls. |
 | An old image shows **Bytes evicted**. | Select **Rehydrate**. Orb uses the stored prompt, settings, and seed to make the image again. |

--- a/docs/features/image-generation.md
+++ b/docs/features/image-generation.md
@@ -108,13 +108,11 @@ from ComfyUI instead.
 ## Reference images
 
 Edit workflows - Qwen-Image-Edit, Flux Kontext, Krea Identity Edit, IPAdapter -
-take one or more input images through **Load Image** nodes. Orb can fill those
-nodes for you. Each render uploads the image to ComfyUI and points the node at
-the uploaded file.
-
-Orb fills only the **Load Image** nodes that the workflow already contains. Orb
-never adds nodes. To use two reference images, export the workflow with two
-**Load Image** nodes.
+take one or more input images through **Load Image** nodes. Orb fills those
+nodes for you: each render uploads the image to ComfyUI and points the node at
+the uploaded file. Orb fills only the **Load Image** nodes the workflow already
+contains and never adds nodes, so a workflow that takes two reference images
+must be exported with two **Load Image** nodes.
 
 Each reference row offers these sources:
 
@@ -127,10 +125,8 @@ Each reference row offers these sources:
 The previous image is the most recent generated image or uploaded image before
 the reply you are visualizing. If a reply has image variants, Orb sends the
 variant that is currently shown. Orb never sends the image already attached to
-the reply you are visualizing.
-
-When no source resolves, the render fails and names the slot. Orb does not
-substitute a different image.
+the reply you are visualizing. When no source resolves, the render fails and
+names the slot - Orb does not substitute a different image.
 
 !!! note
     These workflows take the output size from the reference image or from a
@@ -139,25 +135,21 @@ substitute a different image.
 
 ### Set the character reference image
 
-1. Open a conversation with the character.
-2. Open **Image Generation** settings.
-3. Find **This Character Only**.
-4. Under **Reference image**, select an image file. The limit is 10 MB.
-5. Select **Save**.
+1. Open a conversation with the character, then open **Image Generation**
+   settings and find **This Character Only**.
+2. Under **Reference image**, select an image file. The limit is 10 MB.
+3. Select **Save**.
 
 When you set no reference image, Orb sends the character card's avatar.
 
 ### Reference images and reroll
 
 Reroll changes the seed only. Orb records where each reference came from and
-fetches the same image again, so the picture keeps its subject.
-
-- If the source image was deleted, or its bytes were evicted, the reroll fails.
-  Use **Regenerate** instead.
-- A character reference is read again from the character profile. Change the
-  reference image and reroll to apply it.
-- You cannot reroll onto a different style whose workflow uses reference
-  images. Use **Regenerate**.
+fetches the same image again, so the picture keeps its subject. A character
+reference is re-read from the character profile, so changing it and rerolling
+applies the new image. If the source image was deleted or its bytes were
+evicted, or the reroll targets a different style whose workflow uses reference
+images, the reroll fails - use **Regenerate** instead.
 
 !!! warning
     A ComfyUI server that is not on this machine receives your conversation

--- a/docs/features/image-generation.md
+++ b/docs/features/image-generation.md
@@ -141,7 +141,7 @@ substitute a different image.
 
 1. Open a conversation with the character.
 2. Open **Image Generation** settings.
-3. Find **Per-character Prompt**.
+3. Find **This Character Only**.
 4. Under **Reference image**, select an image file. The limit is 3 MB.
 5. Select **Save**.
 
@@ -231,7 +231,7 @@ is name of a non-OC character, some image models do better with canon character 
 
 1. Open a conversation with the character.
 2. Open **Image Generation** settings.
-3. Find **Per-character Prompt**.
+3. Find **This Character Only**.
 4. Enter comma-separated appearance tags in **Positive prompt**.
 5. Enter unwanted character features in **Negative prompt**.
 6. Select **Save**.

--- a/frontend/workflows/image_gen/config_panel.js
+++ b/frontend/workflows/image_gen/config_panel.js
@@ -29,6 +29,19 @@ import {
 
 const WORKFLOW_ID = "image_gen";
 
+// What a mapped LoadImage node can be fed, in menu order. The combined choice is
+// the default for a first slot: a pure edit graph cannot render without a
+// reference, so a slot pinned to "previous" alone hard-fails on the first
+// Visualize of every new conversation.
+const REFERENCE_SOURCES = [
+  ["previous_or_character", "Previous image, else character reference"],
+  ["previous", "Previous image in the chat"],
+  ["character", "Character reference image"],
+];
+// Ceiling mirrored from MAX_REFERENCE_SLOTS in the backend config normalizer.
+const MAX_REFERENCE_SLOTS = 4;
+const MAX_REFERENCE_IMAGE_BYTES = 3_000_000;
+
 // How a style's prompt format reads next to its name, in both pickers. One
 // builder, because the summary below is written twice -- once at render, once as
 // the field is edited -- and two spellings of the same badge would drift.
@@ -56,6 +69,8 @@ export function initConfigPanel(sharedConfig) {
   registerAction(WORKFLOW_ID, "test", () => testConnection());
   registerAction(WORKFLOW_ID, "save", () => saveSettings());
   registerAction(WORKFLOW_ID, "graphFile", (el) => importGraphFile(el));
+  registerAction(WORKFLOW_ID, "referenceFile", (el) => pickReferenceImage(el));
+  registerAction(WORKFLOW_ID, "referenceClear", () => clearReferenceImage());
   registerAction(WORKFLOW_ID, "graphAdd", () => addPendingGraph());
   registerAction(WORKFLOW_ID, "graphRemove", (el) => removeGraph(el.dataset.graphId));
   registerAction(WORKFLOW_ID, "styleAdd", () => addStyle());
@@ -392,9 +407,11 @@ function openSettings(expandStyleId = "") {
   const ext = cfg.external_comfy || {};
   pendingGraph = null;
   // Start honest: discovery for a previous modal/server must not make this one
-  // look probed before its own request completes.
+  // look probed before its own request completes, and a reference image picked
+  // for a different character must not survive into this form.
   checkpointProbeId += 1;
   checkpointNames = [];
+  referenceImage = { reference_image_b64: "", reference_mime: "" };
   draft = {
     styles: (Array.isArray(ext.styles) ? ext.styles : []).map((s) => ({ ...s })),
     graphs: (Array.isArray(ext.user_graphs) ? ext.user_graphs : []).map((g) => ({ ...g })),
@@ -485,6 +502,26 @@ async function graphNodeTypes(graph) {
   }
 }
 
+// One row per detected image-upload widget. Every row defaults to "Not used", so
+// a plain text-to-image graph imports exactly as it did before this existed and
+// an edit graph is opt-in per node — Orb never guesses which LoadImage is the
+// identity and which is the scene.
+function referenceRows(items) {
+  if (!items.length) return "";
+  const rows = items
+    .slice(0, MAX_REFERENCE_SLOTS)
+    .map((item, i) => {
+      const options = [`<option value="" selected>Not used</option>`]
+        .concat(REFERENCE_SOURCES.map(([id, text]) => `<option value="${id}">${esc(text)}</option>`))
+        .join("");
+      return `<label>${esc(item.label)}<select data-ig-ref="${i}" data-ig-ref-slot="${escAttr(item.value)}">${options}</select></label>`;
+    })
+    .join("");
+  return `<div class="ig-heading ig-reference-heading">Reference images</div>
+    <div class="image-gen-note">This workflow loads images. Point each one at what Orb should feed it, or leave it unused to keep the file the workflow was exported with.</div>
+    <div class="ig-grid">${rows}</div>`;
+}
+
 async function importGraphFile(input) {
   const file = input.files?.[0];
   const picker = document.getElementById("ig-graph-picker");
@@ -512,12 +549,27 @@ async function importGraphFile(input) {
         <label>Image output<select id="ig-slot-output">${candidateOptions(candidates.output)}</select></label>
         <label>Model<select id="ig-slot-model">${candidateOptions(candidates.checkpoint, model, "None — keep the workflow's own model")}</select></label>
       </div>
+      ${referenceRows(candidates.image)}
       <button class="btn btn-sm" data-wf-action="image_gen:graphAdd">Confirm slots and add workflow</button>
     </div>`;
   } catch (e) {
     pendingGraph = null;
     picker.innerHTML = `<div class="image-gen-note">${esc(e.message || "Could not import this workflow.")}</div>`;
   }
+}
+
+// Reads the reference rows back into the stored `slots.references` shape. An
+// unmapped row is simply absent — that is how "Not used" is encoded, and it keeps
+// a t2i graph's slot map byte-identical to what it was before.
+function readReferenceRows() {
+  const references = [];
+  for (const el of document.querySelectorAll("[data-ig-ref]")) {
+    const slot = splitCandidate(el.dataset.igRefSlot);
+    if (!el.value || !slot) continue;
+    const item = pendingGraph?.candidates?.image?.[Number(el.dataset.igRef)];
+    references.push({ slot, source: el.value, label: item?.label || `${slot[0]} — ${slot[1]}` });
+  }
+  return references;
 }
 
 function addPendingGraph() {
@@ -536,6 +588,8 @@ function addPendingGraph() {
   // The model slot is patched from the style's checkpoint at render time, so the
   // user's Orb selection overrides the model baked into the imported graph.
   if (model) slots.checkpoint = model;
+  const references = readReferenceRows();
+  if (references.length) slots.references = references;
   draft.graphs.push({ id, label, graph: pendingGraph.graph, slots });
   const list = document.getElementById("ig-graph-list");
   if (list) list.innerHTML = graphRows();
@@ -576,7 +630,7 @@ async function testConnection() {
 
 async function saveSettings() {
   const next = readConfig();
-  if (!confirmRemotePrivacy(next.external_comfy.api_url)) return;
+  if (!confirmRemotePrivacy(next.external_comfy.api_url, next.external_comfy.user_graphs)) return;
   try {
     // The response is the *normalized* config: the backend bounds and drops what
     // it will not honour, and adopting its answer is what stops the panel from
@@ -600,15 +654,80 @@ async function saveSettings() {
   }
 }
 
-function confirmRemotePrivacy(apiUrl) {
+// Uploading conversation images is a materially bigger disclosure than sending
+// prompt text, so it gets its own acknowledgement key: a user who accepted the
+// prompt-only wording is asked again the first time a graph maps references.
+function confirmRemotePrivacy(apiUrl, graphs) {
   if (isLoopbackUrl(apiUrl)) return true;
-  const key = `orb:image-gen-privacy:${new URL(apiUrl).origin}`;
+  const sendsImages = (graphs || []).some((g) => (g?.slots?.references || []).length > 0);
+  const origin = new URL(apiUrl).origin;
+  const key = `orb:image-gen-privacy${sendsImages ? "-images" : ""}:${origin}`;
   if (localStorage.getItem(key) === "acknowledged") return true;
   const accepted = window.confirm(
-    "This ComfyUI server is not on this machine. Your scene prompts leave Orb, other clients may read queued prompts, and generated files remain on that server. Save this connection?",
+    sendsImages
+      ? "This ComfyUI server is not on this machine. A workflow you assigned uses reference images, so images from your conversations and your character reference image are uploaded to that server along with your scene prompts. Other clients may read queued prompts, and uploaded and generated files remain on that server. Save this connection?"
+      : "This ComfyUI server is not on this machine. Your scene prompts leave Orb, other clients may read queued prompts, and generated files remain on that server. Save this connection?",
   );
   if (accepted) localStorage.setItem(key, "acknowledged");
   return accepted;
+}
+
+// The character's reference image as the form currently holds it — loaded with
+// the profile, replaced by the file picker, emptied by Clear, and written back on
+// Save. Kept in module state rather than read off the rendered <img>, so a save
+// that never touched the picker round-trips the stored bytes untouched.
+let referenceImage = { reference_image_b64: "", reference_mime: "" };
+
+function referenceImageHtml() {
+  const stored = !!referenceImage.reference_image_b64;
+  // With no image there is no preview column, so the controls start at the same
+  // left edge as the prompt fields above rather than floating inset.
+  const preview = stored
+    ? `<div class="ig-reference-preview"><img class="ig-reference-thumb" alt="Character reference image" src="data:${escAttr(referenceImage.reference_mime || "image/png")};base64,${escAttr(referenceImage.reference_image_b64)}"></div>`
+    : "";
+  return `<div class="ig-reference-image">
+      ${preview}
+      <div class="ig-reference-controls">
+        <input type="file" accept="image/png,image/jpeg,image/webp" data-wf-action="image_gen:referenceFile" data-wf-on="change">
+        ${stored ? `<button class="btn btn-sm" data-wf-action="image_gen:referenceClear">Clear</button>` : ""}
+        ${stored ? "" : `<span class="image-gen-note ig-reference-empty">No reference image — the character card's avatar is used.</span>`}
+      </div>
+    </div>`;
+}
+
+function renderReferenceImage() {
+  const host = document.getElementById("ig-reference-host");
+  if (host) host.innerHTML = referenceImageHtml();
+}
+
+async function pickReferenceImage(input) {
+  const file = input.files?.[0];
+  if (!file) return;
+  if (file.size > MAX_REFERENCE_IMAGE_BYTES) {
+    toast("That image is too large — use one under 3 MB", "error");
+    input.value = "";
+    return;
+  }
+  try {
+    const buffer = await file.arrayBuffer();
+    // Chunked so a multi-MB image does not blow the argument limit of
+    // String.fromCharCode, which a single spread of the whole array would.
+    const bytes = new Uint8Array(buffer);
+    let binary = "";
+    for (let i = 0; i < bytes.length; i += 0x8000) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+    }
+    referenceImage = { reference_image_b64: btoa(binary), reference_mime: file.type || "image/png" };
+    renderReferenceImage();
+  } catch {
+    toast("Could not read that image", "error");
+  }
+  input.value = "";
+}
+
+function clearReferenceImage() {
+  referenceImage = { reference_image_b64: "", reference_mime: "" };
+  renderReferenceImage();
 }
 
 async function populateProfile() {
@@ -623,9 +742,18 @@ async function populateProfile() {
       return;
     }
     el.classList.remove("image-gen-note");
+    referenceImage = {
+      reference_image_b64: res.profile.reference_image_b64 || "",
+      reference_mime: res.profile.reference_mime || "",
+    };
     el.innerHTML = `<div class="ig-profile-fields">
         <label>Positive prompt<textarea id="ig-appearance" placeholder="Per-character permanent tags, fill as much as you can (e.g. Hatsune Miku, black and white)">${esc(res.profile.appearance_prompt || "")}</textarea></label>
         <label>Negative prompt<textarea id="ig-profile-negative" placeholder="Per-character things to never render (e.g. glasses, colored, color). Quality and scene negatives are already handled.">${esc(res.profile.negative_prompt || "")}</textarea></label>
+        <div class="ig-profile-reference">
+          <span class="ig-profile-reference-label">Reference image</span>
+          <span class="image-gen-note">Used by workflows whose reference slots are set to the character.</span>
+          <div id="ig-reference-host">${referenceImageHtml()}</div>
+        </div>
       </div>`;
   } catch {
     el.textContent = "Could not load character appearance.";
@@ -642,6 +770,7 @@ async function saveProfile() {
     profile: {
       appearance_prompt: appearanceEl.value || "",
       negative_prompt: document.getElementById("ig-profile-negative")?.value || "",
+      ...referenceImage,
     },
   });
 }

--- a/frontend/workflows/image_gen/config_panel.js
+++ b/frontend/workflows/image_gen/config_panel.js
@@ -431,7 +431,7 @@ function openSettings(expandStyleId = "") {
       <button class="btn btn-sm" data-wf-action="image_gen:styleAdd">Add style</button>
     </section>
     <section class="ig-section">
-      <div class="ig-heading">Per-character prompt</div>
+      <div class="ig-heading">This Character Only</div>
       <div id="ig-profile" class="image-gen-note">Open a conversation to edit its character-specific prompt.</div>
     </section>
     <section class="ig-section">
@@ -747,11 +747,11 @@ async function populateProfile() {
       reference_mime: res.profile.reference_mime || "",
     };
     el.innerHTML = `<div class="ig-profile-fields">
-        <label>Positive prompt<textarea id="ig-appearance" placeholder="Per-character permanent tags, fill as much as you can (e.g. Hatsune Miku, black and white)">${esc(res.profile.appearance_prompt || "")}</textarea></label>
-        <label>Negative prompt<textarea id="ig-profile-negative" placeholder="Per-character things to never render (e.g. glasses, colored, color). Quality and scene negatives are already handled.">${esc(res.profile.negative_prompt || "")}</textarea></label>
+        <label>Positive prompt<textarea id="ig-appearance" placeholder="Permanent tags, fill with permanent traits (e.g. Hatsune Miku, black and white)">${esc(res.profile.appearance_prompt || "")}</textarea></label>
+        <label>Negative prompt<textarea id="ig-profile-negative" placeholder="Things to never render (e.g. 3D, colored, color). Quality and scene negatives are already handled.">${esc(res.profile.negative_prompt || "")}</textarea></label>
         <div class="ig-profile-reference">
           <span class="ig-profile-reference-label">Reference image</span>
-          <span class="image-gen-note">Used by workflows whose reference slots are set to the character.</span>
+          <span class="image-gen-note">Used by workflows with reference image slots.</span>
           <div id="ig-reference-host">${referenceImageHtml()}</div>
         </div>
       </div>`;

--- a/frontend/workflows/image_gen/config_panel.js
+++ b/frontend/workflows/image_gen/config_panel.js
@@ -29,20 +29,17 @@ import {
 
 const WORKFLOW_ID = "image_gen";
 
-// What a mapped LoadImage node can be fed, in menu order. The combined choice is
-// the default for a first slot: a pure edit graph cannot render without a
-// reference, so a slot pinned to "previous" alone hard-fails on the first
-// Visualize of every new conversation.
+// What a mapped LoadImage node can be fed, in menu order — the combined choice
+// leads because it is the one with no cold-start cliff on a fresh conversation.
 const REFERENCE_SOURCES = [
   ["previous_or_character", "Previous image, else character reference"],
   ["previous", "Previous image in the chat"],
   ["character", "Character reference image"],
 ];
-// Ceiling mirrored from MAX_REFERENCE_SLOTS in the backend config normalizer.
+// Mirrored from the backend config normalizer. The count is enforced at the
+// picker for the same reason the size cap is: the normalizer truncates the
+// overflow, and a count that comes back short cannot say which graph went missing.
 const MAX_REFERENCE_SLOTS = 4;
-// Mirrored from MAX_USER_GRAPHS. Enforced at the picker for the same reason the
-// size cap is: the normalizer truncates the overflow, and a count that comes back
-// short cannot say which workflow went missing or why.
 const MAX_USER_GRAPHS = 32;
 const MAX_REFERENCE_IMAGE_BYTES = 10_000_000;
 
@@ -74,7 +71,9 @@ export function initConfigPanel(sharedConfig) {
   registerAction(WORKFLOW_ID, "save", () => saveSettings());
   registerAction(WORKFLOW_ID, "graphFile", (el) => importGraphFile(el));
   registerAction(WORKFLOW_ID, "referenceFile", (el) => pickReferenceImage(el));
-  registerAction(WORKFLOW_ID, "referenceClear", () => clearReferenceImage());
+  registerAction(WORKFLOW_ID, "referenceClear", () =>
+    setReferenceImage({ reference_image_b64: "", reference_mime: "" }),
+  );
   registerAction(WORKFLOW_ID, "graphAdd", () => addPendingGraph());
   registerAction(WORKFLOW_ID, "graphRemove", (el) => removeGraph(el.dataset.graphId));
   registerAction(WORKFLOW_ID, "styleAdd", () => addStyle());
@@ -506,20 +505,20 @@ async function graphNodeTypes(graph) {
   }
 }
 
-// One row per detected image-upload widget. Every row defaults to "Not used", so
-// a plain text-to-image graph imports exactly as it did before this existed and
-// an edit graph is opt-in per node — Orb never guesses which LoadImage is the
-// identity and which is the scene.
+// One row per detected image-upload widget, defaulting to "Not used": a plain
+// text-to-image graph imports exactly as it did before this existed, and an edit
+// graph is opt-in per node — Orb never guesses which LoadImage is the identity.
 function referenceRows(items) {
   if (!items.length) return "";
+  const options = [`<option value="" selected>Not used</option>`]
+    .concat(REFERENCE_SOURCES.map(([id, text]) => `<option value="${id}">${esc(text)}</option>`))
+    .join("");
   const rows = items
     .slice(0, MAX_REFERENCE_SLOTS)
-    .map((item, i) => {
-      const options = [`<option value="" selected>Not used</option>`]
-        .concat(REFERENCE_SOURCES.map(([id, text]) => `<option value="${id}">${esc(text)}</option>`))
-        .join("");
-      return `<label>${esc(item.label)}<select data-ig-ref="${i}" data-ig-ref-slot="${escAttr(item.value)}">${options}</select></label>`;
-    })
+    .map(
+      (item, i) =>
+        `<label>${esc(item.label)}<select data-ig-ref="${i}" data-ig-ref-slot="${escAttr(item.value)}">${options}</select></label>`,
+    )
     .join("");
   return `<div class="ig-heading ig-reference-heading">Reference images</div>
     <div class="image-gen-note">This workflow loads images. Point each one at what Orb should feed it, or leave it unused to keep the file the workflow was exported with.</div>
@@ -564,9 +563,9 @@ async function importGraphFile(input) {
   }
 }
 
-// Reads the reference rows back into the stored `slots.references` shape. An
-// unmapped row is simply absent — that is how "Not used" is encoded, and it keeps
-// a t2i graph's slot map byte-identical to what it was before.
+// Reads the rows back into the stored `slots.references` shape. An unmapped row is
+// simply absent — that is how "Not used" is encoded, and it keeps a t2i graph's
+// slot map byte-identical to what it was before.
 function readReferenceRows() {
   const references = [];
   for (const el of document.querySelectorAll("[data-ig-ref]")) {
@@ -646,10 +645,8 @@ async function saveSettings() {
     const droppedGraphs = next.external_comfy.user_graphs.length - (stored.external_comfy?.user_graphs?.length || 0);
     Object.assign(cfg, stored);
     await saveProfile();
-    // Deliberately does not name a cause. The picker already gates the two the
-    // user can act on (size, count), so anything the normalizer still drops here
-    // is a graph it would not store -- and this diff is a count, which cannot tell
-    // those apart. It used to blame every drop on size, including the count cap.
+    // Deliberately unattributed: the picker already gates the two causes the user
+    // can act on (size, count), and a bare count cannot tell the rest apart.
     toast(
       droppedGraphs > 0
         ? `Saved, but ${droppedGraphs} imported workflow${droppedGraphs > 1 ? "s" : ""} could not be stored`
@@ -670,13 +667,14 @@ async function saveSettings() {
 function confirmRemotePrivacy(apiUrl, graphs) {
   if (isLoopbackUrl(apiUrl)) return true;
   const sendsImages = (graphs || []).some((g) => (g?.slots?.references || []).length > 0);
-  const origin = new URL(apiUrl).origin;
-  const key = `orb:image-gen-privacy${sendsImages ? "-images" : ""}:${origin}`;
+  const key = `orb:image-gen-privacy${sendsImages ? "-images" : ""}:${new URL(apiUrl).origin}`;
   if (localStorage.getItem(key) === "acknowledged") return true;
   const accepted = window.confirm(
-    sendsImages
-      ? "This ComfyUI server is not on this machine. A workflow you assigned uses reference images, so images from your conversations and your character reference image are uploaded to that server along with your scene prompts. Other clients may read queued prompts, and uploaded and generated files remain on that server. Save this connection?"
-      : "This ComfyUI server is not on this machine. Your scene prompts leave Orb, other clients may read queued prompts, and generated files remain on that server. Save this connection?",
+    "This ComfyUI server is not on this machine. Your scene prompts leave Orb, other clients may read queued prompts, and generated files remain on that server. " +
+      (sendsImages
+        ? "A workflow you assigned uses reference images, so images from your conversations and your character reference image are uploaded there too. "
+        : "") +
+      "Save this connection?",
   );
   if (accepted) localStorage.setItem(key, "acknowledged");
   return accepted;
@@ -692,20 +690,21 @@ function referenceImageHtml() {
   const stored = !!referenceImage.reference_image_b64;
   // With no image there is no preview column, so the controls start at the same
   // left edge as the prompt fields above rather than floating inset.
-  const preview = stored
-    ? `<div class="ig-reference-preview"><img class="ig-reference-thumb" alt="Character reference image" src="data:${escAttr(referenceImage.reference_mime || "image/png")};base64,${escAttr(referenceImage.reference_image_b64)}"></div>`
-    : "";
   return `<div class="ig-reference-image">
-      ${preview}
+      ${stored ? `<div class="ig-reference-preview"><img class="ig-reference-thumb" alt="Character reference image" src="data:${escAttr(referenceImage.reference_mime || "image/png")};base64,${escAttr(referenceImage.reference_image_b64)}"></div>` : ""}
       <div class="ig-reference-controls">
         <input type="file" accept="image/png,image/jpeg,image/webp" data-wf-action="image_gen:referenceFile" data-wf-on="change">
-        ${stored ? `<button class="btn btn-sm" data-wf-action="image_gen:referenceClear">Clear</button>` : ""}
-        ${stored ? "" : `<span class="image-gen-note ig-reference-empty">No reference image — the character card's avatar is used.</span>`}
+        ${
+          stored
+            ? `<button class="btn btn-sm" data-wf-action="image_gen:referenceClear">Clear</button>`
+            : `<span class="image-gen-note ig-reference-empty">No reference image — the character card's avatar is used.</span>`
+        }
       </div>
     </div>`;
 }
 
-function renderReferenceImage() {
+function setReferenceImage(next) {
+  referenceImage = next;
   const host = document.getElementById("ig-reference-host");
   if (host) host.innerHTML = referenceImageHtml();
 }
@@ -719,25 +718,16 @@ async function pickReferenceImage(input) {
     return;
   }
   try {
-    const buffer = await file.arrayBuffer();
     // Chunked so a multi-MB image does not blow the argument limit of
     // String.fromCharCode, which a single spread of the whole array would.
-    const bytes = new Uint8Array(buffer);
+    const bytes = new Uint8Array(await file.arrayBuffer());
     let binary = "";
-    for (let i = 0; i < bytes.length; i += 0x8000) {
-      binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
-    }
-    referenceImage = { reference_image_b64: btoa(binary), reference_mime: file.type || "image/png" };
-    renderReferenceImage();
+    for (let i = 0; i < bytes.length; i += 0x8000) binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+    setReferenceImage({ reference_image_b64: btoa(binary), reference_mime: file.type || "image/png" });
   } catch {
     toast("Could not read that image", "error");
   }
   input.value = "";
-}
-
-function clearReferenceImage() {
-  referenceImage = { reference_image_b64: "", reference_mime: "" };
-  renderReferenceImage();
 }
 
 async function populateProfile() {

--- a/frontend/workflows/image_gen/config_panel.js
+++ b/frontend/workflows/image_gen/config_panel.js
@@ -40,7 +40,11 @@ const REFERENCE_SOURCES = [
 ];
 // Ceiling mirrored from MAX_REFERENCE_SLOTS in the backend config normalizer.
 const MAX_REFERENCE_SLOTS = 4;
-const MAX_REFERENCE_IMAGE_BYTES = 3_000_000;
+// Mirrored from MAX_USER_GRAPHS. Enforced at the picker for the same reason the
+// size cap is: the normalizer truncates the overflow, and a count that comes back
+// short cannot say which workflow went missing or why.
+const MAX_USER_GRAPHS = 32;
+const MAX_REFERENCE_IMAGE_BYTES = 10_000_000;
 
 // How a style's prompt format reads next to its name, in both pickers. One
 // builder, because the summary below is written twice -- once at render, once as
@@ -527,6 +531,8 @@ async function importGraphFile(input) {
   const picker = document.getElementById("ig-graph-picker");
   if (!file || !picker) return;
   try {
+    if (draft.graphs.length >= MAX_USER_GRAPHS)
+      throw new Error(`Orb stores at most ${MAX_USER_GRAPHS} imported workflows. Remove one before importing another.`);
     const graph = file.name.toLowerCase().endsWith(".png")
       ? graphFromPng(await file.arrayBuffer())
       : graphFromApiJson(await file.text());
@@ -640,9 +646,13 @@ async function saveSettings() {
     const droppedGraphs = next.external_comfy.user_graphs.length - (stored.external_comfy?.user_graphs?.length || 0);
     Object.assign(cfg, stored);
     await saveProfile();
+    // Deliberately does not name a cause. The picker already gates the two the
+    // user can act on (size, count), so anything the normalizer still drops here
+    // is a graph it would not store -- and this diff is a count, which cannot tell
+    // those apart. It used to blame every drop on size, including the count cap.
     toast(
       droppedGraphs > 0
-        ? `Saved, but ${droppedGraphs} imported workflow${droppedGraphs > 1 ? "s were" : " was"} rejected as too large`
+        ? `Saved, but ${droppedGraphs} imported workflow${droppedGraphs > 1 ? "s" : ""} could not be stored`
         : "Image generation settings saved",
       droppedGraphs > 0 ? "error" : undefined,
     );
@@ -704,7 +714,7 @@ async function pickReferenceImage(input) {
   const file = input.files?.[0];
   if (!file) return;
   if (file.size > MAX_REFERENCE_IMAGE_BYTES) {
-    toast("That image is too large — use one under 3 MB", "error");
+    toast("That image is too large — use one under 10 MB", "error");
     input.value = "";
     return;
   }

--- a/frontend/workflows/image_gen/graph_import.js
+++ b/frontend/workflows/image_gen/graph_import.js
@@ -12,12 +12,9 @@ const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
 // Mirrors MAX_GRAPH_BYTES in backend/workflows/image_gen/config.py. Checked here
 // too so an oversized graph is refused at the file picker, where the user can
 // still see which file they chose, instead of being dropped by normalization
-// after save and reported only as a count that came back short.
-//
-// The measurement has to match the backend's or the two gates disagree: it counts
-// UTF-8 bytes of the graph *after* `is_changed` is stripped. Counting UTF-16 code
-// units instead let a CJK graph through the picker at a third of its real size,
-// and counting before the strip bounced graphs the backend would have stored.
+// after save and reported only as a count that came back short. The measurement
+// must match the backend's -- UTF-8 bytes, taken *after* `is_changed` is stripped
+// -- or the two gates disagree in both directions.
 export const MAX_GRAPH_BYTES = 512_000;
 
 const FALLBACK_TEXT_INPUTS = ["text"];
@@ -25,8 +22,7 @@ const FALLBACK_SEED_INPUTS = ["seed", "noise_seed"];
 const FALLBACK_OUTPUT_CLASSES = ["SaveImage", "PreviewImage"];
 // Upload widgets are typed server-side off /object_info's `image_upload` flag.
 // Unreachable server or unknown class: only the stock loaders are guessed, since
-// the input is named `image` on both and a wrong guess here would offer a
-// reference slot that patches something else.
+// a wrong guess would offer a reference slot that patches something else.
 const FALLBACK_IMAGE_CLASSES = ["LoadImage", "LoadImageMask"];
 const FALLBACK_IMAGE_INPUTS = ["image"];
 // Widget inputs that name the diffusion model a loader reads. Offered as a
@@ -37,23 +33,17 @@ const MODEL_INPUTS = ["ckpt_name", "unet_name"];
 
 // Mirrors `_strip_machine_local_state` in the backend normalizer: ComfyUI's API
 // export embeds a per-node `is_changed` hash that is meaningless off the machine
-// that wrote it. Copies rather than mutates — the caller stores the graph it
-// passed in, and the backend does its own strip on arrival.
-function withoutMachineLocalState(graph) {
-  const stripped = {};
-  for (const [nodeId, node] of Object.entries(graph)) {
-    if (node && typeof node === "object" && !Array.isArray(node) && "is_changed" in node) {
-      const { is_changed: _drop, ...rest } = node;
-      stripped[nodeId] = rest;
-    } else {
-      stripped[nodeId] = node;
-    }
-  }
-  return stripped;
-}
-
+// that wrote it. Measured on a copy — the caller stores the graph it passed in,
+// and the backend does its own strip on arrival.
 function graphByteLength(graph) {
-  return new TextEncoder().encode(JSON.stringify(withoutMachineLocalState(graph))).length;
+  const stripped = Object.fromEntries(
+    Object.entries(graph).map(([nodeId, node]) => {
+      if (!node || typeof node !== "object" || Array.isArray(node)) return [nodeId, node];
+      const { is_changed: _drop, ...rest } = node;
+      return [nodeId, rest];
+    }),
+  );
+  return new TextEncoder().encode(JSON.stringify(stripped)).length;
 }
 
 function parseGraphJson(text) {
@@ -157,9 +147,8 @@ export function slotCandidates(graph, nodeTypes = {}) {
       if (!isOutput && textInputs.includes(name)) text.push(item);
       if (seedInputs.includes(name)) (isOutput ? seedTail : seed).push(item);
       if (MODEL_INPUTS.includes(name)) (isOutput ? checkpointTail : checkpoint).push(item);
-      // An upload widget is where an edit workflow takes its reference image. The
-      // row is labelled by node rather than by input name, because a two-reference
-      // graph asks the user which LoadImage is the identity and which is the scene.
+      // Labelled by node rather than by input name: a two-reference graph asks the
+      // user which LoadImage is the identity and which is the scene.
       if (imageInputs.includes(name)) image.push({ ...item, label: label(nodeId, node) });
     }
     if (isOutput) {

--- a/frontend/workflows/image_gen/graph_import.js
+++ b/frontend/workflows/image_gen/graph_import.js
@@ -18,6 +18,12 @@ export const MAX_GRAPH_BYTES = 512_000;
 const FALLBACK_TEXT_INPUTS = ["text"];
 const FALLBACK_SEED_INPUTS = ["seed", "noise_seed"];
 const FALLBACK_OUTPUT_CLASSES = ["SaveImage", "PreviewImage"];
+// Upload widgets are typed server-side off /object_info's `image_upload` flag.
+// Unreachable server or unknown class: only the stock loaders are guessed, since
+// the input is named `image` on both and a wrong guess here would offer a
+// reference slot that patches something else.
+const FALLBACK_IMAGE_CLASSES = ["LoadImage", "LoadImageMask"];
+const FALLBACK_IMAGE_INPUTS = ["image"];
 // Widget inputs that name the diffusion model a loader reads. Offered as a
 // "Model" slot so an imported graph's model can be overridden by the checkpoint
 // the user picked in Orb, instead of staying pinned to a filename from whatever
@@ -101,6 +107,7 @@ export function slotCandidates(graph, nodeTypes = {}) {
   const seed = [];
   const output = [];
   const checkpoint = [];
+  const image = [];
   const seedTail = [];
   const checkpointTail = [];
   for (const [nodeId, node] of Object.entries(graph || {})) {
@@ -108,6 +115,11 @@ export function slotCandidates(graph, nodeTypes = {}) {
     const typing = nodeTypes[node.class_type];
     const textInputs = typing ? typing.text_inputs || [] : FALLBACK_TEXT_INPUTS;
     const seedInputs = typing ? typing.seed_inputs || [] : FALLBACK_SEED_INPUTS;
+    const imageInputs = typing
+      ? typing.image_inputs || []
+      : FALLBACK_IMAGE_CLASSES.includes(node.class_type)
+        ? FALLBACK_IMAGE_INPUTS
+        : [];
     const isOutput = typing ? !!typing.output_node : FALLBACK_OUTPUT_CLASSES.includes(node.class_type);
     for (const name of Object.keys(inputs)) {
       if (!isWidget(inputs[name])) continue;
@@ -119,12 +131,16 @@ export function slotCandidates(graph, nodeTypes = {}) {
       if (!isOutput && textInputs.includes(name)) text.push(item);
       if (seedInputs.includes(name)) (isOutput ? seedTail : seed).push(item);
       if (MODEL_INPUTS.includes(name)) (isOutput ? checkpointTail : checkpoint).push(item);
+      // An upload widget is where an edit workflow takes its reference image. The
+      // row is labelled by node rather than by input name, because a two-reference
+      // graph asks the user which LoadImage is the identity and which is the scene.
+      if (imageInputs.includes(name)) image.push({ ...item, label: label(nodeId, node) });
     }
     if (isOutput) {
       output.push({ value: `${nodeId}\u001fimages`, nodeId, input: "images", label: label(nodeId, node) });
     }
   }
-  return { text, seed: [...seed, ...seedTail], output, checkpoint: [...checkpoint, ...checkpointTail] };
+  return { text, seed: [...seed, ...seedTail], output, checkpoint: [...checkpoint, ...checkpointTail], image };
 }
 
 // The three roles a graph cannot render without. `negative` is deliberately

--- a/frontend/workflows/image_gen/graph_import.js
+++ b/frontend/workflows/image_gen/graph_import.js
@@ -11,8 +11,13 @@ const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
 
 // Mirrors MAX_GRAPH_BYTES in backend/workflows/image_gen/config.py. Checked here
 // too so an oversized graph is refused at the file picker, where the user can
-// still see which file they chose, instead of being silently dropped by
-// normalization after save.
+// still see which file they chose, instead of being dropped by normalization
+// after save and reported only as a count that came back short.
+//
+// The measurement has to match the backend's or the two gates disagree: it counts
+// UTF-8 bytes of the graph *after* `is_changed` is stripped. Counting UTF-16 code
+// units instead let a CJK graph through the picker at a third of its real size,
+// and counting before the strip bounced graphs the backend would have stored.
 export const MAX_GRAPH_BYTES = 512_000;
 
 const FALLBACK_TEXT_INPUTS = ["text"];
@@ -30,6 +35,27 @@ const FALLBACK_IMAGE_INPUTS = ["image"];
 // machine exported the PNG.
 const MODEL_INPUTS = ["ckpt_name", "unet_name"];
 
+// Mirrors `_strip_machine_local_state` in the backend normalizer: ComfyUI's API
+// export embeds a per-node `is_changed` hash that is meaningless off the machine
+// that wrote it. Copies rather than mutates — the caller stores the graph it
+// passed in, and the backend does its own strip on arrival.
+function withoutMachineLocalState(graph) {
+  const stripped = {};
+  for (const [nodeId, node] of Object.entries(graph)) {
+    if (node && typeof node === "object" && !Array.isArray(node) && "is_changed" in node) {
+      const { is_changed: _drop, ...rest } = node;
+      stripped[nodeId] = rest;
+    } else {
+      stripped[nodeId] = node;
+    }
+  }
+  return stripped;
+}
+
+function graphByteLength(graph) {
+  return new TextEncoder().encode(JSON.stringify(withoutMachineLocalState(graph))).length;
+}
+
 function parseGraphJson(text) {
   let value;
   try {
@@ -46,7 +72,7 @@ function parseGraphJson(text) {
   if (!nodes.length || nodes.some(([, node]) => !node || typeof node.class_type !== "string" || !node.inputs)) {
     throw new Error("The file is not a ComfyUI API workflow.");
   }
-  if (JSON.stringify(value).length > MAX_GRAPH_BYTES) {
+  if (graphByteLength(value) > MAX_GRAPH_BYTES) {
     throw new Error("This workflow is too large to store in Orb's settings.");
   }
   return value;

--- a/frontend/workflows/image_gen/image_gen.css
+++ b/frontend/workflows/image_gen/image_gen.css
@@ -71,6 +71,24 @@
 .ig-advanced-body{display:grid;gap:10px;padding:10px;border-top:1px solid var(--border)}
 .image-gen-graph-picker{display:grid;gap:10px}
 .image-gen-graph-picker button{justify-self:start}
+/* The reference rows are a sub-section of the picker, not a peer of the modal's
+   top-level headings, so the divider is enough to separate them. */
+.ig-reference-heading{margin-top:2px}
+
+/* ---- per-character reference image ----
+   Thumbnail beside its controls so what is stored and how to change it read as
+   one control. The preview is capped rather than sized, since a portrait
+   reference and a landscape one both land here. The label carries the same
+   styling the global `label` rule gives the prompt fields it sits under, since
+   it is a span rather than a label -- the section holds a file input plus a
+   button, not one field. */
+.ig-profile-reference{display:grid;gap:5px}
+.ig-profile-reference-label{font-size:11px;font-weight:500;text-transform:uppercase;letter-spacing:.5px;color:var(--text-secondary)}
+.ig-reference-image{display:flex;align-items:flex-start;gap:10px;margin-top:4px}
+.ig-reference-preview{flex:0 0 auto}
+.ig-reference-thumb{display:block;max-width:96px;max-height:96px;border-radius:var(--radius);border:1px solid var(--border);object-fit:cover}
+.ig-reference-controls{flex:1;display:grid;gap:6px;min-width:0;justify-items:start}
+.ig-reference-empty{display:block}
 
 @media (max-width:560px){.ig-grid{grid-template-columns:1fr}}
 

--- a/frontend/workflows/image_gen/image_gen.css
+++ b/frontend/workflows/image_gen/image_gen.css
@@ -71,17 +71,14 @@
 .ig-advanced-body{display:grid;gap:10px;padding:10px;border-top:1px solid var(--border)}
 .image-gen-graph-picker{display:grid;gap:10px}
 .image-gen-graph-picker button{justify-self:start}
-/* The reference rows are a sub-section of the picker, not a peer of the modal's
-   top-level headings, so the divider is enough to separate them. */
+/* A sub-section of the picker, not a peer of the modal's top-level headings. */
 .ig-reference-heading{margin-top:2px}
 
 /* ---- per-character reference image ----
-   Thumbnail beside its controls so what is stored and how to change it read as
-   one control. The preview is capped rather than sized, since a portrait
-   reference and a landscape one both land here. The label carries the same
-   styling the global `label` rule gives the prompt fields it sits under, since
-   it is a span rather than a label -- the section holds a file input plus a
-   button, not one field. */
+   Thumbnail beside its controls, so what is stored and how to change it read as
+   one control; the preview is capped rather than sized, since portrait and
+   landscape references both land here. `-label` is a span, not a label -- the
+   section holds a file input plus a button -- so it restates the global rule. */
 .ig-profile-reference{display:grid;gap:5px}
 .ig-profile-reference-label{font-size:11px;font-weight:500;text-transform:uppercase;letter-spacing:.5px;color:var(--text-secondary)}
 .ig-reference-image{display:flex;align-items:flex-start;gap:10px;margin-top:4px}

--- a/frontend/workflows/image_gen/render.js
+++ b/frontend/workflows/image_gen/render.js
@@ -22,6 +22,39 @@ const POV_SOURCE_LABELS = {
   default: "default (the narration read as ambiguous)",
 };
 
+// Where a reference image came from, phrased as the thing a user would go look at.
+const REFERENCE_SOURCE_LABELS = {
+  previous: "previous image",
+  character: "character reference",
+  previous_or_character: "previous image, else character reference",
+};
+
+// The origin is a machine key ("attachment:41", "upload:12:3", "character:<id>"),
+// and its useful half is which *kind* of thing was fed in — a wrong reference is
+// usually the wrong kind, not the wrong row.
+function originLabel(origin) {
+  const kind = String(origin || "").split(":")[0];
+  if (kind === "attachment") return "a generated image in this chat";
+  if (kind === "upload") return "an image you uploaded";
+  if (kind === "character") return "the character";
+  return "";
+}
+
+// One row per mapped slot. Absent on images rendered by a workflow with no
+// reference slots, so the row is omitted rather than shown empty.
+function referenceRows(cm, esc) {
+  const items = Array.isArray(cm.references) ? cm.references : [];
+  return items
+    .map((ref) => {
+      const node = Array.isArray(ref?.slot) ? `#${ref.slot[0]}` : "";
+      const source = REFERENCE_SOURCE_LABELS[ref?.source] || ref?.source || "";
+      const from = originLabel(ref?.origin);
+      const detail = [source, from && `from ${from}`].filter(Boolean).join(" — ");
+      return `<dt>Reference${node ? esc(` ${node}`) : ""}</dt><dd>${esc(detail)}</dd>`;
+    })
+    .join("");
+}
+
 export function hasAttachment(msg) {
   return (msg?.workflow_attachments || []).some((a) => a.workflow_id === WORKFLOW_ID);
 }
@@ -71,7 +104,7 @@ export function attachmentDetailsHtml(att, defaultHtml, { esc, escAttr, pending 
     : "";
   return `${defaultHtml}<details class="image-gen-details" open><summary>Render details</summary>
     <dl><dt>Style</dt><dd>${style}</dd>
-      <dt>Source</dt><dd>${esc(cm.source || "External ComfyUI")}</dd>${camera}
+      <dt>Source</dt><dd>${esc(cm.source || "External ComfyUI")}</dd>${camera}${referenceRows(cm, esc)}
       <dt>Seed</dt><dd><code>${esc(att?.seed || "")}</code></dd>
       <dt>Prompt ${pencil("prompt", "Prompt")}</dt><dd>${field("prompt", "Prompt", pending?.prompt ?? cm.prompt ?? "")}${marker}</dd>
       <dt>Negative ${pencil("negative_prompt", "Negative prompt")}</dt><dd>${field("negative_prompt", "Negative prompt", pending?.negative_prompt ?? cm.negative_prompt ?? "")}</dd>${notes}</dl>

--- a/frontend/workflows/image_gen/render.js
+++ b/frontend/workflows/image_gen/render.js
@@ -28,28 +28,24 @@ const REFERENCE_SOURCE_LABELS = {
   character: "character reference",
   previous_or_character: "previous image, else character reference",
 };
-
 // The origin is a machine key ("attachment:41", "upload:12:3", "character:<id>"),
 // and its useful half is which *kind* of thing was fed in — a wrong reference is
 // usually the wrong kind, not the wrong row.
-function originLabel(origin) {
-  const kind = String(origin || "").split(":")[0];
-  if (kind === "attachment") return "a generated image in this chat";
-  if (kind === "upload") return "an image you uploaded";
-  if (kind === "character") return "the character";
-  return "";
-}
+const REFERENCE_ORIGIN_LABELS = {
+  attachment: "a generated image in this chat",
+  upload: "an image you uploaded",
+  character: "the character",
+};
 
-// One row per mapped slot. Absent on images rendered by a workflow with no
-// reference slots, so the row is omitted rather than shown empty.
+// One row per mapped slot, so a workflow with no reference slots gets none.
 function referenceRows(cm, esc) {
-  const items = Array.isArray(cm.references) ? cm.references : [];
-  return items
+  return (Array.isArray(cm.references) ? cm.references : [])
     .map((ref) => {
       const node = Array.isArray(ref?.slot) ? `#${ref.slot[0]}` : "";
-      const source = REFERENCE_SOURCE_LABELS[ref?.source] || ref?.source || "";
-      const from = originLabel(ref?.origin);
-      const detail = [source, from && `from ${from}`].filter(Boolean).join(" — ");
+      const from = REFERENCE_ORIGIN_LABELS[String(ref?.origin || "").split(":")[0]];
+      const detail = [REFERENCE_SOURCE_LABELS[ref?.source] || ref?.source || "", from && `from ${from}`]
+        .filter(Boolean)
+        .join(" — ");
       return `<dt>Reference${node ? esc(` ${node}`) : ""}</dt><dd>${esc(detail)}</dd>`;
     })
     .join("");

--- a/tests/frontend/image_gen_graph_import.test.mjs
+++ b/tests/frontend/image_gen_graph_import.test.mjs
@@ -19,9 +19,9 @@ const GRAPH = {
 // What the `node_types` query action answers with: the typing verdict only,
 // derived server-side from /object_info so the browser never receives that payload.
 const NODE_TYPES = {
-  CLIPTextEncode: { output_node: false, text_inputs: ["text"], seed_inputs: [] },
-  KSampler: { output_node: false, text_inputs: [], seed_inputs: ["seed"] },
-  SaveImage: { output_node: true, text_inputs: [], seed_inputs: [] },
+  CLIPTextEncode: { output_node: false, text_inputs: ["text"], seed_inputs: [], image_inputs: [] },
+  KSampler: { output_node: false, text_inputs: [], seed_inputs: ["seed"], image_inputs: [] },
+  SaveImage: { output_node: true, text_inputs: [], seed_inputs: [], image_inputs: [] },
 };
 
 function pngWith(payload) {
@@ -181,4 +181,57 @@ test("model-loader inputs are offered as model-override candidates", () => {
   assert.deepEqual(splitCandidate(c.checkpoint[0].value), ["1", "unet_name"]);
   // weight_dtype is a widget too, but not a model input.
   assert.equal(c.checkpoint.length, 1);
+});
+
+test("upload widgets become reference candidates from server typing", () => {
+  // Qwen-Image-Edit shape: LoadImage (#103) feeds a scale node, which feeds both
+  // encoders. The reference always enters through the LoadImage widget — the
+  // encoder's image1 is a link and has no widget to patch.
+  const edit = {
+    103: { class_type: "LoadImage", inputs: { image: "woman-in-black.jpeg" }, _meta: { title: "Load Image" } },
+    93: { class_type: "ImageScaleToTotalPixels", inputs: { image: ["103", 0], megapixels: 1 } },
+    104: { class_type: "TextEncodeQwenImageEditPlus", inputs: { prompt: "", image1: ["93", 0] } },
+    3: { class_type: "KSampler", inputs: { seed: 1 } },
+    60: { class_type: "SaveImage", inputs: { images: ["8", 0] } },
+  };
+  const typing = {
+    LoadImage: { output_node: false, text_inputs: [], seed_inputs: [], image_inputs: ["image"] },
+    ImageScaleToTotalPixels: { output_node: false, text_inputs: [], seed_inputs: [], image_inputs: [] },
+    TextEncodeQwenImageEditPlus: { output_node: false, text_inputs: ["prompt"], seed_inputs: [], image_inputs: [] },
+    KSampler: { output_node: false, text_inputs: [], seed_inputs: ["seed"], image_inputs: [] },
+    SaveImage: { output_node: true, text_inputs: [], seed_inputs: [], image_inputs: [] },
+  };
+  const c = slotCandidates(edit, typing);
+  assert.equal(c.image.length, 1);
+  assert.deepEqual(splitCandidate(c.image[0].value), ["103", "image"]);
+  assert.equal(c.image[0].label, "Load Image (#103)");
+  // The scale node's `image` input is a link, so it is never offered.
+  assert.deepEqual(missingRoles(c), []);
+});
+
+test("the unreachable-server fallback still finds stock loaders", () => {
+  const edit = {
+    72: { class_type: "LoadImage", inputs: { image: "scene.png" } },
+    90: { class_type: "LoadImageMask", inputs: { image: "identity.png", channel: "red" } },
+    1: { class_type: "CLIPTextEncode", inputs: { text: "" } },
+    2: { class_type: "KSampler", inputs: { seed: 1 } },
+    3: { class_type: "SaveImage", inputs: { images: ["2", 0] } },
+  };
+  const c = slotCandidates(edit, {});
+  assert.deepEqual(
+    c.image.map((i) => splitCandidate(i.value)),
+    [
+      ["72", "image"],
+      ["90", "image"],
+    ],
+  );
+  // `channel` is a widget on the same node, but not an upload input.
+  assert.equal(c.image.length, 2);
+});
+
+test("a plain text-to-image graph yields no reference rows", () => {
+  // example.png's shape: nothing to map, so the importer renders exactly the five
+  // slots it always did and the stored slot map gains no `references` key.
+  assert.deepEqual(slotCandidates(GRAPH, NODE_TYPES).image, []);
+  assert.deepEqual(slotCandidates(GRAPH, {}).image, []);
 });

--- a/tests/frontend/image_gen_graph_import.test.mjs
+++ b/tests/frontend/image_gen_graph_import.test.mjs
@@ -47,33 +47,25 @@ test("refuses a graph too large for the config slot", () => {
   assert.throws(() => graphFromApiJson(JSON.stringify(huge)), /too large/);
 });
 
-// The cap is a UTF-8 byte count on the backend. Measuring JSON.stringify().length
-// here instead counted UTF-16 code units, so a CJK prompt weighed a third of what
-// the normalizer would weigh: the picker accepted the graph, the save silently
-// came back one workflow short.
-test("measures the size cap in UTF-8 bytes, not UTF-16 code units", () => {
-  const cjk = {
+// The picker must weigh a graph exactly as the normalizer does — UTF-8 bytes,
+// taken after `is_changed` is stripped. Measuring UTF-16 code units let a CJK
+// graph through at a third of its real size and the save came back one workflow
+// short; measuring before the strip bounced graphs the backend would have stored.
+test("measures the size cap the way the backend does", () => {
+  const cjk = JSON.stringify({
     1: { class_type: "CLIPTextEncode", inputs: { text: "幻想的な風景、細部まで描写された".repeat(12000) } },
     2: { class_type: "KSampler", inputs: { seed: 1 } },
     3: { class_type: "SaveImage", inputs: { images: ["2", 0] } },
-  };
-  const serialized = JSON.stringify(cjk);
-  assert.ok(serialized.length < 512_000, "precondition: under the cap when counted as UTF-16 code units");
-  assert.ok(new TextEncoder().encode(serialized).length > 512_000, "precondition: over the cap in real bytes");
-  assert.throws(() => graphFromApiJson(serialized), /too large/);
-});
+  });
+  assert.ok(cjk.length < 512_000 && new TextEncoder().encode(cjk).length > 512_000, "precondition: under in UTF-16, over in bytes");
+  assert.throws(() => graphFromApiJson(cjk), /too large/);
 
-// The backend strips `is_changed` before it measures, so measuring with the hashes
-// still attached bounced graphs the normalizer would have stored happily.
-test("strips is_changed before measuring, as the backend does", () => {
-  const node = (i) => ({ class_type: "LoadImage", inputs: { image: `${i}.png` }, is_changed: ["a".repeat(600)] });
   const graph = { 1: { class_type: "CLIPTextEncode", inputs: { text: "" } }, 2: { class_type: "KSampler", inputs: { seed: 1 } } };
-  for (let i = 3; i < 800; i++) graph[i] = node(i);
+  for (let i = 3; i < 800; i++) graph[i] = { class_type: "LoadImage", inputs: { image: `${i}.png` }, is_changed: ["a".repeat(600)] };
   assert.ok(JSON.stringify(graph).length > 512_000, "precondition: over the cap only because of is_changed");
-  const parsed = graphFromApiJson(JSON.stringify(graph));
   // Accepted, and the caller still gets the graph it passed in — the strip is for
   // measurement only, and the backend repeats it on arrival.
-  assert.deepEqual(parsed[3].is_changed, graph[3].is_changed);
+  assert.deepEqual(graphFromApiJson(JSON.stringify(graph))[3].is_changed, graph[3].is_changed);
 });
 
 test("builds explicit slot candidates", () => {
@@ -242,25 +234,17 @@ test("the unreachable-server fallback still finds stock loaders", () => {
   const edit = {
     72: { class_type: "LoadImage", inputs: { image: "scene.png" } },
     90: { class_type: "LoadImageMask", inputs: { image: "identity.png", channel: "red" } },
-    1: { class_type: "CLIPTextEncode", inputs: { text: "" } },
-    2: { class_type: "KSampler", inputs: { seed: 1 } },
-    3: { class_type: "SaveImage", inputs: { images: ["2", 0] } },
   };
-  const c = slotCandidates(edit, {});
+  // `channel` is a widget on the same node, but not an upload input.
   assert.deepEqual(
-    c.image.map((i) => splitCandidate(i.value)),
+    slotCandidates(edit, {}).image.map((i) => splitCandidate(i.value)),
     [
       ["72", "image"],
       ["90", "image"],
     ],
   );
-  // `channel` is a widget on the same node, but not an upload input.
-  assert.equal(c.image.length, 2);
-});
-
-test("a plain text-to-image graph yields no reference rows", () => {
-  // example.png's shape: nothing to map, so the importer renders exactly the five
-  // slots it always did and the stored slot map gains no `references` key.
+  // And example.png's shape has nothing to map, typed or not, so a plain
+  // text-to-image graph imports exactly the five slots it always did.
   assert.deepEqual(slotCandidates(GRAPH, NODE_TYPES).image, []);
   assert.deepEqual(slotCandidates(GRAPH, {}).image, []);
 });

--- a/tests/frontend/image_gen_graph_import.test.mjs
+++ b/tests/frontend/image_gen_graph_import.test.mjs
@@ -47,6 +47,35 @@ test("refuses a graph too large for the config slot", () => {
   assert.throws(() => graphFromApiJson(JSON.stringify(huge)), /too large/);
 });
 
+// The cap is a UTF-8 byte count on the backend. Measuring JSON.stringify().length
+// here instead counted UTF-16 code units, so a CJK prompt weighed a third of what
+// the normalizer would weigh: the picker accepted the graph, the save silently
+// came back one workflow short.
+test("measures the size cap in UTF-8 bytes, not UTF-16 code units", () => {
+  const cjk = {
+    1: { class_type: "CLIPTextEncode", inputs: { text: "幻想的な風景、細部まで描写された".repeat(12000) } },
+    2: { class_type: "KSampler", inputs: { seed: 1 } },
+    3: { class_type: "SaveImage", inputs: { images: ["2", 0] } },
+  };
+  const serialized = JSON.stringify(cjk);
+  assert.ok(serialized.length < 512_000, "precondition: under the cap when counted as UTF-16 code units");
+  assert.ok(new TextEncoder().encode(serialized).length > 512_000, "precondition: over the cap in real bytes");
+  assert.throws(() => graphFromApiJson(serialized), /too large/);
+});
+
+// The backend strips `is_changed` before it measures, so measuring with the hashes
+// still attached bounced graphs the normalizer would have stored happily.
+test("strips is_changed before measuring, as the backend does", () => {
+  const node = (i) => ({ class_type: "LoadImage", inputs: { image: `${i}.png` }, is_changed: ["a".repeat(600)] });
+  const graph = { 1: { class_type: "CLIPTextEncode", inputs: { text: "" } }, 2: { class_type: "KSampler", inputs: { seed: 1 } } };
+  for (let i = 3; i < 800; i++) graph[i] = node(i);
+  assert.ok(JSON.stringify(graph).length > 512_000, "precondition: over the cap only because of is_changed");
+  const parsed = graphFromApiJson(JSON.stringify(graph));
+  // Accepted, and the caller still gets the graph it passed in — the strip is for
+  // measurement only, and the backend repeats it on arrival.
+  assert.deepEqual(parsed[3].is_changed, graph[3].is_changed);
+});
+
 test("builds explicit slot candidates", () => {
   const candidates = slotCandidates(GRAPH, NODE_TYPES);
   assert.equal(candidates.text[0].label, "Positive (#1) — text");

--- a/tests/frontend/image_gen_render.test.mjs
+++ b/tests/frontend/image_gen_render.test.mjs
@@ -183,3 +183,39 @@ test("an image generated before the camera was recorded shows no camera row", ()
   const html = attachmentDetailsHtml({ consumption_metadata: { style_id: "anime" } }, "", MARKERS);
   assert.ok(!html.includes("<dt>Camera</dt>"));
 });
+
+test("a reference row names the slot, the source, and where the bytes came from", () => {
+  // A wrong reference is the failure a user needs traced, and the useful half of
+  // the origin is which *kind* of thing was fed in.
+  const html = attachmentDetailsHtml(
+    {
+      consumption_metadata: {
+        references: [
+          { slot: ["72", "image"], source: "previous_or_character", origin: "attachment:41" },
+          { slot: ["90", "image"], source: "character", origin: "character:card-1" },
+        ],
+      },
+    },
+    "",
+    MARKERS,
+  );
+  assert.ok(html.includes("<dt>Reference« #72»</dt>"));
+  assert.ok(html.includes("«previous image, else character reference — from a generated image in this chat»"));
+  assert.ok(html.includes("<dt>Reference« #90»</dt>"));
+  assert.ok(html.includes("«character reference — from the character»"));
+});
+
+test("an image rendered without references shows no reference row", () => {
+  const html = attachmentDetailsHtml({ consumption_metadata: { style_id: "anime" } }, "", MARKERS);
+  assert.ok(!html.includes("<dt>Reference"));
+});
+
+test("a hostile recorded reference is escaped like every other field", () => {
+  const html = attachmentDetailsHtml(
+    { consumption_metadata: { references: [{ slot: [HOSTILE, "image"], source: HOSTILE, origin: HOSTILE }] } },
+    "",
+    MARKERS,
+  );
+  // Everything inside markers went through esc(); nothing hostile may survive outside them.
+  assert.ok(!html.replaceAll(/«[^»]*»/gs, "").includes("<script>"));
+});

--- a/tests/frontend/image_gen_render.test.mjs
+++ b/tests/frontend/image_gen_render.test.mjs
@@ -203,11 +203,9 @@ test("a reference row names the slot, the source, and where the bytes came from"
   assert.ok(html.includes("«previous image, else character reference — from a generated image in this chat»"));
   assert.ok(html.includes("<dt>Reference« #90»</dt>"));
   assert.ok(html.includes("«character reference — from the character»"));
-});
 
-test("an image rendered without references shows no reference row", () => {
-  const html = attachmentDetailsHtml({ consumption_metadata: { style_id: "anime" } }, "", MARKERS);
-  assert.ok(!html.includes("<dt>Reference"));
+  // A workflow with no reference slots records none, so the row is omitted.
+  assert.ok(!attachmentDetailsHtml({ consumption_metadata: { style_id: "anime" } }, "", MARKERS).includes("<dt>Reference"));
 });
 
 test("a hostile recorded reference is escaped like every other field", () => {

--- a/tests/unit/workflows/image_gen/test_comfy_client.py
+++ b/tests/unit/workflows/image_gen/test_comfy_client.py
@@ -169,13 +169,12 @@ async def test_unavailable_queue_endpoint_does_not_fail_the_render():
 
 @pytest.mark.asyncio
 async def test_reference_upload_posts_multipart_and_returns_the_widget_value():
-    seen: dict[str, object] = {}
+    seen: dict[str, str] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/upload/image"
-        seen["auth"] = request.headers.get("authorization")
-        body = request.content.decode("latin-1")
-        seen["body"] = body
+        seen["auth"] = request.headers.get("authorization") or ""
+        seen["body"] = request.content.decode("latin-1")
         return httpx.Response(200, json={"name": "orb_0123456789abcdef.webp", "subfolder": "orb", "type": "input"})
 
     client = ComfyClient("http://comfy.test", "sekrit", transport=httpx.MockTransport(handler))
@@ -185,7 +184,7 @@ async def test_reference_upload_posts_multipart_and_returns_the_widget_value():
     # under the input directory, which is what the LoadImage widget must carry.
     assert value == "orb/orb_0123456789abcdef.webp"
     assert seen["auth"] == "Bearer sekrit"
-    body = str(seen["body"])
+    body = seen["body"]
     assert 'name="image"; filename="orb_0123456789abcdef.webp"' in body
     assert 'name="subfolder"' in body and "orb" in body
     assert 'name="type"' in body and "input" in body

--- a/tests/unit/workflows/image_gen/test_comfy_client.py
+++ b/tests/unit/workflows/image_gen/test_comfy_client.py
@@ -168,6 +168,40 @@ async def test_unavailable_queue_endpoint_does_not_fail_the_render():
 
 
 @pytest.mark.asyncio
+async def test_reference_upload_posts_multipart_and_returns_the_widget_value():
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/upload/image"
+        seen["auth"] = request.headers.get("authorization")
+        body = request.content.decode("latin-1")
+        seen["body"] = body
+        return httpx.Response(200, json={"name": "orb_0123456789abcdef.webp", "subfolder": "orb", "type": "input"})
+
+    client = ComfyClient("http://comfy.test", "sekrit", transport=httpx.MockTransport(handler))
+    value = await client.upload_image(b"RIFFxxxxWEBP", "image/webp", digest="0123456789abcdef" + "f" * 48)
+
+    # `folder_paths.get_annotated_filepath` resolves a bare "<subfolder>/<name>"
+    # under the input directory, which is what the LoadImage widget must carry.
+    assert value == "orb/orb_0123456789abcdef.webp"
+    assert seen["auth"] == "Bearer sekrit"
+    body = str(seen["body"])
+    assert 'name="image"; filename="orb_0123456789abcdef.webp"' in body
+    assert 'name="subfolder"' in body and "orb" in body
+    assert 'name="type"' in body and "input" in body
+    # ComfyUI compares `overwrite` against the strings "true"/"1"; a bool would
+    # silently mean "no" and leave a new file behind on every render.
+    assert 'name="overwrite"' in body and "true" in body
+
+
+@pytest.mark.asyncio
+async def test_a_refused_reference_upload_funnels_through_the_one_error_type():
+    client = ComfyClient("http://comfy.test", transport=httpx.MockTransport(lambda _: httpx.Response(413)))
+    with pytest.raises(ImageGenerationError, match="reference image"):
+        await client.upload_image(b"x", "image/png", digest="a" * 64)
+
+
+@pytest.mark.asyncio
 async def test_malformed_queue_entries_are_ignored():
     client = ComfyClient(
         "http://comfy.test",

--- a/tests/unit/workflows/image_gen/test_config.py
+++ b/tests/unit/workflows/image_gen/test_config.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from backend.workflows.image_gen.config import (
     DEFAULT_PROMPT_FORMAT,
+    MAX_REFERENCE_IMAGE_B64,
+    MAX_REFERENCE_SLOTS,
     MAX_USER_GRAPHS,
     PROMPT_FORMATS,
     normalize_config,
+    normalize_profile,
     resolve_style,
 )
 from backend.workflows.image_gen.hooks import fold_seed
@@ -130,3 +133,101 @@ def test_a_style_naming_the_removed_core_graph_migrates_to_unconfigured():
 def test_default_style_falls_back_when_it_no_longer_resolves():
     cfg = normalize_config({"default_style": "deleted", "external_comfy": {"styles": [{"id": "only", "label": "Only"}]}})
     assert cfg["default_style"] == "only"
+
+
+# ── reference slots ──────────────────────────────────────────────────────────
+
+_BASE_SLOTS = {"positive": ["0", "text"], "seed": ["s", "seed"], "output": ["o", "images"]}
+
+
+def _stored(user_graph: dict) -> dict:
+    return normalize_config({"external_comfy": {"user_graphs": [user_graph]}})["external_comfy"]["user_graphs"][0]
+
+
+def test_reference_slots_survive_normalization():
+    stored = _stored(
+        _user_graph(
+            slots={
+                **_BASE_SLOTS,
+                "references": [
+                    {"slot": ["72", "image"], "source": "previous_or_character", "label": "Load Image (#72)"},
+                    {"slot": [90, "image"], "source": "character"},
+                ],
+            }
+        )
+    )
+    assert stored["slots"]["references"][0] == {
+        "slot": ["72", "image"],
+        "source": "previous_or_character",
+        "label": "Load Image (#72)",
+    }
+    # A numeric node id normalizes to a string, and a missing label gets a usable one.
+    assert stored["slots"]["references"][1]["slot"] == ["90", "image"]
+    assert stored["slots"]["references"][1]["label"]
+
+
+def test_an_unknown_reference_source_is_dropped_not_stored():
+    stored = _stored(
+        _user_graph(
+            slots={
+                **_BASE_SLOTS,
+                "references": [
+                    {"slot": ["72", "image"], "source": "whatever_the_user_typed"},
+                    {"slot": ["90", "image"], "source": "character"},
+                ],
+            }
+        )
+    )
+    assert [r["slot"] for r in stored["slots"]["references"]] == [["90", "image"]]
+
+
+def test_reference_slots_are_capped():
+    references = [{"slot": [str(i), "image"], "source": "character"} for i in range(MAX_REFERENCE_SLOTS + 3)]
+    stored = _stored(_user_graph(slots={**_BASE_SLOTS, "references": references}))
+    assert len(stored["slots"]["references"]) == MAX_REFERENCE_SLOTS
+
+
+def test_a_graph_with_no_references_round_trips_unchanged():
+    """A plain text-to-image graph must normalize exactly as it did before
+    references existed -- no empty key introduced into its slot map."""
+    stored = _stored(_user_graph(slots=dict(_BASE_SLOTS)))
+    assert stored["slots"] == _BASE_SLOTS
+    assert "references" not in stored["slots"]
+
+
+def test_is_changed_is_stripped_from_every_node_at_import():
+    """ComfyUI's API export embeds `is_changed` -- for a LoadImage node, a hash of
+    the file on the exporter's disk. IsChangedCache returns a client-supplied value
+    verbatim instead of computing the real one, so a stored hash makes ComfyUI miss
+    a file whose *contents* changed under an unchanged path and hand back the
+    previously decoded image. Machine-local state about another machine's disk has
+    no business in a stored graph regardless."""
+    graph = _graph()
+    graph["0"]["is_changed"] = ["b80d1d64deadbeef"]
+    graph["s"]["is_changed"] = ["another"]
+    stored = _stored({"id": "user_a", "label": "a", "graph": graph, "slots": dict(_BASE_SLOTS)})
+    assert all("is_changed" not in node for node in stored["graph"].values())
+    # Only the machine-local key goes; the node itself is intact.
+    assert stored["graph"]["0"]["inputs"]["text"]
+
+
+# ── per-character reference image ────────────────────────────────────────────
+
+
+def test_a_character_reference_image_needs_both_halves():
+    profile = normalize_profile({"reference_image_b64": "aGk=", "reference_mime": "image/png"})
+    assert (profile["reference_image_b64"], profile["reference_mime"]) == ("aGk=", "image/png")
+
+    # A payload Orb cannot tell ComfyUI how to read is not a reference.
+    assert normalize_profile({"reference_image_b64": "aGk=", "reference_mime": "text/plain"})["reference_image_b64"] == ""
+    assert normalize_profile({"reference_image_b64": "aGk="})["reference_image_b64"] == ""
+    # ...and a mime with no bytes is not a half-set field either.
+    assert normalize_profile({"reference_mime": "image/png"})["reference_mime"] == ""
+
+
+def test_an_oversized_reference_image_is_dropped_rather_than_truncated():
+    """Half a base64 payload is not a smaller image, it is a corrupt one -- and
+    this profile is read on every generate."""
+    oversized = "A" * (MAX_REFERENCE_IMAGE_B64 + 1)
+    profile = normalize_profile({"reference_image_b64": oversized, "reference_mime": "image/png"})
+    assert (profile["reference_image_b64"], profile["reference_mime"]) == ("", "")

--- a/tests/unit/workflows/image_gen/test_config.py
+++ b/tests/unit/workflows/image_gen/test_config.py
@@ -144,47 +144,30 @@ def _stored(user_graph: dict) -> dict:
     return normalize_config({"external_comfy": {"user_graphs": [user_graph]}})["external_comfy"]["user_graphs"][0]
 
 
+def _references(*entries: dict) -> dict:
+    return _stored(_user_graph(slots={**_BASE_SLOTS, "references": list(entries)}))["slots"].get("references", [])
+
+
 def test_reference_slots_survive_normalization():
-    stored = _stored(
-        _user_graph(
-            slots={
-                **_BASE_SLOTS,
-                "references": [
-                    {"slot": ["72", "image"], "source": "previous_or_character", "label": "Load Image (#72)"},
-                    {"slot": [90, "image"], "source": "character"},
-                ],
-            }
-        )
+    stored = _references(
+        {"slot": ["72", "image"], "source": "previous_or_character", "label": "Load Image (#72)"},
+        {"slot": [90, "image"], "source": "character"},
     )
-    assert stored["slots"]["references"][0] == {
-        "slot": ["72", "image"],
-        "source": "previous_or_character",
-        "label": "Load Image (#72)",
-    }
+    assert stored[0] == {"slot": ["72", "image"], "source": "previous_or_character", "label": "Load Image (#72)"}
     # A numeric node id normalizes to a string, and a missing label gets a usable one.
-    assert stored["slots"]["references"][1]["slot"] == ["90", "image"]
-    assert stored["slots"]["references"][1]["label"]
+    assert stored[1]["slot"] == ["90", "image"]
+    assert stored[1]["label"]
 
 
-def test_an_unknown_reference_source_is_dropped_not_stored():
-    stored = _stored(
-        _user_graph(
-            slots={
-                **_BASE_SLOTS,
-                "references": [
-                    {"slot": ["72", "image"], "source": "whatever_the_user_typed"},
-                    {"slot": ["90", "image"], "source": "character"},
-                ],
-            }
-        )
+def test_unstorable_reference_slots_are_dropped_and_the_rest_capped():
+    unknown = _references(
+        {"slot": ["72", "image"], "source": "whatever_the_user_typed"},
+        {"slot": ["90", "image"], "source": "character"},
     )
-    assert [r["slot"] for r in stored["slots"]["references"]] == [["90", "image"]]
+    assert [r["slot"] for r in unknown] == [["90", "image"]]
 
-
-def test_reference_slots_are_capped():
-    references = [{"slot": [str(i), "image"], "source": "character"} for i in range(MAX_REFERENCE_SLOTS + 3)]
-    stored = _stored(_user_graph(slots={**_BASE_SLOTS, "references": references}))
-    assert len(stored["slots"]["references"]) == MAX_REFERENCE_SLOTS
+    entries = [{"slot": [str(i), "image"], "source": "character"} for i in range(MAX_REFERENCE_SLOTS + 3)]
+    assert len(_references(*entries)) == MAX_REFERENCE_SLOTS
 
 
 def test_a_graph_with_no_references_round_trips_unchanged():
@@ -196,12 +179,9 @@ def test_a_graph_with_no_references_round_trips_unchanged():
 
 
 def test_is_changed_is_stripped_from_every_node_at_import():
-    """ComfyUI's API export embeds `is_changed` -- for a LoadImage node, a hash of
-    the file on the exporter's disk. IsChangedCache returns a client-supplied value
-    verbatim instead of computing the real one, so a stored hash makes ComfyUI miss
-    a file whose *contents* changed under an unchanged path and hand back the
-    previously decoded image. Machine-local state about another machine's disk has
-    no business in a stored graph regardless."""
+    """A client-supplied `is_changed` is returned verbatim by IsChangedCache, so a
+    hash of the exporter's disk makes ComfyUI miss a file whose *contents* changed
+    under an unchanged path and hand back the previously decoded image."""
     graph = _graph()
     graph["0"]["is_changed"] = ["b80d1d64deadbeef"]
     graph["s"]["is_changed"] = ["another"]
@@ -214,20 +194,18 @@ def test_is_changed_is_stripped_from_every_node_at_import():
 # ── per-character reference image ────────────────────────────────────────────
 
 
-def test_a_character_reference_image_needs_both_halves():
-    profile = normalize_profile({"reference_image_b64": "aGk=", "reference_mime": "image/png"})
-    assert (profile["reference_image_b64"], profile["reference_mime"]) == ("aGk=", "image/png")
+def test_a_character_reference_image_survives_only_with_both_halves():
+    """Bytes Orb cannot tell ComfyUI how to read are not a reference, a mime with
+    no bytes is not a half-set field, and an oversized payload is dropped rather
+    than truncated -- half a base64 payload is a corrupt image, not a smaller one."""
+    kept = normalize_profile({"reference_image_b64": "aGk=", "reference_mime": "image/png"})
+    assert (kept["reference_image_b64"], kept["reference_mime"]) == ("aGk=", "image/png")
 
-    # A payload Orb cannot tell ComfyUI how to read is not a reference.
-    assert normalize_profile({"reference_image_b64": "aGk=", "reference_mime": "text/plain"})["reference_image_b64"] == ""
-    assert normalize_profile({"reference_image_b64": "aGk="})["reference_image_b64"] == ""
-    # ...and a mime with no bytes is not a half-set field either.
-    assert normalize_profile({"reference_mime": "image/png"})["reference_mime"] == ""
-
-
-def test_an_oversized_reference_image_is_dropped_rather_than_truncated():
-    """Half a base64 payload is not a smaller image, it is a corrupt one -- and
-    this profile is read on every generate."""
-    oversized = "A" * (MAX_REFERENCE_IMAGE_B64 + 1)
-    profile = normalize_profile({"reference_image_b64": oversized, "reference_mime": "image/png"})
-    assert (profile["reference_image_b64"], profile["reference_mime"]) == ("", "")
+    for raw in (
+        {"reference_image_b64": "aGk=", "reference_mime": "text/plain"},
+        {"reference_image_b64": "aGk="},
+        {"reference_mime": "image/png"},
+        {"reference_image_b64": "A" * (MAX_REFERENCE_IMAGE_B64 + 1), "reference_mime": "image/png"},
+    ):
+        profile = normalize_profile(raw)
+        assert (profile["reference_image_b64"], profile["reference_mime"]) == ("", "")

--- a/tests/unit/workflows/image_gen/test_display_encode.py
+++ b/tests/unit/workflows/image_gen/test_display_encode.py
@@ -32,24 +32,17 @@ def test_non_image_bytes_pass_through_untouched():
 
 
 def test_a_normal_reference_is_uploaded_byte_for_byte():
-    """Identity-edit workflows are exactly the ones that lose face detail to a
-    downscale, so the cap only exists to stop a 12 MP phone upload -- a render or
-    an avatar must reach ComfyUI untouched."""
+    """Identity-edit workflows are the ones that lose face detail to a downscale,
+    so the cap only exists to stop a 12 MP phone upload."""
     src = _png(1024, 1536)
     assert normalize_reference(src, "image/png") == (src, "image/png")
+    # And a reference Orb cannot read is still one ComfyUI probably can.
+    assert normalize_reference(b"not an image", "image/png") == (b"not an image", "image/png")
 
 
 def test_an_oversized_reference_is_bounded():
-    src = _png(5000, 3000)
-    out, mime = normalize_reference(src, "image/png")
+    out, mime = normalize_reference(_png(5000, 3000), "image/png")
     assert mime == "image/webp"
     with Image.open(io.BytesIO(out)) as img:
         assert max(img.size) == 4096
         assert abs(img.size[0] / img.size[1] - 5000 / 3000) < 0.01  # aspect preserved
-
-
-def test_a_reference_that_cannot_be_re_encoded_is_sent_as_is():
-    """A reference Orb cannot read is still one ComfyUI probably can, so failure
-    here degrades rather than sinking the generation."""
-    junk = b"not an image"
-    assert normalize_reference(junk, "image/png") == (junk, "image/png")

--- a/tests/unit/workflows/image_gen/test_display_encode.py
+++ b/tests/unit/workflows/image_gen/test_display_encode.py
@@ -2,7 +2,10 @@ import io
 
 from PIL import Image
 
-from backend.workflows.image_gen.engine.display_encode import shrink_for_display
+from backend.workflows.image_gen.engine.display_encode import (
+    normalize_reference,
+    shrink_for_display,
+)
 
 
 def _png(w, h):
@@ -26,3 +29,27 @@ def test_reencodes_to_webp_at_full_resolution():
 def test_non_image_bytes_pass_through_untouched():
     junk = b"not an image"
     assert shrink_for_display(junk, "image/png") == (junk, "image/png")
+
+
+def test_a_normal_reference_is_uploaded_byte_for_byte():
+    """Identity-edit workflows are exactly the ones that lose face detail to a
+    downscale, so the cap only exists to stop a 12 MP phone upload -- a render or
+    an avatar must reach ComfyUI untouched."""
+    src = _png(1024, 1536)
+    assert normalize_reference(src, "image/png") == (src, "image/png")
+
+
+def test_an_oversized_reference_is_bounded():
+    src = _png(5000, 3000)
+    out, mime = normalize_reference(src, "image/png")
+    assert mime == "image/webp"
+    with Image.open(io.BytesIO(out)) as img:
+        assert max(img.size) == 4096
+        assert abs(img.size[0] / img.size[1] - 5000 / 3000) < 0.01  # aspect preserved
+
+
+def test_a_reference_that_cannot_be_re_encoded_is_sent_as_is():
+    """A reference Orb cannot read is still one ComfyUI probably can, so failure
+    here degrades rather than sinking the generation."""
+    junk = b"not an image"
+    assert normalize_reference(junk, "image/png") == (junk, "image/png")

--- a/tests/unit/workflows/image_gen/test_external_adapter.py
+++ b/tests/unit/workflows/image_gen/test_external_adapter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 
@@ -176,6 +178,117 @@ async def test_node_roles_type_slots_from_object_info_and_skip_unknown_classes(m
     assert roles["KSampler"]["seed_inputs"] == ["seed"]
     assert roles["SaveImage"]["output_node"] is True
     assert "Nope" not in roles
+
+
+@pytest.mark.asyncio
+async def test_node_roles_type_upload_widgets_off_the_image_upload_flag(monkeypatch):
+    """An upload widget's declared type is the *combo* of files already in the
+    server's input directory, so no string-kind comparison can find it; the
+    `image_upload` flag is the typing rule."""
+    info = {
+        "LoadImage": {
+            "input": {
+                "required": {"image": [["a.png", "b.png"], {"image_upload": True}]},
+                "optional": {"channel": [["red", "green"], {}]},
+            }
+        },
+        "CheckpointLoaderSimple": {"input": {"required": {"ckpt_name": [["m.safetensors"], {}]}}},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=info)
+
+    _install_client(monkeypatch, handler)
+    invalidate_object_info()
+    roles = await external_comfy.node_roles(normalize_config({}), ["LoadImage", "CheckpointLoaderSimple"])
+
+    assert roles["LoadImage"]["image_inputs"] == ["image"]
+    # A plain combo (`channel`, `ckpt_name`) is a fixed menu, not an upload slot.
+    assert roles["CheckpointLoaderSimple"]["image_inputs"] == []
+
+
+EDIT_USER_GRAPH = {
+    "id": "user_edit",
+    "label": "Edit",
+    "graph": {
+        "1": {"class_type": "LoadImage", "inputs": {"image": "exported-from-another-machine.png"}},
+        "2": {"class_type": "CLIPTextEncode", "inputs": {"text": ""}},
+        "3": {"class_type": "KSampler", "inputs": {"seed": 0}},
+        "4": {"class_type": "SaveImage", "inputs": {"images": ["3", 0]}},
+    },
+    "slots": {
+        "positive": ["2", "text"],
+        "seed": ["3", "seed"],
+        "output": ["4", "images"],
+        "references": [{"slot": ["1", "image"], "source": "character", "label": "Load Image (#1)"}],
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_generate_uploads_each_reference_once_and_patches_the_widget(monkeypatch):
+    from backend.workflows.image_gen.engine.contracts import (
+        ImageRequest,
+        ResolvedReference,
+    )
+
+    uploads: list[str] = []
+    submitted: dict = {}
+    png = b"\x89PNG\r\n\x1a\n" + b"out"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/upload/image":
+            uploads.append(request.content.decode("latin-1"))
+            return httpx.Response(200, json={"name": "orb_deadbeefdeadbeef.png", "subfolder": "orb", "type": "input"})
+        if path == "/prompt":
+            submitted.update(json.loads(request.content))
+            return httpx.Response(200, json={"prompt_id": "p1", "number": 1})
+        if path == "/queue":
+            return httpx.Response(200, json={"queue_running": [], "queue_pending": []})
+        if path == "/history/p1":
+            return httpx.Response(
+                200,
+                json={
+                    "p1": {
+                        "status": {"completed": True},
+                        "outputs": {"4": {"images": [{"filename": "x.png", "subfolder": "", "type": "output"}]}},
+                    }
+                },
+            )
+        if path == "/view":
+            return httpx.Response(200, content=png, headers={"content-type": "image/png"})
+        return httpx.Response(404)
+
+    _install_client(monkeypatch, handler)
+    config = normalize_config(
+        {"external_comfy": {"user_graphs": [EDIT_USER_GRAPH], "styles": [{"id": "s", "label": "S", "workflow": "user_edit"}]}}
+    )
+    reference = ResolvedReference(
+        slot=("1", "image"),
+        source="character",
+        data=b"\x89PNG\r\n\x1a\n" + b"ref",
+        mime="image/png",
+        origin="character:card-1",
+        digest="deadbeefdeadbeef" + "0" * 48,
+    )
+    request = ImageRequest(
+        prompt="p",
+        negative_prompt="",
+        seed=1,
+        style_id="s",
+        timeout_seconds=5,
+        # Two slots, one image: the adapter must upload once.
+        references=(reference, ResolvedReference(**{**reference.__dict__, "slot": ("1", "image")})),
+    )
+
+    result = await external_comfy.generate(config, request, checkpoint="", graph_id="user_edit")
+
+    assert len(uploads) == 1
+    assert submitted["prompt"]["1"]["inputs"]["image"] == "orb/orb_deadbeefdeadbeef.png"
+    # The replay record names where the bytes came from, not just what was sent.
+    assert result.backend_info["references"][0]["origin"] == "character:card-1"
+    assert result.backend_info["references"][0]["comfy_name"] == "orb/orb_deadbeefdeadbeef.png"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/image_gen/test_external_adapter.py
+++ b/tests/unit/workflows/image_gen/test_external_adapter.py
@@ -194,11 +194,7 @@ async def test_node_roles_type_upload_widgets_off_the_image_upload_flag(monkeypa
         },
         "CheckpointLoaderSimple": {"input": {"required": {"ckpt_name": [["m.safetensors"], {}]}}},
     }
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json=info)
-
-    _install_client(monkeypatch, handler)
+    _install_client(monkeypatch, lambda _request: httpx.Response(200, json=info))
     invalidate_object_info()
     roles = await external_comfy.node_roles(normalize_config({}), ["LoadImage", "CheckpointLoaderSimple"])
 
@@ -207,20 +203,14 @@ async def test_node_roles_type_upload_widgets_off_the_image_upload_flag(monkeypa
     assert roles["CheckpointLoaderSimple"]["image_inputs"] == []
 
 
+# USER_GRAPH plus a LoadImage pinning a filename from the exporting machine.
 EDIT_USER_GRAPH = {
+    **USER_GRAPH,
     "id": "user_edit",
-    "label": "Edit",
-    "graph": {
-        "1": {"class_type": "LoadImage", "inputs": {"image": "exported-from-another-machine.png"}},
-        "2": {"class_type": "CLIPTextEncode", "inputs": {"text": ""}},
-        "3": {"class_type": "KSampler", "inputs": {"seed": 0}},
-        "4": {"class_type": "SaveImage", "inputs": {"images": ["3", 0]}},
-    },
+    "graph": {**USER_GRAPH["graph"], "0": {"class_type": "LoadImage", "inputs": {"image": "exported-elsewhere.png"}}},
     "slots": {
-        "positive": ["2", "text"],
-        "seed": ["3", "seed"],
-        "output": ["4", "images"],
-        "references": [{"slot": ["1", "image"], "source": "character", "label": "Load Image (#1)"}],
+        **USER_GRAPH["slots"],
+        "references": [{"slot": ["0", "image"], "source": "character", "label": "Load Image (#0)"}],
     },
 }
 
@@ -234,38 +224,28 @@ async def test_generate_uploads_each_reference_once_and_patches_the_widget(monke
 
     uploads: list[str] = []
     submitted: dict = {}
-    png = b"\x89PNG\r\n\x1a\n" + b"out"
+    outputs = {"4": {"images": [{"filename": "x.png", "subfolder": "", "type": "output"}]}}
+    responses = {
+        "/prompt": httpx.Response(200, json={"prompt_id": "p1", "number": 1}),
+        "/queue": httpx.Response(200, json={"queue_running": [], "queue_pending": []}),
+        "/history/p1": httpx.Response(200, json={"p1": {"status": {"completed": True}, "outputs": outputs}}),
+        "/view": httpx.Response(200, content=b"\x89PNG\r\n\x1a\n" + b"out", headers={"content-type": "image/png"}),
+    }
 
     def handler(request: httpx.Request) -> httpx.Response:
-        path = request.url.path
-        if path == "/upload/image":
+        if request.url.path == "/upload/image":
             uploads.append(request.content.decode("latin-1"))
             return httpx.Response(200, json={"name": "orb_deadbeefdeadbeef.png", "subfolder": "orb", "type": "input"})
-        if path == "/prompt":
+        if request.url.path == "/prompt":
             submitted.update(json.loads(request.content))
-            return httpx.Response(200, json={"prompt_id": "p1", "number": 1})
-        if path == "/queue":
-            return httpx.Response(200, json={"queue_running": [], "queue_pending": []})
-        if path == "/history/p1":
-            return httpx.Response(
-                200,
-                json={
-                    "p1": {
-                        "status": {"completed": True},
-                        "outputs": {"4": {"images": [{"filename": "x.png", "subfolder": "", "type": "output"}]}},
-                    }
-                },
-            )
-        if path == "/view":
-            return httpx.Response(200, content=png, headers={"content-type": "image/png"})
-        return httpx.Response(404)
+        return responses.get(request.url.path, httpx.Response(404))
 
     _install_client(monkeypatch, handler)
     config = normalize_config(
         {"external_comfy": {"user_graphs": [EDIT_USER_GRAPH], "styles": [{"id": "s", "label": "S", "workflow": "user_edit"}]}}
     )
     reference = ResolvedReference(
-        slot=("1", "image"),
+        slot=("0", "image"),
         source="character",
         data=b"\x89PNG\r\n\x1a\n" + b"ref",
         mime="image/png",
@@ -279,13 +259,13 @@ async def test_generate_uploads_each_reference_once_and_patches_the_widget(monke
         style_id="s",
         timeout_seconds=5,
         # Two slots, one image: the adapter must upload once.
-        references=(reference, ResolvedReference(**{**reference.__dict__, "slot": ("1", "image")})),
+        references=(reference, reference),
     )
 
     result = await external_comfy.generate(config, request, checkpoint="", graph_id="user_edit")
 
     assert len(uploads) == 1
-    assert submitted["prompt"]["1"]["inputs"]["image"] == "orb/orb_deadbeefdeadbeef.png"
+    assert submitted["prompt"]["0"]["inputs"]["image"] == "orb/orb_deadbeefdeadbeef.png"
     # The replay record names where the bytes came from, not just what was sent.
     assert result.backend_info["references"][0]["origin"] == "character:card-1"
     assert result.backend_info["references"][0]["comfy_name"] == "orb/orb_deadbeefdeadbeef.png"

--- a/tests/unit/workflows/image_gen/test_graph.py
+++ b/tests/unit/workflows/image_gen/test_graph.py
@@ -64,7 +64,18 @@ OBJECT_INFO = {
     "EmptyLatentImage": {"input": {"required": {"width": ["INT", {}], "height": ["INT", {}]}}},
     "VAEDecode": {"input": {"required": {}}},
     "SaveImage": {"input": {"required": {"images": ["IMAGE"]}}, "output_node": True},
+    # The real shape of an upload widget: a combo of the server's input directory
+    # plus the `image_upload` flag that types it as a reference slot.
+    "LoadImage": {"input": {"required": {"image": [["already-there.png"], {"image_upload": True}]}}},
 }
+
+
+def _with_reference():
+    """The core graph plus a LoadImage carrying a filename from another machine."""
+    graph, slots = _core()
+    graph["11"] = {"class_type": "LoadImage", "inputs": {"image": "woman-in-black.jpeg"}}
+    slots["references"] = [{"slot": ["11", "image"], "source": "character", "label": "Load Image (#11)"}]
+    return graph, slots
 
 
 def _core():
@@ -175,6 +186,50 @@ def test_validation_requires_the_output_slot_to_name_a_present_node():
     graph, slots = _core()
     slots["output"] = ["999", "images"]
     with pytest.raises(ImageGenerationError, match="no configured output node"):
+        validate_graph_structure(graph, slots, OBJECT_INFO)
+
+
+# ── reference images ─────────────────────────────────────────────────────────
+
+
+def test_a_reference_slot_is_patched_with_the_uploaded_widget_value():
+    graph, slots = _with_reference()
+    patched, _ = patch_graph(
+        graph,
+        slots,
+        prompt="p",
+        negative_prompt="n",
+        seed=1,
+        checkpoint="model.safetensors",
+        references=[(("11", "image"), "orb/orb_abc123.webp")],
+    )
+    assert patched["11"]["inputs"]["image"] == "orb/orb_abc123.webp"
+    # The original is untouched, as it is for every other patched slot.
+    assert graph["11"]["inputs"]["image"] == "woman-in-black.jpeg"
+
+
+def test_a_mapped_reference_is_exempt_from_the_combo_membership_check():
+    """The widget value is replaced per render with a file this server does not
+    have yet, so its membership in the input-directory listing means nothing.
+    Without the exemption, Test connection rejects every edit workflow."""
+    graph, slots = _with_reference()
+    validate_graph_structure(graph, slots, OBJECT_INFO)
+
+
+def test_an_unmapped_image_input_says_how_to_fix_it():
+    # "no longer available on this server" reads as a broken install; for a
+    # filename the actionable answer is to upload it there or map the slot.
+    graph, slots = _with_reference()
+    slots.pop("references")
+    with pytest.raises(ImageGenerationError, match="map it as a reference image"):
+        validate_graph_structure(graph, slots, OBJECT_INFO)
+
+
+def test_a_dangling_reference_slot_is_caught_at_test_connection():
+    """Otherwise it only surfaces mid-render, after the upload and a queue wait."""
+    graph, slots = _with_reference()
+    slots["references"].append({"slot": ["999", "image"], "source": "character", "label": "Gone"})
+    with pytest.raises(ImageGenerationError, match="reference image slot points to a missing node"):
         validate_graph_structure(graph, slots, OBJECT_INFO)
 
 

--- a/tests/unit/workflows/image_gen/test_graph.py
+++ b/tests/unit/workflows/image_gen/test_graph.py
@@ -70,14 +70,6 @@ OBJECT_INFO = {
 }
 
 
-def _with_reference():
-    """The core graph plus a LoadImage carrying a filename from another machine."""
-    graph, slots = _core()
-    graph["11"] = {"class_type": "LoadImage", "inputs": {"image": "woman-in-black.jpeg"}}
-    slots["references"] = [{"slot": ["11", "image"], "source": "character", "label": "Load Image (#11)"}]
-    return graph, slots
-
-
 def _core():
     """A representative imported graph with a checkpoint filled in, as a real submission has."""
     graph = _base_graph()
@@ -192,6 +184,14 @@ def test_validation_requires_the_output_slot_to_name_a_present_node():
 # ── reference images ─────────────────────────────────────────────────────────
 
 
+def _with_reference():
+    """The core graph plus a LoadImage carrying a filename from another machine."""
+    graph, slots = _core()
+    graph["11"] = {"class_type": "LoadImage", "inputs": {"image": "woman-in-black.jpeg"}}
+    slots["references"] = [{"slot": ["11", "image"], "source": "character", "label": "Load Image (#11)"}]
+    return graph, slots
+
+
 def test_a_reference_slot_is_patched_with_the_uploaded_widget_value():
     graph, slots = _with_reference()
     patched, _ = patch_graph(
@@ -212,8 +212,7 @@ def test_a_mapped_reference_is_exempt_from_the_combo_membership_check():
     """The widget value is replaced per render with a file this server does not
     have yet, so its membership in the input-directory listing means nothing.
     Without the exemption, Test connection rejects every edit workflow."""
-    graph, slots = _with_reference()
-    validate_graph_structure(graph, slots, OBJECT_INFO)
+    validate_graph_structure(*_with_reference(), OBJECT_INFO)
 
 
 def test_an_unmapped_image_input_says_how_to_fix_it():

--- a/tests/unit/workflows/image_gen/test_references.py
+++ b/tests/unit/workflows/image_gen/test_references.py
@@ -1,0 +1,266 @@
+"""Which image an edit workflow's `LoadImage` slot actually gets fed.
+
+The failure this guards is silent and expensive: a reference resolved off the
+wrong row produces a picture of the wrong person, which reads as a bad model
+rather than a bad lookup. So the walk-back rules -- active sibling, evicted rows,
+the excluded anchor -- are pinned here rather than left to the end-to-end path.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from backend.workflows.image_gen import references as refs
+from backend.workflows.image_gen.engine.contracts import ImageGenerationError
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"first"
+OTHER = b"\x89PNG\r\n\x1a\n" + b"second"
+AVATAR = b"\x89PNG\r\n\x1a\n" + b"avatar"
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode()
+
+
+def _gen(att_id: int, data: bytes = PNG, **extra) -> dict:
+    return {
+        "id": att_id,
+        "workflow_id": "image_gen",
+        "mime_type": "image/png",
+        "data_b64": _b64(data),
+        "parent_attachment_id": None,
+        "active_sibling_id": None,
+        **extra,
+    }
+
+
+def _msg(msg_id: int, *, workflow=(), user=()) -> dict:
+    return {"id": msg_id, "workflow_attachments": list(workflow), "user_attachments": list(user)}
+
+
+def _slots(source: str = "previous", node: str = "72") -> dict:
+    return {"references": [{"slot": [node, "image"], "source": source, "label": f"Load Image (#{node})"}]}
+
+
+@pytest.fixture(autouse=True)
+def _no_db(monkeypatch):
+    """Nothing here should reach the database unless a test says so."""
+
+    async def unavailable(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(refs, "get_character_avatar", unavailable)
+    monkeypatch.setattr(refs, "get_workflow_character_state", unavailable)
+
+
+@pytest.mark.asyncio
+async def test_no_mapped_slots_resolves_to_nothing():
+    """A plain text-to-image graph must not pay for any of this."""
+    assert await refs.resolve_references({}, history=[], anchor_id=1, character_id=None) == ()
+
+
+@pytest.mark.asyncio
+async def test_the_walk_back_picks_the_sibling_the_user_is_looking_at():
+    # Reroll siblings share a group root; active_sibling_id names the one on
+    # screen. Taking the newest instead would reference an image the user
+    # explicitly swiped away from.
+    root = _gen(10, PNG, active_sibling_id=10)
+    sibling = _gen(11, OTHER, parent_attachment_id=10)
+    history = [_msg(1, workflow=[root, sibling]), _msg(2)]
+
+    resolved = await refs.resolve_references(_slots(), history=history, anchor_id=2, character_id=None)
+
+    assert resolved[0].data == PNG
+    assert resolved[0].origin == "attachment:10"
+    assert resolved[0].slot == ("72", "image")
+
+
+@pytest.mark.asyncio
+async def test_a_group_with_no_active_sibling_uses_the_newest():
+    history = [_msg(1, workflow=[_gen(10, PNG), _gen(11, OTHER, parent_attachment_id=10)]), _msg(2)]
+    resolved = await refs.resolve_references(_slots(), history=history, anchor_id=2, character_id=None)
+    assert resolved[0].origin == "attachment:11"
+
+
+@pytest.mark.asyncio
+async def test_an_evicted_row_is_skipped_for_the_next_usable_image():
+    evicted = _gen(20, data=PNG)
+    evicted["data_b64"] = "[evicted]"
+    history = [_msg(1, workflow=[_gen(10, PNG)]), _msg(2, workflow=[evicted]), _msg(3)]
+
+    resolved = await refs.resolve_references(_slots(), history=history, anchor_id=3, character_id=None)
+
+    assert resolved[0].origin == "attachment:10"
+
+
+@pytest.mark.asyncio
+async def test_the_anchor_message_cannot_reference_its_own_image():
+    """Otherwise a regenerate edits the render already on the message instead of
+    the scene, and each pass drifts further from what the reply describes."""
+    history = [_msg(1, workflow=[_gen(10, PNG)]), _msg(2, workflow=[_gen(20, OTHER)])]
+    resolved = await refs.resolve_references(_slots(), history=history, anchor_id=2, character_id=None)
+    assert resolved[0].origin == "attachment:10"
+
+
+@pytest.mark.asyncio
+async def test_a_user_upload_counts_as_a_previous_image():
+    upload = {"id": 5, "mime_type": "image/jpeg", "data_b64": _b64(OTHER)}
+    history = [_msg(1, user=[upload]), _msg(2)]
+
+    resolved = await refs.resolve_references(_slots(), history=history, anchor_id=2, character_id=None)
+
+    # User attachments are only readable per-message, so the origin carries both ids.
+    assert resolved[0].origin == "upload:1:5"
+    assert resolved[0].data == OTHER
+
+
+@pytest.mark.asyncio
+async def test_a_generated_image_beats_an_upload_on_the_same_message():
+    upload = {"id": 5, "mime_type": "image/jpeg", "data_b64": _b64(OTHER)}
+    history = [_msg(1, workflow=[_gen(10, PNG)], user=[upload]), _msg(2)]
+    resolved = await refs.resolve_references(_slots(), history=history, anchor_id=2, character_id=None)
+    assert resolved[0].origin == "attachment:10"
+
+
+@pytest.mark.asyncio
+async def test_the_character_source_falls_back_to_the_card_avatar(monkeypatch):
+    async def avatar(card_id):
+        assert card_id == "card-1"
+        return AVATAR, "image/png"
+
+    monkeypatch.setattr(refs, "get_character_avatar", avatar)
+
+    resolved = await refs.resolve_references(_slots("character"), history=[], anchor_id=1, character_id="card-1")
+
+    assert resolved[0].data == AVATAR
+    assert resolved[0].origin == "character:card-1"
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_character_reference_beats_the_avatar(monkeypatch):
+    async def avatar(_card_id):
+        return AVATAR, "image/png"
+
+    monkeypatch.setattr(refs, "get_character_avatar", avatar)
+    profile = {"reference_image_b64": _b64(OTHER), "reference_mime": "image/png"}
+
+    resolved = await refs.resolve_references(
+        _slots("character"), history=[], anchor_id=1, character_id="card-1", profile=profile
+    )
+
+    assert resolved[0].data == OTHER
+
+
+@pytest.mark.asyncio
+async def test_the_combined_source_prefers_the_previous_image(monkeypatch):
+    async def avatar(_card_id):
+        return AVATAR, "image/png"
+
+    monkeypatch.setattr(refs, "get_character_avatar", avatar)
+    history = [_msg(1, workflow=[_gen(10, PNG)]), _msg(2)]
+
+    resolved = await refs.resolve_references(
+        _slots("previous_or_character"), history=history, anchor_id=2, character_id="card-1"
+    )
+    assert resolved[0].data == PNG
+
+    # ...and falls through on the first Visualize of a new conversation, which is
+    # the cold-start cliff this source exists to remove.
+    cold = await refs.resolve_references(_slots("previous_or_character"), history=[_msg(1)], anchor_id=1, character_id="card-1")
+    assert cold[0].data == AVATAR
+
+
+@pytest.mark.asyncio
+async def test_both_sources_empty_names_the_slot_and_what_was_tried():
+    with pytest.raises(ImageGenerationError) as raised:
+        await refs.resolve_references(_slots("previous_or_character"), history=[_msg(1)], anchor_id=1, character_id="card-1")
+    message = str(raised.value)
+    assert "Load Image (#72)" in message
+    assert "previous image" in message and "character reference" in message
+
+
+@pytest.mark.asyncio
+async def test_two_slots_sharing_a_source_resolve_to_one_upload(monkeypatch):
+    async def avatar(_card_id):
+        return AVATAR, "image/png"
+
+    monkeypatch.setattr(refs, "get_character_avatar", avatar)
+    slots = {
+        "references": [
+            {"slot": ["72", "image"], "source": "character", "label": "a"},
+            {"slot": ["90", "image"], "source": "character", "label": "b"},
+        ]
+    }
+
+    resolved = await refs.resolve_references(slots, history=[], anchor_id=1, character_id="card-1")
+
+    assert len(resolved) == 2
+    # One digest, so the adapter uploads one file and patches both slots with it.
+    assert resolved[0].digest == resolved[1].digest
+
+
+# ── replay ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_reroll_refetches_strictly_by_recorded_origin(monkeypatch):
+    async def by_id(att_id):
+        assert att_id == 10
+        return {"id": 10, "mime_type": "image/png", "data_b64": _b64(PNG)}
+
+    monkeypatch.setattr(refs, "get_workflow_attachment_by_id", by_id)
+    recorded = [{"slot": ["72", "image"], "source": "previous", "origin": "attachment:10", "digest": "x"}]
+
+    resolved = await refs.refetch_references(recorded)
+
+    assert resolved[0].data == PNG
+    assert resolved[0].origin == "attachment:10"
+
+
+@pytest.mark.asyncio
+async def test_a_deleted_origin_fails_rather_than_substituting(monkeypatch):
+    """A reroll promises the same picture with a different seed. Re-resolving
+    would hand back a different subject and report success."""
+
+    async def gone(_att_id):
+        return None
+
+    monkeypatch.setattr(refs, "get_workflow_attachment_by_id", gone)
+    recorded = [{"slot": ["72", "image"], "source": "previous", "origin": "attachment:10", "digest": "x"}]
+
+    with pytest.raises(ImageGenerationError, match="cannot be reproduced exactly"):
+        await refs.refetch_references(recorded)
+
+
+@pytest.mark.asyncio
+async def test_an_evicted_origin_fails_the_same_way(monkeypatch):
+    async def evicted(_att_id):
+        return {"id": 10, "mime_type": "image/png", "data_b64": "[evicted]"}
+
+    monkeypatch.setattr(refs, "get_workflow_attachment_by_id", evicted)
+    with pytest.raises(ImageGenerationError):
+        await refs.refetch_references([{"slot": ["72", "image"], "source": "previous", "origin": "attachment:10"}])
+
+
+@pytest.mark.asyncio
+async def test_a_character_origin_rereads_the_current_profile(monkeypatch):
+    """The origin addresses a setting, not a chat message, so "change the
+    character reference, then reroll" does what it says."""
+
+    async def state(card_id, workflow_id):
+        assert (card_id, workflow_id) == ("card-1", "image_gen")
+        return {"reference_image_b64": _b64(OTHER), "reference_mime": "image/png"}
+
+    monkeypatch.setattr(refs, "get_workflow_character_state", state)
+
+    resolved = await refs.refetch_references([{"slot": ["72", "image"], "source": "character", "origin": "character:card-1"}])
+
+    assert resolved[0].data == OTHER
+
+
+@pytest.mark.asyncio
+async def test_nothing_recorded_replays_as_no_references():
+    assert await refs.refetch_references(None) == ()
+    assert await refs.refetch_references([]) == ()

--- a/tests/unit/workflows/image_gen/test_references.py
+++ b/tests/unit/workflows/image_gen/test_references.py
@@ -40,8 +40,16 @@ def _msg(msg_id: int, *, workflow=(), user=()) -> dict:
     return {"id": msg_id, "workflow_attachments": list(workflow), "user_attachments": list(user)}
 
 
-def _slots(source: str = "previous", node: str = "72") -> dict:
-    return {"references": [{"slot": [node, "image"], "source": source, "label": f"Load Image (#{node})"}]}
+def _upload(att_id: int, data: bytes) -> dict:
+    return {"id": att_id, "mime_type": "image/jpeg", "data_b64": _b64(data)}
+
+
+def _entries(source: str = "previous", node: str = "72") -> list[dict]:
+    return [{"slot": [node, "image"], "source": source, "label": f"Load Image (#{node})"}]
+
+
+async def _resolve(entries, history, anchor_id=99, character_id=None):
+    return await refs.resolve_references(entries, history=history, anchor_id=anchor_id, character_id=character_id)
 
 
 @pytest.fixture(autouse=True)
@@ -58,124 +66,40 @@ def _no_db(monkeypatch):
 @pytest.mark.asyncio
 async def test_no_mapped_slots_resolves_to_nothing():
     """A plain text-to-image graph must not pay for any of this."""
-    assert await refs.resolve_references({}, history=[], anchor_id=1, character_id=None) == ()
+    assert await _resolve([], []) == ()
 
 
+# Every rule the walk back applies, as one table. `anchor` is the message being
+# visualized, and `origin` is the row those rules must land on.
 @pytest.mark.asyncio
-async def test_the_walk_back_picks_the_sibling_the_user_is_looking_at():
-    # Reroll siblings share a group root; active_sibling_id names the one on
-    # screen. Taking the newest instead would reference an image the user
-    # explicitly swiped away from.
-    root = _gen(10, PNG, active_sibling_id=10)
-    sibling = _gen(11, OTHER, parent_attachment_id=10)
-    history = [_msg(1, workflow=[root, sibling]), _msg(2)]
-
-    resolved = await refs.resolve_references(_slots(), history=history, anchor_id=2, character_id=None)
-
-    assert resolved[0].data == PNG
-    assert resolved[0].origin == "attachment:10"
-    assert resolved[0].slot == ("72", "image")
-
-
-@pytest.mark.asyncio
-async def test_a_group_with_no_active_sibling_uses_the_newest():
-    history = [_msg(1, workflow=[_gen(10, PNG), _gen(11, OTHER, parent_attachment_id=10)]), _msg(2)]
-    resolved = await refs.resolve_references(_slots(), history=history, anchor_id=2, character_id=None)
-    assert resolved[0].origin == "attachment:11"
-
-
-@pytest.mark.asyncio
-async def test_an_evicted_row_is_skipped_for_the_next_usable_image():
-    evicted = _gen(20, data=PNG)
-    evicted["data_b64"] = "[evicted]"
-    history = [_msg(1, workflow=[_gen(10, PNG)]), _msg(2, workflow=[evicted]), _msg(3)]
-
-    resolved = await refs.resolve_references(_slots(), history=history, anchor_id=3, character_id=None)
-
-    assert resolved[0].origin == "attachment:10"
-
-
-@pytest.mark.asyncio
-async def test_the_anchor_message_cannot_reference_its_own_image():
-    """Otherwise a regenerate edits the render already on the message instead of
-    the scene, and each pass drifts further from what the reply describes."""
-    history = [_msg(1, workflow=[_gen(10, PNG)]), _msg(2, workflow=[_gen(20, OTHER)])]
-    resolved = await refs.resolve_references(_slots(), history=history, anchor_id=2, character_id=None)
-    assert resolved[0].origin == "attachment:10"
-
-
-@pytest.mark.asyncio
-async def test_a_user_upload_counts_as_a_previous_image():
-    upload = {"id": 5, "mime_type": "image/jpeg", "data_b64": _b64(OTHER)}
-    history = [_msg(1, user=[upload]), _msg(2)]
-
-    resolved = await refs.resolve_references(_slots(), history=history, anchor_id=2, character_id=None)
-
-    # User attachments are only readable per-message, so the origin carries both ids.
-    assert resolved[0].origin == "upload:1:5"
-    assert resolved[0].data == OTHER
-
-
-@pytest.mark.asyncio
-async def test_a_generated_image_beats_an_upload_on_the_same_message():
-    upload = {"id": 5, "mime_type": "image/jpeg", "data_b64": _b64(OTHER)}
-    history = [_msg(1, workflow=[_gen(10, PNG)], user=[upload]), _msg(2)]
-    resolved = await refs.resolve_references(_slots(), history=history, anchor_id=2, character_id=None)
-    assert resolved[0].origin == "attachment:10"
-
-
-@pytest.mark.asyncio
-async def test_the_character_source_falls_back_to_the_card_avatar(monkeypatch):
-    async def avatar(card_id):
-        assert card_id == "card-1"
-        return AVATAR, "image/png"
-
-    monkeypatch.setattr(refs, "get_character_avatar", avatar)
-
-    resolved = await refs.resolve_references(_slots("character"), history=[], anchor_id=1, character_id="card-1")
-
-    assert resolved[0].data == AVATAR
-    assert resolved[0].origin == "character:card-1"
-
-
-@pytest.mark.asyncio
-async def test_an_explicit_character_reference_beats_the_avatar(monkeypatch):
-    async def avatar(_card_id):
-        return AVATAR, "image/png"
-
-    monkeypatch.setattr(refs, "get_character_avatar", avatar)
-    profile = {"reference_image_b64": _b64(OTHER), "reference_mime": "image/png"}
-
-    resolved = await refs.resolve_references(
-        _slots("character"), history=[], anchor_id=1, character_id="card-1", profile=profile
-    )
-
-    assert resolved[0].data == OTHER
-
-
-@pytest.mark.asyncio
-async def test_the_combined_source_prefers_the_previous_image(monkeypatch):
-    async def avatar(_card_id):
-        return AVATAR, "image/png"
-
-    monkeypatch.setattr(refs, "get_character_avatar", avatar)
-    history = [_msg(1, workflow=[_gen(10, PNG)]), _msg(2)]
-
-    resolved = await refs.resolve_references(
-        _slots("previous_or_character"), history=history, anchor_id=2, character_id="card-1"
-    )
-    assert resolved[0].data == PNG
-
-    # ...and falls through on the first Visualize of a new conversation, which is
-    # the cold-start cliff this source exists to remove.
-    cold = await refs.resolve_references(_slots("previous_or_character"), history=[_msg(1)], anchor_id=1, character_id="card-1")
-    assert cold[0].data == AVATAR
+@pytest.mark.parametrize(
+    ("history", "anchor", "origin"),
+    [
+        # Reroll siblings share a group root; active_sibling_id names the one on
+        # screen. Taking the newest would reference an image the user swiped away.
+        ([_msg(1, workflow=[_gen(10, active_sibling_id=10), _gen(11, OTHER, parent_attachment_id=10)])], 99, "attachment:10"),
+        ([_msg(1, workflow=[_gen(10), _gen(11, OTHER, parent_attachment_id=10)])], 99, "attachment:11"),
+        # An evicted row holds a sentinel, not bytes, so the walk keeps going.
+        ([_msg(1, workflow=[_gen(10)]), _msg(2, workflow=[_gen(20) | {"data_b64": "[evicted]"}])], 99, "attachment:10"),
+        # The anchor is excluded, or a regenerate would edit the render already on
+        # the message instead of the scene, drifting further from the reply each pass.
+        ([_msg(1, workflow=[_gen(10)]), _msg(2, workflow=[_gen(20, OTHER)])], 2, "attachment:10"),
+        # A user upload counts, and its origin carries the message id too, since
+        # user attachments are only readable per-message.
+        ([_msg(1, user=[_upload(5, OTHER)])], 99, "upload:1:5"),
+        ([_msg(1, workflow=[_gen(10)], user=[_upload(5, OTHER)])], 99, "attachment:10"),
+    ],
+    ids=["active sibling", "newest sibling", "evicted skipped", "anchor excluded", "upload counts", "generated wins"],
+)
+async def test_the_walk_back_lands_on_the_image_the_user_is_looking_at(history, anchor, origin):
+    resolved = await _resolve(_entries(), history, anchor_id=anchor)
+    assert (resolved[0].origin, resolved[0].slot) == (origin, ("72", "image"))
 
 
 @pytest.mark.asyncio
 async def test_both_sources_empty_names_the_slot_and_what_was_tried():
     with pytest.raises(ImageGenerationError) as raised:
-        await refs.resolve_references(_slots("previous_or_character"), history=[_msg(1)], anchor_id=1, character_id="card-1")
+        await _resolve(_entries("previous_or_character"), [_msg(1)], character_id="card-1")
     message = str(raised.value)
     assert "Load Image (#72)" in message
     assert "previous image" in message and "character reference" in message
@@ -187,21 +111,18 @@ async def test_two_slots_sharing_a_source_resolve_to_one_upload(monkeypatch):
         return AVATAR, "image/png"
 
     monkeypatch.setattr(refs, "get_character_avatar", avatar)
-    slots = {
-        "references": [
-            {"slot": ["72", "image"], "source": "character", "label": "a"},
-            {"slot": ["90", "image"], "source": "character", "label": "b"},
-        ]
-    }
+    entries = _entries("character", "72") + _entries("character", "90")
 
-    resolved = await refs.resolve_references(slots, history=[], anchor_id=1, character_id="card-1")
+    resolved = await _resolve(entries, [], character_id="card-1")
 
-    assert len(resolved) == 2
     # One digest, so the adapter uploads one file and patches both slots with it.
+    assert len(resolved) == 2
     assert resolved[0].digest == resolved[1].digest
 
 
 # ── replay ───────────────────────────────────────────────────────────────────
+
+RECORDED = [{"slot": ["72", "image"], "source": "previous", "origin": "attachment:10", "digest": "x"}]
 
 
 @pytest.mark.asyncio
@@ -211,37 +132,25 @@ async def test_a_reroll_refetches_strictly_by_recorded_origin(monkeypatch):
         return {"id": 10, "mime_type": "image/png", "data_b64": _b64(PNG)}
 
     monkeypatch.setattr(refs, "get_workflow_attachment_by_id", by_id)
-    recorded = [{"slot": ["72", "image"], "source": "previous", "origin": "attachment:10", "digest": "x"}]
 
-    resolved = await refs.refetch_references(recorded)
+    resolved = await refs.refetch_references(RECORDED)
 
-    assert resolved[0].data == PNG
-    assert resolved[0].origin == "attachment:10"
+    assert (resolved[0].data, resolved[0].origin) == (PNG, "attachment:10")
 
 
 @pytest.mark.asyncio
-async def test_a_deleted_origin_fails_rather_than_substituting(monkeypatch):
+@pytest.mark.parametrize("row", [None, {"id": 10, "mime_type": "image/png", "data_b64": "[evicted]"}])
+async def test_a_gone_or_evicted_origin_fails_rather_than_substituting(monkeypatch, row):
     """A reroll promises the same picture with a different seed. Re-resolving
     would hand back a different subject and report success."""
 
-    async def gone(_att_id):
-        return None
+    async def lookup(_att_id):
+        return row
 
-    monkeypatch.setattr(refs, "get_workflow_attachment_by_id", gone)
-    recorded = [{"slot": ["72", "image"], "source": "previous", "origin": "attachment:10", "digest": "x"}]
+    monkeypatch.setattr(refs, "get_workflow_attachment_by_id", lookup)
 
     with pytest.raises(ImageGenerationError, match="cannot be reproduced exactly"):
-        await refs.refetch_references(recorded)
-
-
-@pytest.mark.asyncio
-async def test_an_evicted_origin_fails_the_same_way(monkeypatch):
-    async def evicted(_att_id):
-        return {"id": 10, "mime_type": "image/png", "data_b64": "[evicted]"}
-
-    monkeypatch.setattr(refs, "get_workflow_attachment_by_id", evicted)
-    with pytest.raises(ImageGenerationError):
-        await refs.refetch_references([{"slot": ["72", "image"], "source": "previous", "origin": "attachment:10"}])
+        await refs.refetch_references(RECORDED)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/image_gen/test_replay.py
+++ b/tests/unit/workflows/image_gen/test_replay.py
@@ -8,8 +8,14 @@ with a different image and reports success.
 
 from __future__ import annotations
 
+import pytest
+
+from backend.workflows.image_gen import hooks
 from backend.workflows.image_gen.config import normalize_config
-from backend.workflows.image_gen.engine import resolve_render_target
+from backend.workflows.image_gen.engine import (
+    ImageGenerationError,
+    resolve_render_target,
+)
 
 GRAPH = {
     "0": {"class_type": "CLIPTextEncode", "inputs": {"text": ""}},
@@ -57,3 +63,70 @@ def test_a_user_graph_replay_without_a_recorded_model_falls_through_to_the_style
     config = _config(user_graphs=[{"id": "user_a", "label": "Mine", "graph": GRAPH, "slots": SLOTS}])
     target = resolve_render_target(config, "anime", {"workflow_id": "user_a", "backend_model": None})
     assert (target.graph_id, target.checkpoint) == ("user_a", "current.safetensors")
+
+
+# ── reference images on reroll ───────────────────────────────────────────────
+
+EDIT_GRAPH = {**GRAPH, "r": {"class_type": "LoadImage", "inputs": {"image": "exported.png"}}}
+EDIT_SLOTS = {**SLOTS, "references": [{"slot": ["r", "image"], "source": "character", "label": "Load Image (#r)"}]}
+
+
+class _RerollCtx:
+    def __init__(self, prior_style: str):
+        self.prior_consumption_metadata = {"style_id": prior_style}
+
+
+def _edit_config() -> dict:
+    return normalize_config(
+        {
+            "default_style": "edit",
+            "external_comfy": {
+                "user_graphs": [{"id": "user_edit", "label": "Edit", "graph": EDIT_GRAPH, "slots": EDIT_SLOTS}],
+                "styles": [
+                    {"id": "edit", "label": "Edit", "workflow": "user_edit"},
+                    {"id": "plain", "label": "Plain"},
+                ],
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_style_swap_on_reroll_drops_the_recorded_references(monkeypatch):
+    """They name node ids in the OLD graph, so they cannot be replayed onto a
+    different one -- and RerollGenCtx carries no history to re-resolve from."""
+    monkeypatch.setattr(hooks, "get_workflow_config", _stub(_edit_config()))
+    params = {
+        "prompt": "a quiet room",
+        "negative_prompt": "",
+        # The override swapped this reroll from the edit style onto a plain one.
+        "style_id": "plain",
+        "workflow_id": "user_edit",
+        "references": [{"slot": ["r", "image"], "source": "character", "origin": "character:card-1"}],
+    }
+
+    # The plain style pins no workflow, so the render dies on the normal "assign a
+    # workflow" path -- but only after the stale pins are gone from `params`, which
+    # is what the persisted sibling records.
+    with pytest.raises(ImageGenerationError, match="Import a ComfyUI workflow"):
+        await hooks.reroll_gen(_RerollCtx("edit"), params, "1")
+    assert "references" not in params
+    assert "workflow_id" not in params
+
+
+@pytest.mark.asyncio
+async def test_rerolling_onto_a_reference_style_is_refused_with_a_reason(monkeypatch):
+    """Submitting anyway would ship the new graph's exporter filenames, which
+    fails at ComfyUI with nothing the user can act on."""
+    monkeypatch.setattr(hooks, "get_workflow_config", _stub(_edit_config()))
+    params = {"prompt": "p", "negative_prompt": "", "style_id": "edit", "workflow_id": "user_other"}
+
+    with pytest.raises(ImageGenerationError, match="reference images"):
+        await hooks.reroll_gen(_RerollCtx("plain"), params, "1")
+
+
+def _stub(config: dict):
+    async def get_config(_workflow_id):
+        return config
+
+    return get_config

--- a/tests/unit/workflows/image_gen/test_replay.py
+++ b/tests/unit/workflows/image_gen/test_replay.py
@@ -25,12 +25,12 @@ GRAPH = {
 SLOTS = {"positive": ["0", "text"], "seed": ["s", "seed"], "output": ["o", "images"]}
 
 
-def _config(**external) -> dict:
+def _config(default_style: str = "anime", **external) -> dict:
     base = {
         "styles": [{"id": "anime", "label": "Anime", "checkpoint": "current.safetensors"}],
     }
     base.update(external)
-    return normalize_config({"default_style": "anime", "external_comfy": base})
+    return normalize_config({"default_style": default_style, "external_comfy": base})
 
 
 def test_a_fresh_render_follows_the_style():
@@ -76,30 +76,29 @@ class _RerollCtx:
         self.prior_consumption_metadata = {"style_id": prior_style}
 
 
-def _edit_config() -> dict:
-    return normalize_config(
-        {
-            "default_style": "edit",
-            "external_comfy": {
-                "user_graphs": [{"id": "user_edit", "label": "Edit", "graph": EDIT_GRAPH, "slots": EDIT_SLOTS}],
-                "styles": [
-                    {"id": "edit", "label": "Edit", "workflow": "user_edit"},
-                    {"id": "plain", "label": "Plain"},
-                ],
-            },
-        }
+@pytest.fixture
+def _edit_config(monkeypatch):
+    config = _config(
+        default_style="edit",
+        user_graphs=[{"id": "user_edit", "label": "Edit", "graph": EDIT_GRAPH, "slots": EDIT_SLOTS}],
+        styles=[{"id": "edit", "label": "Edit", "workflow": "user_edit"}, {"id": "plain", "label": "Plain"}],
     )
+
+    async def get_config(_workflow_id):
+        return config
+
+    monkeypatch.setattr(hooks, "get_workflow_config", get_config)
 
 
 @pytest.mark.asyncio
-async def test_a_style_swap_on_reroll_drops_the_recorded_references(monkeypatch):
+@pytest.mark.usefixtures("_edit_config")
+async def test_a_style_swap_on_reroll_drops_the_recorded_references():
     """They name node ids in the OLD graph, so they cannot be replayed onto a
     different one -- and RerollGenCtx carries no history to re-resolve from."""
-    monkeypatch.setattr(hooks, "get_workflow_config", _stub(_edit_config()))
+    # The override swapped this reroll from the edit style onto a plain one.
     params = {
         "prompt": "a quiet room",
         "negative_prompt": "",
-        # The override swapped this reroll from the edit style onto a plain one.
         "style_id": "plain",
         "workflow_id": "user_edit",
         "references": [{"slot": ["r", "image"], "source": "character", "origin": "character:card-1"}],
@@ -110,23 +109,15 @@ async def test_a_style_swap_on_reroll_drops_the_recorded_references(monkeypatch)
     # is what the persisted sibling records.
     with pytest.raises(ImageGenerationError, match="Import a ComfyUI workflow"):
         await hooks.reroll_gen(_RerollCtx("edit"), params, "1")
-    assert "references" not in params
-    assert "workflow_id" not in params
+    assert "references" not in params and "workflow_id" not in params
 
 
 @pytest.mark.asyncio
-async def test_rerolling_onto_a_reference_style_is_refused_with_a_reason(monkeypatch):
+@pytest.mark.usefixtures("_edit_config")
+async def test_rerolling_onto_a_reference_style_is_refused_with_a_reason():
     """Submitting anyway would ship the new graph's exporter filenames, which
     fails at ComfyUI with nothing the user can act on."""
-    monkeypatch.setattr(hooks, "get_workflow_config", _stub(_edit_config()))
     params = {"prompt": "p", "negative_prompt": "", "style_id": "edit", "workflow_id": "user_other"}
 
     with pytest.raises(ImageGenerationError, match="reference images"):
         await hooks.reroll_gen(_RerollCtx("plain"), params, "1")
-
-
-def _stub(config: dict):
-    async def get_config(_workflow_id):
-        return config
-
-    return get_config


### PR DESCRIPTION
Support workflows with reference images (Qwen-Image-Edit, Flux Kontext, IPAdapter, etc.).

ComfyUI has a Load Image node type. This input can be configured in Orb - where to get the image. There are several options:
- Not used.
- An image previously generated in this convo branch.
- A custom, uploaded character reference image. With card's avatar as fallback.

If character reference image is set, but nothing was uploaded, fallback to using character card's avatar.

If nothing satisfies e.g. previous image mode but there's no images generated in the convo yet, error out.