### PR TITLE
Error visibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,13 +64,17 @@ features/<name>/
 | `backend/pipeline/entrypoints.py` | 5 public `handle_*` functions — top of the turn lifecycle |
 | `backend/pipeline/orchestrator.py` | `_run_pipeline()`: director→writer→editor coordination |
 | `backend/pipeline/state.py` | `TurnState`, `ModelLane`, `_PipelineConfig`, `LorebookTurn` |
+| `backend/pipeline/failures.py` | `describe_failure(exc)` → the `error` event's payload; the only place a failure is classified (status class, never provider vocabulary) |
 | `backend/inference/tool_registry.py` | All tool schemas + `TOOLS`/`PRE_WRITER_TOOLS`/`POST_WRITER_TOOLS` |
+| `backend/inference/errors.py` | `LLMCallError(httpx.HTTPStatusError)` + `provider_sentence`/`redact` — keeps the provider's own words instead of `raise_for_status()`'s canned line. **Must** stay an `HTTPStatusError` or `RetryPolicy` silently stops retrying |
 | `backend/core/text_segmentation.py` | Canonical non-workflow backend sentence/quote policy; sentences never contain line breaks |
 | `backend/database/models.py` | TypedDict row contracts (the model layer) |
 | `backend/database/schema.py` | `CREATE TABLES` — source of truth for columns |
 | `backend/database/preset_schema.py` | Preset policy: `DOMAIN_ROOTS`, `SECRET_COLUMNS`, etc. |
 | `frontend/state.js` | Global `S` object — every key declared here; pub/sub bus |
-| `frontend/chat.js` | Barrel re-exporting `chat_core/stream/messages/inspector/workflow/conversations` |
+| `frontend/chat.js` | Barrel re-exporting `chat_core/stream/messages/inspector/workflow/conversations/error` |
+| `frontend/chat_error.js` | The failed-turn card: `S.turnError` → persistent card with Retry / Details / Copy, painted from `renderMessages()` |
+| `frontend/notify.js` | The toast stack — one element and one timer per entry; errors are sticky. `utils.js` re-exports `toast` from here |
 | `frontend/sse.js` | THE SSE parser (`sseEvents`, `streamPost`) — only one in the app |
 | `frontend/text_segmentation.js` | Canonical non-workflow frontend sentence policy; line breaks are standalone stream units |
 | `frontend/workflow_api.js` | Plugin facade ABI v2 — the only import for `frontend/workflows/**` |

--- a/backend/inference/__init__.py
+++ b/backend/inference/__init__.py
@@ -25,6 +25,7 @@ from .endpoint_profiles import (
     note_forced_tool_choice_ignored,
     profile_for,
 )
+from .errors import LLMCallError, provider_sentence, redact
 from .kv_tracker import _KVCacheTracker
 from .lorebook import compute_constant_lorebook_block, compute_depth_lorebook_block
 from .prompt_builder import (
@@ -72,6 +73,10 @@ __all__ = [
     "separate_agent_lane_configured",
     # retry
     "RetryPolicy",
+    # errors — the provider's own words, kept
+    "LLMCallError",
+    "provider_sentence",
+    "redact",
     # endpoint_profiles — provider adapter
     "ModelProfile",
     "honors_forced_tool_choice",

--- a/backend/inference/client.py
+++ b/backend/inference/client.py
@@ -10,6 +10,7 @@ from typing import Any
 import httpx
 
 from . import endpoint_profiles, text_completion
+from .errors import llm_call_error
 from .gemma_tool_format import parse_gemma_tool_calls
 from .retry import RetryPolicy
 
@@ -595,7 +596,17 @@ class LLMClient:
                             if fix is not None:
                                 logger.warning("LLM recovery: %s", fix)
                                 continue  # leave async-with cleanly, then retry
-                        resp.raise_for_status()
+
+                        # Concern 3: keep the body. raise_for_status() would
+                        # replace the provider's own sentence with httpx's canned
+                        # status line, and it is the only part the user can act on.
+                        raise llm_call_error(
+                            response=resp,
+                            body=err_text,
+                            url=self._url(),
+                            model=model,
+                            api_key=self.api_key,
+                        )
                     async for payload in self._iter_sse_payloads(resp):
                         try:
                             chunk = json.loads(payload)
@@ -784,7 +795,13 @@ class LLMClient:
         """POST *body* to llama.cpp ``/completion`` and yield each parsed SSE chunk.
 
         Races reads against abort via the shared :meth:`_iter_sse_payloads`.
-        The single HTTP seam of the text transport (patched wholesale in tests).
+        The single HTTP seam of the text transport (patched wholesale in tests,
+        which is why the signature stays exactly ``(url, body)``).
+
+        A rejection is raised as :class:`LLMCallError` with no model attributed:
+        llama.cpp's native ``/completion`` serves whichever model the server
+        loaded and the body never names one, so there is nothing honest to put
+        there.
         """
         # read=None for the same reason as the chat transport: llama.cpp is
         # silent for the whole prefill, which legitimately exceeds any flat
@@ -792,8 +809,8 @@ class LLMClient:
         async with httpx.AsyncClient(timeout=httpx.Timeout(self.timeout, read=None), proxy=self.proxy) as client:
             async with client.stream("POST", url, json=body, headers=self._headers()) as resp:
                 if resp.status_code >= 400:
-                    await _read_error_body(resp, url)
-                    resp.raise_for_status()
+                    err_text = await _read_error_body(resp, url)
+                    raise llm_call_error(response=resp, body=err_text, url=url, model="", api_key=self.api_key)
                 async for payload in self._iter_sse_payloads(resp):
                     try:
                         yield json.loads(payload)

--- a/backend/inference/errors.py
+++ b/backend/inference/errors.py
@@ -1,0 +1,224 @@
+"""The provider's own words, kept alongside the status they arrived with.
+
+``raise_for_status()`` throws away the only part of an HTTP failure the user can
+act on. *"Reasoning is mandatory for this endpoint and cannot be disabled."* is a
+setting away from being fixed; ``Client error '400 Bad Request' for url ...`` is
+not. This module is the seam where the transport stops discarding the body.
+
+Sibling of image_gen's cloud funnel
+(``workflows/image_gen/engine/openai_image_client.py:74-137``), deliberately not a
+reuse of it: ``inference/`` is L4 and may not import ``workflows/`` (L3). The two
+share a strategy -- name the well-known shapes, then walk for any human-looking
+string -- and differ in how much they scrub. image_gen strips URLs and paths
+because a render failure travels to a user who may not be the operator; Orb's chat
+transport is self-hosted, the user *is* the operator, and the endpoint URL is the
+single most diagnostic token in a misrouted request. Only the credential goes.
+
+:class:`LLMCallError` subclasses ``httpx.HTTPStatusError`` on purpose, not
+``RuntimeError``: ``LLMClient._with_retry`` catches ``httpx.HTTPError`` and
+``RetryPolicy.should_retry`` reads ``exc.response.status_code`` off an
+``HTTPStatusError``. A plain ``RuntimeError`` here would silently disable retry
+for every 429/500/503 that reaches it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+
+# Long enough for a full provider sentence, short enough that a stack trace or an
+# HTML error page pasted into a body cannot become the headline.
+SENTENCE_LIMIT = 300
+
+# The whole body is kept for the Details pane, but a provider that answers a 400
+# with a megabyte of HTML must not be allowed to bloat every SSE frame.
+BODY_LIMIT = 20_000
+
+# Below this a "secret" is more likely a placeholder than a credential, and
+# blanking it would shred unrelated text (a 1-char key would redact every match).
+_MIN_SECRET_LEN = 4
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+# How many nested gateway envelopes to unwrap. One gateway in front of one
+# provider is the shape that exists; the cap is only so a body that quotes itself
+# cannot recurse without end.
+_MAX_UNWRAP = 3
+
+
+class LLMCallError(httpx.HTTPStatusError):
+    """A provider rejection with the provider's own words kept alongside the status.
+
+    ``sentence`` is the one line worth putting in front of a user; ``body`` is the
+    whole response, credential removed, for the case where the sentence is not
+    enough. Both are already sanitized -- a consumer may render them without
+    re-checking.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        request: httpx.Request,
+        response: httpx.Response,
+        sentence: str,
+        body: str,
+        host: str,
+        model: str,
+    ) -> None:
+        super().__init__(message, request=request, response=response)
+        self.sentence = sentence
+        self.body = body
+        self.host = host
+        self.model = model
+
+
+def redact(text: str, secret: str) -> str:
+    """*text* with the API key removed, and nothing else removed.
+
+    URLs and filesystem paths stay: Orb runs on the user's own machine, so there is
+    no third party to leak them to, and the endpoint URL is usually what explains a
+    404. The credential is the one token that is never diagnostic.
+    """
+    if not secret or len(secret) < _MIN_SECRET_LEN:
+        return text
+    return text.replace(secret, "[redacted]")
+
+
+def _walk_strings(payload: Any, *, limit: int = 6, budget: int = 200) -> str:
+    """Every human-looking string in a body, outermost first.
+
+    The fallback for a shape nobody enumerated, and the reason the well-known keys
+    in :func:`provider_sentence` can stay a short list instead of growing a row per
+    provider. Breadth first, because the outer strings are the summary and the inner
+    ones the particulars.
+    """
+    found: list[str] = []
+    queue: list[Any] = [payload]
+    visited = 0
+    while queue and len(found) < limit and visited < budget:
+        node = queue.pop(0)
+        visited += 1
+        if isinstance(node, str):
+            text = node.strip()
+            if text and len(text) <= SENTENCE_LIMIT:
+                found.append(text)
+        elif isinstance(node, Mapping):
+            queue.extend(node.values())
+        elif isinstance(node, (list, tuple)):
+            queue.extend(node)
+    return "; ".join(dict.fromkeys(found))
+
+
+def _first_string(value: Any) -> str:
+    """A string, or the first string inside a list of them (FastAPI ``detail``)."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (list, tuple)):
+        parts = [p for p in (_first_string(v) for v in value) if p]
+        if parts:
+            return "; ".join(dict.fromkeys(parts))
+    if isinstance(value, Mapping):
+        for key in ("msg", "message", "detail"):
+            got = value.get(key)
+            if isinstance(got, str) and got.strip():
+                return got
+    return ""
+
+
+def provider_sentence(body: str, _depth: int = 0) -> str:
+    """The one sentence from an error body worth showing the user.
+
+    Deliberately incurious: the well-known keys first (they yield a clean single
+    sentence), then a generic walk. No vocabulary matching against provider prose --
+    a marker list has to be right about words no two providers share, and when it is
+    wrong it replaces an actionable message with a confident wrong one.
+
+    ``error.metadata.raw`` outranks ``error.message`` because of what a gateway
+    *is*. When OpenRouter proxies an upstream rejection it answers with its own
+    constant -- ``"Provider returned error"`` -- and parks the upstream's verbatim
+    body in ``metadata.raw``. Reading ``message`` first there yields precisely the
+    non-sentence this module exists to eliminate. The preference is structural, not
+    a vocabulary match: ``raw`` is by construction the more specific of the two, so
+    it wins whenever it is present and says something, whatever words it uses.
+    ``raw`` is usually itself a JSON body, hence the bounded recursion.
+    """
+    text = body.strip()
+    if not text:
+        return ""
+    try:
+        payload: Any = json.loads(text)
+    except (ValueError, TypeError):
+        return _WHITESPACE_RE.sub(" ", text).strip()[:SENTENCE_LIMIT]
+
+    found = ""
+    if isinstance(payload, Mapping):
+        error = payload.get("error")
+        if isinstance(error, Mapping):
+            metadata = error.get("metadata")
+            if isinstance(metadata, Mapping) and _depth < _MAX_UNWRAP:
+                raw = _first_string(metadata.get("raw"))
+                if raw:
+                    found = provider_sentence(raw, _depth + 1)
+            if not found:
+                found = _first_string(error.get("message"))
+            if not found:
+                for key in ("detail", "code", "type"):
+                    found = _first_string(error.get(key))
+                    if found:
+                        break
+        elif isinstance(error, str):
+            found = error
+        if not found:
+            for key in ("message", "detail"):
+                found = _first_string(payload.get(key))
+                if found:
+                    break
+    elif isinstance(payload, str):
+        found = payload
+
+    if not found:
+        found = _walk_strings(payload)
+    return _WHITESPACE_RE.sub(" ", found).strip()[:SENTENCE_LIMIT]
+
+
+def llm_call_error(
+    *,
+    response: httpx.Response,
+    body: str,
+    url: str,
+    model: str,
+    api_key: str,
+) -> LLMCallError:
+    """Build the typed rejection from what the transport already holds.
+
+    *body* is the text ``_read_error_body`` already read and logged; passing it in
+    rather than re-reading matters because a streaming response can only be read
+    once.
+
+    ``Response.request`` raises ``RuntimeError`` when the response was constructed
+    without one, so it is never read bare — a synthesized request from *url* keeps
+    the exception well-formed for ``RetryPolicy`` either way.
+    """
+    clean = redact(body, api_key)[:BODY_LIMIT]
+    sentence = redact(provider_sentence(body), api_key)[:SENTENCE_LIMIT]
+    host = urlsplit(url).netloc
+    detail = f": {sentence}" if sentence else ""
+    try:
+        request = response.request
+    except (RuntimeError, AttributeError):
+        request = httpx.Request("POST", url)
+    return LLMCallError(
+        f"HTTP {response.status_code} from {host}{detail}",
+        request=request,
+        response=response,
+        sentence=sentence,
+        body=clean,
+        host=host,
+        model=model,
+    )

--- a/backend/pipeline/entrypoints.py
+++ b/backend/pipeline/entrypoints.py
@@ -30,6 +30,7 @@ from .context import (
     _prepare_turn,
     _TurnSetup,
 )
+from .failures import describe_failure
 from .orchestrator import _run_pipeline
 from .passes.director import progressive
 from .passes.editor.editor import AUDIT_BASELINE_WINDOW
@@ -54,7 +55,9 @@ async def _run_turn_handler(
 
     Loads the pipeline context, guards the missing-conversation case, and
     converts any pipeline exception into the terminal SSE error event — one
-    place defines the error wire contract for every handler.
+    place defines the error wire contract for every handler. The payload is
+    ``describe_failure``'s dict, so the provider's own sentence survives to the
+    browser instead of being replaced by a constant (see failures.py).
     """
     try:
         ctx = await _load_pipeline_context(conversation_id, abort_token=abort_token)
@@ -63,9 +66,9 @@ async def _run_turn_handler(
             return
         async for event in body(ctx):
             yield event
-    except Exception:
+    except Exception as e:
         logger.exception("%s error", log_label)
-        yield {"event": "error", "data": "Generation failed; see server logs"}
+        yield {"event": "error", "data": describe_failure(e)}
 
 
 async def _load_direction_notes(ctx: PipelineContext, conversation_id: str, path: Sequence[Mapping[str, Any]]) -> None:

--- a/backend/pipeline/failures.py
+++ b/backend/pipeline/failures.py
@@ -1,0 +1,210 @@
+"""One description of a failed turn, shaped for the wire and for a human.
+
+``backend/workflows/errors.py`` names the principle: *"Hiding the first behind
+'see server logs' is the difference between a user who fixes it in the settings
+panel and a user who files a bug."* The chat pipeline is the generation path that
+never adopted it -- every exception became the constant string
+``"Generation failed; see server logs"``. :func:`describe_failure` is the
+adoption.
+
+It lives in ``pipeline/`` (L2) rather than ``inference/`` (L4) because it has to
+classify both an ``httpx`` transport error (L4's dependency) and a
+``WorkflowUserFacingError`` (L3), and L2 is the lowest layer allowed to see both.
+
+**Classification keys on the status class only.** No vocabulary matching against
+provider prose: a marker list over words no two providers share is wrong often
+enough that it replaces an actionable message with a confident wrong one
+(``workflows/image_gen/engine/openai_image_client.py:6-14`` argues the same trade
+at length). The headline says what Orb can be sure of; ``sentence`` carries what
+the provider actually said, unedited apart from the credential.
+
+``kind`` distinguishes a misconfiguration from a defect. ``"internal"`` means an
+exception nobody classified -- a bug, not something the user did -- so it ships no
+``body`` and does not pretend otherwise. It is still strictly more than "see
+server logs".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from ..inference import LLMCallError, provider_sentence
+from ..workflows.errors import WorkflowUserFacingError
+
+# Cap on an unclassified exception's repr. The full traceback is in the log; this
+# is the line that reaches a chat bubble.
+INTERNAL_SENTENCE_LIMIT = 300
+
+# Same cap the transport applies, for the branch that reads a body itself.
+BODY_LIMIT = 20_000
+
+# Which pass raised, written onto the exception by the orchestrator. An attribute
+# rather than a parameter because the failure travels from inside a pass generator
+# to ``entrypoints._run_turn_handler`` with no shared object between them, and the
+# alternatives are worse: ``turn_scratch`` is part of the public workflow-hook
+# surface (``workflows/contracts.py``), and ``PipelineContext`` is frozen and not
+# passed to ``_run_pipeline`` at all.
+_STAGE_ATTR = "_orb_stage"
+
+STAGE_DIRECTOR = "director pass"
+STAGE_WRITER = "writer pass"
+STAGE_EDITOR = "editor pass"
+STAGE_WORKFLOWS = "workflow hook"
+
+
+def mark_stage(exc: BaseException, stage: str) -> None:
+    """Record that *exc* escaped *stage*, unless an inner stage already claimed it.
+
+    First writer wins, and unwinding runs innermost-first, so a nested stage keeps
+    the more specific label.
+    """
+    try:
+        if not getattr(exc, _STAGE_ATTR, ""):
+            setattr(exc, _STAGE_ATTR, stage)
+    except AttributeError:
+        # Every exception carries a __dict__ (BaseException grants one even under
+        # __slots__), so this only covers an exotic type with a __setattr__ that
+        # refuses. The stage is a nicety; never let labelling mask the failure.
+        pass
+
+
+def stage_of(exc: BaseException) -> str:
+    """The pass *exc* escaped, or ``""`` when nothing claimed it."""
+    got = getattr(exc, _STAGE_ATTR, "")
+    return got if isinstance(got, str) else ""
+
+
+_STATUS_HEADLINES: tuple[tuple[frozenset[int], str], ...] = (
+    (frozenset({400, 422}), "The model provider rejected the request."),
+    (frozenset({401, 403}), "The endpoint rejected Orb's credentials."),
+    (frozenset({404}), "The endpoint or model was not found."),
+    (frozenset({408, 504}), "The provider timed out."),
+    (frozenset({429}), "Rate limited, or out of credits."),
+)
+
+TRANSPORT_HEADLINE = "Couldn't reach the endpoint."
+SERVER_HEADLINE = "The provider had an internal error."
+GENERIC_HTTP_HEADLINE = "The model provider rejected the request."
+WORKFLOW_HEADLINE = "A workflow step failed."
+INTERNAL_HEADLINE = "Something went wrong inside Orb."
+
+
+def headline_for_status(status: int) -> str:
+    """The one sentence Orb can assert from a status code alone."""
+    for codes, text in _STATUS_HEADLINES:
+        if status in codes:
+            return text
+    if 500 <= status < 600:
+        return SERVER_HEADLINE
+    return GENERIC_HTTP_HEADLINE
+
+
+def _internal_sentence(exc: BaseException) -> str:
+    return f"{type(exc).__name__}: {exc}"[:INTERNAL_SENTENCE_LIMIT]
+
+
+def _host_of(exc: httpx.HTTPError) -> str:
+    """The ``host:port`` the request was aimed at, or ``""``.
+
+    ``HTTPError.request`` raises ``RuntimeError`` when the exception was built
+    without one -- which a hand-rolled transport error in a test is -- so this is
+    never read bare.
+    """
+    try:
+        return exc.request.url.netloc.decode("ascii", "replace")
+    except (RuntimeError, AttributeError):
+        return ""
+
+
+def _body_of(exc: httpx.HTTPStatusError) -> str:
+    """The response text, or ``""`` when it cannot be read.
+
+    ``.text`` raises ``httpx.ResponseNotRead`` (a ``RuntimeError``) on a streaming
+    response nobody drained, so it is never read bare.
+    """
+    try:
+        return exc.response.text or ""
+    except (RuntimeError, AttributeError):
+        return ""
+
+
+def describe_failure(exc: BaseException) -> dict[str, Any]:
+    """Turn *exc* into the ``error`` event's data payload.
+
+    Keys: ``headline`` (always), ``sentence`` (always, possibly empty), ``kind``
+    (always), ``stage`` (always, ``""`` when no pass claimed it), and
+    ``status``/``host``/``model``/``body`` when the failure is one the transport
+    could attribute. A consumer renders ``headline`` big, ``sentence`` small, and
+    hides ``body`` behind a disclosure.
+    """
+    stage = stage_of(exc)
+
+    if isinstance(exc, LLMCallError):
+        return {
+            "headline": headline_for_status(exc.response.status_code),
+            "sentence": exc.sentence,
+            "status": exc.response.status_code,
+            "host": exc.host,
+            "model": exc.model,
+            "body": exc.body,
+            "kind": "provider",
+            "stage": stage,
+        }
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        # A status failure raised somewhere the typed error is not built (a bare
+        # raise_for_status on a non-streaming call). The response is still right
+        # here, so read it rather than printing httpx's canned "Client error '400
+        # Bad Request' for url ..." -- the exact line ``inference/errors.py`` was
+        # written to stop showing people. Falls back to the repr when the body is
+        # unreadable or says nothing.
+        #
+        # Unredacted, unlike the LLMCallError branch: the credential is not in
+        # scope here. Acceptable because this branch covers Orb's own internal
+        # calls, whose bodies do not echo an Authorization header -- but it is the
+        # reason a key must never be routed through a bare raise_for_status.
+        body = _body_of(exc)
+        payload = {
+            "headline": headline_for_status(exc.response.status_code),
+            "sentence": provider_sentence(body) or _internal_sentence(exc),
+            "status": exc.response.status_code,
+            "host": _host_of(exc),
+            "model": "",
+            "kind": "provider",
+            "stage": stage,
+        }
+        # Omitted rather than sent empty: the Details pane distinguishes "no body"
+        # from "a body that said nothing", and an empty string is not a body.
+        if body:
+            payload["body"] = body[:BODY_LIMIT]
+        return payload
+
+    if isinstance(exc, httpx.TransportError):
+        # Left unwrapped at the transport seam on purpose so RetryPolicy's
+        # isinstance check over RETRYABLE_TRANSPORT_ERRORS still fires; this is
+        # where the classification it skipped happens instead.
+        return {
+            "headline": TRANSPORT_HEADLINE,
+            "sentence": _internal_sentence(exc),
+            "host": _host_of(exc),
+            "kind": "transport",
+            "stage": stage,
+        }
+
+    if isinstance(exc, WorkflowUserFacingError):
+        # The message is already sanitized -- that is what raising this type promises.
+        return {
+            "headline": WORKFLOW_HEADLINE,
+            "sentence": str(exc)[:INTERNAL_SENTENCE_LIMIT],
+            "kind": "workflow",
+            "stage": stage,
+        }
+
+    return {
+        "headline": INTERNAL_HEADLINE,
+        "sentence": _internal_sentence(exc),
+        "kind": "internal",
+        "stage": stage,
+    }

--- a/backend/pipeline/orchestrator.py
+++ b/backend/pipeline/orchestrator.py
@@ -14,12 +14,19 @@ from __future__ import annotations
 
 import logging
 from collections.abc import AsyncIterator, Mapping, Sequence
-from typing import Any
+from typing import Any, TypeVar
 
 from ..core import ChatMessage, Macros
 from ..database.models import PhraseGroup
 from ..inference import LLMClient, _KVCacheTracker
 from .config import _resolve_pipeline_config, _split_interactive_fragments
+from .failures import (
+    STAGE_DIRECTOR,
+    STAGE_EDITOR,
+    STAGE_WORKFLOWS,
+    STAGE_WRITER,
+    mark_stage,
+)
 from .passes.director import direction_note_step, director_stage
 from .passes.editor import editor_stage
 from .passes.writer import writer_stage
@@ -29,8 +36,34 @@ from .workflow_bridge import _PostPipelineResult, _run_post_pipeline
 
 logger = logging.getLogger(__name__)
 
+_Ev = TypeVar("_Ev")
+
 
 # ── Core pipeline ─────────────────────────────────────────────────────────────
+
+
+async def _staged(stage: str, gen: AsyncIterator[_Ev]) -> AsyncIterator[_Ev]:
+    """Pass *gen*'s events through, labelling anything that escapes it with *stage*.
+
+    The sequence below is the only code that knows which pass is running, and a
+    failure is classified two layers up in ``entrypoints._run_turn_handler``. So
+    the label rides the exception (see ``failures.mark_stage``).
+
+    Worth the wrapper because the alternative was a frontend guess keyed on the
+    last phase event, and the phases do not line up with the passes: nothing moves
+    the frontend off ``"directing"`` until the writer's first token, so every
+    writer *rejection* -- which by definition arrives before any token -- used to
+    be reported against the director.
+
+    ``except Exception`` deliberately excludes ``GeneratorExit`` and
+    ``CancelledError``: a stop is not a failed stage and must stay untouched.
+    """
+    try:
+        async for ev in gen:
+            yield ev
+    except Exception as e:
+        mark_stage(e, stage)
+        raise
 
 
 def _make_result(state: TurnState, staged: list[dict] | None = None, staged_state: dict | None = None) -> dict:
@@ -138,17 +171,20 @@ async def _run_pipeline(
     )
 
     # --- Director pass (+ rewrite, style injection, agentic-lorebook block) ---
-    async for ev in director_stage(
-        cfg,
-        state,
-        settings=settings,
-        director=director,
-        mood_fragments=mood_fragments,
-        writer_fragments=writer_fragments,
-        attachments=attachments,
-        kv_tracker=kv_tracker,
-        lorebook=lorebook,
-        macros=macros,
+    async for ev in _staged(
+        STAGE_DIRECTOR,
+        director_stage(
+            cfg,
+            state,
+            settings=settings,
+            director=director,
+            mood_fragments=mood_fragments,
+            writer_fragments=writer_fragments,
+            attachments=attachments,
+            kv_tracker=kv_tracker,
+            lorebook=lorebook,
+            macros=macros,
+        ),
     ):
         yield ev
 
@@ -162,32 +198,38 @@ async def _run_pipeline(
     if direction_note_recording_active(settings, pre_writer_notes, agent_on=cfg.agent_on) and cfg.enabled_tools.get(
         "direct_scene"
     ):
-        async for ev in _consume_direction_note_step(
-            direction_note_step(
-                cfg.agent_lane.client,
-                cfg.agent_lane.base,
-                settings=settings,
-                direction_note_fragments=pre_writer_notes,
-                active_notes=director.get("direction_notes") or [],
-                placement="pre_writer",
-                inj_block=state.scene_direction,
-                kv_tracker=kv_tracker,
-                reasoning_on=cfg.director_reasoning_on,
-                reasoning_prefill=cfg.director_reasoning_prefill,
+        async for ev in _staged(
+            STAGE_DIRECTOR,
+            _consume_direction_note_step(
+                direction_note_step(
+                    cfg.agent_lane.client,
+                    cfg.agent_lane.base,
+                    settings=settings,
+                    direction_note_fragments=pre_writer_notes,
+                    active_notes=director.get("direction_notes") or [],
+                    placement="pre_writer",
+                    inj_block=state.scene_direction,
+                    kv_tracker=kv_tracker,
+                    reasoning_on=cfg.director_reasoning_on,
+                    reasoning_prefill=cfg.director_reasoning_prefill,
+                ),
+                state,
+                "director",
             ),
-            state,
-            "director",
         ):
             yield ev
 
     # --- Writer pass ---
-    async for ev in writer_stage(
-        cfg,
-        state,
-        settings=settings,
-        attachments=attachments,
-        kv_tracker=kv_tracker,
-        depth_block=lorebook.depth_block,
+    async for ev in _staged(
+        STAGE_WRITER,
+        writer_stage(
+            cfg,
+            state,
+            settings=settings,
+            attachments=attachments,
+            kv_tracker=kv_tracker,
+            depth_block=lorebook.depth_block,
+        ),
     ):
         yield ev
 
@@ -198,14 +240,17 @@ async def _run_pipeline(
         return
 
     # --- Editor pass (edit loop + post-writer feedback step) ---
-    async for ev in editor_stage(
-        cfg,
-        state,
-        settings=settings,
-        phrase_bank=phrase_bank,
-        feedback_fragments=feedback_fragments,
-        editor_audit_msgs=editor_audit_msgs,
-        kv_tracker=kv_tracker,
+    async for ev in _staged(
+        STAGE_EDITOR,
+        editor_stage(
+            cfg,
+            state,
+            settings=settings,
+            phrase_bank=phrase_bank,
+            feedback_fragments=feedback_fragments,
+            editor_audit_msgs=editor_audit_msgs,
+            kv_tracker=kv_tracker,
+        ),
     ):
         yield ev
 
@@ -213,21 +258,24 @@ async def _run_pipeline(
     # director_output is a plain dict (PostCtx expects a read-only mapping).
     director_output = state.as_director_output()
     post: _PostPipelineResult | None = None
-    async for ev in _run_post_pipeline(
-        draft=state.resp_text,
-        conversation_id=conversation_id,
-        character_id=character_id,
-        card=card,
-        history=history,
-        effective_msg=state.effective_msg,
-        director_output=director_output,
-        settings=settings,
-        prefix=prefix,
-        enabled_tools=cfg.enabled_tools,
-        turn_scratch=turn_scratch,
-        client=client,
-        kv_tracker=kv_tracker,
-        schema_overrides=schema_overrides,
+    async for ev in _staged(
+        STAGE_WORKFLOWS,
+        _run_post_pipeline(
+            draft=state.resp_text,
+            conversation_id=conversation_id,
+            character_id=character_id,
+            card=card,
+            history=history,
+            effective_msg=state.effective_msg,
+            director_output=director_output,
+            settings=settings,
+            prefix=prefix,
+            enabled_tools=cfg.enabled_tools,
+            turn_scratch=turn_scratch,
+            client=client,
+            kv_tracker=kv_tracker,
+            schema_overrides=schema_overrides,
+        ),
     ):
         if isinstance(ev, _PostPipelineResult):
             post = ev
@@ -246,22 +294,25 @@ async def _run_pipeline(
         and state.resp_text.strip()
         and not client.is_aborted
     ):
-        async for ev in _consume_direction_note_step(
-            direction_note_step(
-                cfg.agent_lane.client,
-                cfg.agent_lane.base,
-                settings=settings,
-                direction_note_fragments=post_turn_notes,
-                active_notes=director.get("direction_notes") or [],
-                placement="post_turn",
-                reply_text=state.resp_text,
-                writer_user_msg=state.writer_content,
-                kv_tracker=kv_tracker,
-                reasoning_on=cfg.editor_reasoning_on,
-                reasoning_prefill=cfg.editor_reasoning_prefill,
+        async for ev in _staged(
+            STAGE_EDITOR,
+            _consume_direction_note_step(
+                direction_note_step(
+                    cfg.agent_lane.client,
+                    cfg.agent_lane.base,
+                    settings=settings,
+                    direction_note_fragments=post_turn_notes,
+                    active_notes=director.get("direction_notes") or [],
+                    placement="post_turn",
+                    reply_text=state.resp_text,
+                    writer_user_msg=state.writer_content,
+                    kv_tracker=kv_tracker,
+                    reasoning_on=cfg.editor_reasoning_on,
+                    reasoning_prefill=cfg.editor_reasoning_prefill,
+                ),
+                state,
+                "editor",
             ),
-            state,
-            "editor",
         ):
             yield ev
 

--- a/backend/pipeline/workflow_bridge.py
+++ b/backend/pipeline/workflow_bridge.py
@@ -7,9 +7,10 @@ attachment artifacts, per-message state), and rejects malformed or
 underscore-prefixed events so one bad hook can neither crash a turn nor
 impersonate an internal event.
 
-Depends only downward (``workflows``, ``inference``, ``core``); imports no
-pipeline sibling, so both the pre-pipeline setup path and the post-pipeline
-orchestrator path can safely import it.
+Depends only downward (``workflows``, ``inference``, ``core``) plus one leaf
+pipeline sibling, ``failures``, which itself imports no pipeline module — so both
+the pre-pipeline setup path and the post-pipeline orchestrator path can still
+safely import it.
 """
 
 from __future__ import annotations
@@ -36,6 +37,8 @@ from ..workflows import (
     public_event_error,
 )
 from ..workflows.enablement import effective_workflow_enabled
+from ..workflows.errors import WorkflowUserFacingError
+from .failures import describe_failure
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +62,27 @@ def _public_hook_event(ev: object, *, hook_type: str, workflow_id: str) -> dict 
         )
         return None
     return cast(dict, ev)
+
+
+def _hook_warning(exc: Exception, workflow_id: str) -> dict | None:
+    """A non-terminal ``warning`` event for a hook failure the user can act on.
+
+    The turn legitimately continues -- a post-pipeline render that the provider
+    rejected does not invalidate the prose -- so the exception stays swallowed.
+    What stops is the *hiding*: a ``WorkflowUserFacingError`` names something the
+    user chose or configured, and vanishing into the log is the failure mode
+    ``workflows/errors.py`` exists to prevent. Anything else is a defect, and a
+    defect is log-only per the same doctrine.
+
+    ``warning``, not ``error``: sse-stream.md documents ``error`` as the single
+    *terminal* channel, and a mid-stream one would break that contract.
+    """
+    if not isinstance(exc, WorkflowUserFacingError):
+        return None
+    payload = describe_failure(exc)
+    payload["headline"] = f"Workflow {workflow_id} failed."
+    payload["workflow_id"] = workflow_id
+    return {"event": "warning", "data": payload}
 
 
 @dataclass(slots=True)
@@ -202,8 +226,11 @@ async def _run_post_pipeline(
                     )
                     if public_event is not None:
                         yield public_event
-            except Exception:
+            except Exception as e:
                 logger.exception("post_pipeline hook %r failed", sub.workflow_id)
+                warning = _hook_warning(e, sub.workflow_id)
+                if warning is not None:
+                    yield warning
 
     yield _PostPipelineResult(draft, staged_attachments, staged_message_state)
 
@@ -402,5 +429,8 @@ async def _iterate_pre_pipeline_hooks(
                     )
                     if public_event is not None:
                         yield public_event
-            except Exception:
+            except Exception as e:
                 logger.exception("pre_pipeline hook %r failed", sub.workflow_id)
+                warning = _hook_warning(e, sub.workflow_id)
+                if warning is not None:
+                    yield warning

--- a/docs/architecture/secondary-workflow.md
+++ b/docs/architecture/secondary-workflow.md
@@ -798,7 +798,8 @@ The three array registrars are idempotent on `workflowId` (re-registration repla
 | `api` | `{get,post,put,del,upload}` | HTTP helper. | stable |
 | `convUrl` | `(...parts) => string` | Build `/conversations/...` paths. | stable |
 | `esc` / `escAttr` | `(s) => string` | HTML / attribute escaping. | stable |
-| `toast` | `(msg, isError?)` | Transient notification. | stable |
+| `toast` | `(msg, isError?)` | Transient notification. `isError: true` is now **sticky** (red, dismissible) rather than a 3 s chip — a failure the user must act on cannot expire. | stable |
+| `notifyError` | `(headline, {sentence?, onDetails?})` | Sticky error toast: headline, the provider's own sentence clamped to two lines, and an optional `Details` button. Strings are written with `textContent`, so an untrusted provider message is safe to pass. | stable |
 | `showModal` / `closeModal` | `(html)` / `()` | Framework modal. | stable |
 | `setModalCloseGuard` | `(() => bool)` | Asked before the current modal closes — return `false` to keep it open (unsaved-draft prompt). Covers all three exits: Close, overlay click, Escape. Cleared automatically whenever a modal opens or closes, so set it *after* `showModal`. | stable |
 | `playAudio` | `({channel, segments, loop?, volume?, stopOn?})` | Play on a shared audio channel. | stable |
@@ -861,7 +862,8 @@ Built-in cases:
 | `phase_status` | requires `data.channel` to start `"workflow:"`; calls `clearWorkflowPhase(channel)` when `state === "done"` or the label is missing/blank, else `setWorkflowPhase(channel, label)` |
 | `editor_done` | append `tool_calls` to `S.lastDirectorData` |
 | `user_message_created` | patch pending user row id; optional in-flight edit POST |
-| `error` | toast |
+| `error` | **terminal.** `JSON.parse` the payload (or fall back to the bare string as a headline); store in `S.turnError` and paint the failure card via `renderTurnError` — no toast |
+| `warning` | **non-terminal.** A hook's `WorkflowUserFacingError`, surfaced as a sticky `notifyError` toast; the turn continues |
 | `workflow_attachments_rejected` | `_mergeWorkflowRejections(msgId, null, rejected)`; no re-render |
 
 Default branch: looks up `S.workflowEventHandlers[event]` (a `{workflowId, handler}` record). If its `workflowId` is effectively enabled (sec. 3.7) and `handler` is a function, parses `data` with `JSON.parse`, falling back to the raw string on parse failure, then invokes `handler(payload, msgDiv)` -- `payload` is the parsed JSON or raw string, `msgDiv` is the streaming message element or `null`. The call is wrapped in `try/catch`; throws are logged via `console.error` and do not abort the stream.
@@ -870,7 +872,7 @@ No `done` case, so `done` falls through to the default branch and reaches `S.wor
 
 ### 12.3 Reserved event names (do not author-emit as custom)
 
-These 10 names are intercepted by built-in `case`s in `handleSSEEvent` before the custom-handler default branch, so registering a handler for them has no effect: `token`, `director_start`, `director_done`, `writer_rewrite`, `reasoning`, `phase_status`, `editor_done`, `user_message_created`, `workflow_attachments_rejected`, `error`. Separately, event names a workflow's pipeline hooks emit are filtered server-side: the pipeline drops any underscore-prefixed name from `post_pipeline` and `pre_pipeline` output (both hook loops in `workflow_bridge.py`), since the `_`-prefix is reserved for internal persistence signals (`_result`, `_refined_result`, `_editor_reasoning`). These never reach the frontend.
+These 11 names are intercepted by built-in `case`s in `handleSSEEvent` before the custom-handler default branch, so registering a handler for them has no effect: `token`, `director_start`, `director_done`, `writer_rewrite`, `reasoning`, `phase_status`, `editor_done`, `user_message_created`, `workflow_attachments_rejected`, `error`, `warning`. Separately, event names a workflow's pipeline hooks emit are filtered server-side: the pipeline drops any underscore-prefixed name from `post_pipeline` and `pre_pipeline` output (both hook loops in `workflow_bridge.py`), since the `_`-prefix is reserved for internal persistence signals (`_result`, `_refined_result`, `_editor_reasoning`). These never reach the frontend.
 
 ### 12.4 `afterStream`
 
@@ -939,7 +941,8 @@ api.post(path, body)         # JSON body
 api.put(path, body)          # JSON body
 convUrl(...parts)            # utils.js -> "/conversations/<part1>/<part2>/..."
 esc(s) / escAttr(s)          # utils.js HTML- / attribute-escape; null/undefined -> ""
-toast(msg, isError?)         # utils.js transient notification
+toast(msg, isError?)         # notify.js (re-exported by utils.js) — transient chip; isError is sticky
+notifyError(headline, {sentence?, onDetails?})   # notify.js sticky error toast
 showModal(html) / closeModal()   # modal.js
 ```
 

--- a/docs/architecture/sse-stream.md
+++ b/docs/architecture/sse-stream.md
@@ -65,9 +65,11 @@ A typical `/send` turn with reasoning on (Director + Writer), an Editor pass, an
 | 9 | `feedback` | BE→FE | `{ "values": {...} }` | *Optional.* User-facing notes; display-only, re-renders the inspector. |
 | 10 | `direction_notes` | BE→FE | `{ "notes": [...] }` | *Optional.* The Director's persistent notes recorded this turn; display-only, re-renders the inspector's Direction Notes block. |
 | 11 | `phase_status`, `tts_autoplay`, … | BE→FE | varies | Secondary-workflow passthrough (see §6). |
-| 12 | `done` | BE→FE | *(none)* | Terminal. Stream closes; FE runs `afterStream()`. |
+| 12 | `warning` | BE→FE | `{ "headline": "…", "sentence": "…", "kind": "workflow", "workflow_id": "…" }` | *Optional, non-terminal.* A secondary-workflow hook raised a `WorkflowUserFacingError`; the turn continues. FE shows a sticky error toast. |
+| 13 | `error` | BE→FE | a JSON object (see §7), or a bare string from a legacy emitter | **Terminal.** FE stores it in `S.turnError` and paints the failure card. |
+| 14 | `done` | BE→FE | *(none)* | Terminal. Stream closes; FE runs `afterStream()`. |
 
-The only event whose `data` is **not** JSON is `token` — it's a raw text delta, with newlines escaped to `\n` and un-escaped on arrival.
+The only event whose `data` is **not** JSON is `token` — it's a raw text delta, with newlines escaped to `\n` and un-escaped on arrival. (`error` is the one dual-shape channel: JSON from the pipeline handlers, a bare string from the pre-pipeline guards listed in §7.)
 
 ---
 
@@ -109,7 +111,9 @@ To prevent collisions, the orchestrator drops any hook attempt to emit a reserve
 - **Stop.** Clicking Stop sends `POST …/stop`, which fires the conversation's `abort_token`. The backend breaks its LLM loop and closes the upstream connection cleanly — no task cancellation needed.
 - **Disconnect.** If the user closes the tab without clicking Stop, a background watcher polling `request.is_disconnected()` trips the same `abort_token` as a backstop.
 - **Partial persistence.** Whether the turn finishes, aborts, or errors, `_consume_pipeline`'s `finally` runs exactly once — persisting whatever prose streamed so far, so an interrupted turn is never lost.
-- **Errors** arrive as a single `error` event whose `data` is a human-readable string; the frontend toasts it. There is exactly one error channel — no separate mid-stream HTTP status.
+- **Errors** arrive as a single **terminal** `error` event. Its `data` is **a JSON object, or a bare string from a legacy emitter** — the frontend tries `JSON.parse` and falls back to treating the whole payload as the headline. The object is `pipeline/failures.py`'s `describe_failure(exc)`: `{headline, sentence, kind}` always, plus `status`/`host`/`model`/`body` when the failure was attributable to a provider call. `headline` is what Orb can assert from the status class alone; `sentence` is the provider's own words, credential-redacted and capped; `body` is the full raw response for the Details pane. `kind` is `provider` | `transport` | `workflow` | `internal`, where `internal` marks a defect (no `body`, and `sentence` is the exception repr). The bare-string emitters that stay as-is: `documents.py`, `conversations.py`, `deps.py`'s concurrency guard, `entrypoints.py`'s missing-conversation guard, and the on-demand routes in `workflows.py`.
+  A **JSON `error` payload must not be run through the frontend's `unescapeSSE`** — `json.dumps` already escaped the newlines *inside* the JSON, so un-escaping would corrupt it (the same trap `sse.js` documents for the document `probs` channel).
+- **Warnings** are the non-terminal sibling: a workflow hook whose `WorkflowUserFacingError` the pipeline legitimately swallows still emits `warning` with the same payload shape and `kind: "workflow"`. `error` stays the single terminal channel; a mid-stream `error` would break that.
 - **Concurrency.** A per-conversation lock (`_conversation_stream_locks`) allows only one active stream per conversation. A second concurrent `/send` gets an immediate `error` ("Another generation is already running") rather than racing.
 
 ---

--- a/frontend/chat.js
+++ b/frontend/chat.js
@@ -34,6 +34,7 @@ export {
   stashCardFragments,
 } from "./chat_conversations.js";
 export { renderMessages } from "./chat_core.js";
+export { clearTurnError, renderTurnError } from "./chat_error.js";
 
 export {
   clearRefineDiff,

--- a/frontend/chat_core.js
+++ b/frontend/chat_core.js
@@ -4,6 +4,7 @@
 // conversations) build on. Split out of chat.js; the public surface is
 // re-exported from chat.js.
 import { api } from "./api.js";
+import { renderTurnError } from "./chat_error.js";
 import {
   _refreshWorkflowViewportObserver,
   _renderWorkflowArtifacts,
@@ -410,6 +411,9 @@ export function renderMessages(forceBottom = false) {
         if (badgeEl) ct.appendChild(badgeEl);
         // Keep streaming box visible while editing; only hide if explicitly flagged
         if (streamingEl && !S.hideStreamingBox && !S.hideUntilBaked) ct.appendChild(streamingEl);
+        // After the last message and after the streaming bubble: a partial draft
+        // that did persist reads above the failure that cut it short.
+        renderTurnError(ct);
       },
       { forceBottom },
     );

--- a/frontend/chat_error.js
+++ b/frontend/chat_error.js
@@ -1,0 +1,185 @@
+// The failed-turn card: what a generation failure leaves behind once the toast
+// is gone.
+//
+// A grey chip reading "Error: Generation failed; see server logs" that fades in
+// three seconds is worse than nothing in a self-hosted app, where the user *is*
+// the operator and the provider's actual sentence — "Reasoning is mandatory for
+// this endpoint and cannot be disabled." — is one settings-panel edit away from a
+// fix. `S.turnError` (set by chat_stream.js from the backend's `describe_failure`
+// payload) is painted here as a persistent card at the tail of the chat: the
+// provider's words inline and the full raw body behind Details. The card only
+// reports — rerunning the turn is the regenerate button's job, on the tail
+// message itself, where the user can see what they are about to replace.
+//
+// Painted from renderMessages() rather than from the stream handler, because
+// afterStream() unconditionally refetches and repaints — a card drawn by the
+// handler would be wiped a moment later.
+import { closeModal, showModal, switchTab } from "./modal.js";
+import { copyToButton } from "./notify.js";
+import { S } from "./state.js";
+import { $, esc } from "./utils.js";
+
+const CARD_ID = "turn-error-card";
+
+// The failure object this card has already announced to assistive tech. Compared
+// by identity, never read for content.
+let _announced = null;
+
+function meta(err) {
+  const bits = [];
+  if (err.stage) bits.push(err.stage);
+  if (err.status) bits.push(`HTTP ${err.status}`);
+  if (err.host) bits.push(err.host);
+  if (err.model) bits.push(err.model);
+  return bits;
+}
+
+// A failure card belongs to the conversation it happened in. Without this guard a
+// switch to another chat would leave the previous chat's failure hanging under
+// someone else's messages.
+function activeError() {
+  const err = S.turnError;
+  if (!err) return null;
+  if (err.convId != null && err.convId !== S.activeConvId) return null;
+  return err;
+}
+
+export function clearTurnError() {
+  S.turnError = null;
+  _announced = null;
+  document.getElementById(CARD_ID)?.remove();
+}
+
+function prettyBody(body) {
+  try {
+    return JSON.stringify(JSON.parse(body), null, 2);
+  } catch (_) {
+    return body;
+  }
+}
+
+function copyReport(err) {
+  const lines = [err.headline || "Generation failed."];
+  if (err.sentence) lines.push("", err.sentence);
+  const bits = meta(err);
+  if (err.at) bits.push(new Date(err.at).toISOString());
+  if (bits.length) lines.push("", bits.join(" · "));
+  if (err.body) lines.push("", "```", prettyBody(err.body), "```");
+  return lines.join("\n");
+}
+
+// showModal takes an HTML string, so every interpolated value goes through esc():
+// a provider response body is untrusted input.
+function showDetails(err) {
+  // err.at, not Date.now(): this pane is read minutes after the fact, and
+  // stamping it on open reported the time the user clicked Details as the time
+  // the turn failed. Older entries predate the field, hence the fallback.
+  const when = err.at ? new Date(err.at).toLocaleString() : "";
+  const rows = [
+    ["When", when],
+    ["Stage", err.stage],
+    ["HTTP status", err.status],
+    ["Host", err.host],
+    ["Model", err.model],
+  ]
+    .filter(([, v]) => v != null && v !== "")
+    .map(([k, v]) => `<div class="turn-error-row"><span>${esc(k)}</span><span>${esc(String(v))}</span></div>`)
+    .join("");
+  const body = err.body
+    ? `<pre class="turn-error-raw">${esc(prettyBody(err.body))}</pre>`
+    : `<div class="turn-error-empty">The endpoint sent no response body. This failure came from inside Orb — the server log has the traceback.</div>`;
+
+  showModal(`
+    <h2>Generation failed</h2>
+    <div class="tabs">
+      <div class="tab active" id="turn-error-tab-summary">Summary</div>
+      <div class="tab" id="turn-error-tab-raw">Provider response</div>
+    </div>
+    <div class="tab-content active" id="turn-error-pane-summary">
+      <div class="turn-error-headline">${esc(err.headline || "Generation failed.")}</div>
+      ${err.sentence ? `<div class="turn-error-sentence">${esc(err.sentence)}</div>` : ""}
+      <div class="turn-error-rows">${rows}</div>
+    </div>
+    <div class="tab-content" id="turn-error-pane-raw">${body}</div>
+    <div class="modal-actions">
+      <button class="btn btn-sm" id="turn-error-copy">Copy</button>
+      <button class="btn btn-sm" id="turn-error-close">Close</button>
+    </div>`);
+
+  const summary = $("turn-error-tab-summary");
+  const raw = $("turn-error-tab-raw");
+  summary.addEventListener("click", () => switchTab(summary, "turn-error-pane-summary"));
+  raw.addEventListener("click", () => switchTab(raw, "turn-error-pane-raw"));
+  $("turn-error-copy").addEventListener("click", (e) => {
+    copyToButton(e.currentTarget, copyReport(err));
+  });
+  $("turn-error-close").addEventListener("click", closeModal);
+}
+
+// Paint (or remove) the card inside *container*, the chat message list. Called at
+// the end of every renderMessages(), so it survives afterStream()'s repaint and
+// disappears the moment S.turnError is cleared.
+export function renderTurnError(container) {
+  container?.querySelector(`#${CARD_ID}`)?.remove();
+  const err = activeError();
+  if (!container || !err) return;
+
+  const card = document.createElement("div");
+  card.id = CARD_ID;
+  card.className = "turn-error";
+  // role="alert" fires an announcement every time the node enters the DOM, and
+  // renderMessages() rebuilds this card on every repaint — switching branches or
+  // opening the inspector re-read the same failure aloud. S.turnError is a fresh
+  // object per failure, so identity marks the one paint that is actually news.
+  if (err !== _announced) {
+    _announced = err;
+    card.setAttribute("role", "alert");
+  }
+
+  const head = document.createElement("div");
+  head.className = "turn-error-head";
+  const icon = document.createElement("span");
+  icon.className = "turn-error-icon";
+  icon.setAttribute("aria-hidden", "true");
+  icon.textContent = "⚠";
+  const headline = document.createElement("span");
+  headline.className = "turn-error-headline";
+  headline.textContent = err.headline || "Generation failed.";
+  head.append(icon, headline);
+  card.appendChild(head);
+
+  // textContent, never innerHTML: this string came from the provider.
+  if (err.sentence) {
+    const sentence = document.createElement("div");
+    sentence.className = "turn-error-sentence";
+    sentence.textContent = err.sentence;
+    card.appendChild(sentence);
+  }
+
+  const bits = meta(err);
+  if (bits.length) {
+    const line = document.createElement("div");
+    line.className = "turn-error-meta";
+    line.textContent = bits.join(" · ");
+    card.appendChild(line);
+  }
+
+  const actions = document.createElement("div");
+  actions.className = "turn-error-actions";
+  actions.append(
+    action("Details", "btn btn-xs", () => showDetails(err)),
+    action("Dismiss", "btn btn-xs", clearTurnError),
+  );
+  card.appendChild(actions);
+
+  container.appendChild(card);
+}
+
+function action(label, className, onClick) {
+  const b = document.createElement("button");
+  b.type = "button";
+  b.className = className;
+  b.textContent = label;
+  b.addEventListener("click", onClick);
+  return b;
+}

--- a/frontend/chat_stream.js
+++ b/frontend/chat_stream.js
@@ -18,6 +18,7 @@ import {
   setMessages,
   updateContextCounter,
 } from "./chat_core.js";
+import { renderTurnError } from "./chat_error.js";
 import {
   _advanceReasoningPass,
   _relightWorkflowPipelinePass,
@@ -48,6 +49,7 @@ import {
   esc,
   formatProse,
   formatProseWithDiff,
+  notifyError,
   pinStreamingMessage,
   resolvePlaceholders,
   scrollToBottom,
@@ -72,6 +74,21 @@ const PHASE_LABELS = {
   generating: "Generating response…",
   refining: "Refining response…",
 };
+
+// The compact form of the same phase, for a failure card's meta line: the
+// frontend already knows which pass was running when the error arrived, so
+// attributing the failure costs zero backend plumbing.
+// Fallback only. The pipeline now names the pass that raised (backend
+// `failures.mark_stage`), and this map cannot: nothing moves the phase off
+// "directing" until the writer's first token, so every writer *rejection* — which
+// by definition arrives before any token — lands here as "director pass". Used
+// when the payload has no stage: a FastAPI error before the generator started, or
+// a connection lost client-side.
+const PHASE_STAGES = { pending: "", directing: "director pass", generating: "writer pass", refining: "editor pass" };
+
+function phaseStage() {
+  return PHASE_STAGES[S.generationPhase] || "";
+}
 
 export function setGenerationPhase(phase) {
   if (!phase) {
@@ -332,6 +349,10 @@ export async function afterStream() {
     const ct = $("chat-messages");
     if (ct.querySelectorAll(".message[data-msg-id]").length < S.messages.length) {
       renderMessages();
+    } else {
+      // This fast path skips renderMessages, and with it the failure card's
+      // paint. Ask for it directly rather than repainting the whole list.
+      renderTurnError(ct);
     }
   } else {
     renderMessages();
@@ -419,6 +440,39 @@ function swapStreamingDraft(text, onRewrite) {
   const original = resolvePlaceholders(S.editorDraftBaseline);
   S.pendingRefineDiff = { original, ops: sentenceDiff(original, resolvePlaceholders(text)) };
   onRewrite(text);
+}
+
+// The human half of an error body that is *not* a describe_failure payload — a
+// FastAPI dependency 4xx/5xx answering before the SSE generator ever starts.
+// Same well-known keys the backend's provider_sentence walks, in the same order.
+function foreignSentence(o) {
+  const first = (v) => {
+    if (typeof v === "string") return v;
+    if (Array.isArray(v)) return v.map(first).filter(Boolean).join("; ");
+    if (v && typeof v === "object") return first(v.msg ?? v.message ?? v.detail);
+    return "";
+  };
+  return first(o.detail) || first(o.error?.message) || first(o.error) || first(o.message) || "";
+}
+
+// The `error`/`warning` data channel carries either a JSON object (the pipeline's
+// describe_failure payload) or a bare string from a legacy emitter. Only the
+// string branch is un-escaped: json.dumps already encoded the newlines *inside*
+// the JSON, so running unescapeSSE over it would corrupt the payload — the exact
+// trap sse.js documents for the document `probs` channel.
+function parseFailure(data) {
+  const raw = String(data ?? "");
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      if (typeof parsed.headline === "string" && parsed.headline) {
+        return { sentence: "", kind: "internal", ...parsed };
+      }
+      // A foreign body: keep all of it for Details, quote the readable part.
+      return { headline: "", sentence: foreignSentence(parsed), kind: "internal", body: raw };
+    }
+  } catch (_) {}
+  return { headline: unescapeSSE(raw), sentence: "", kind: "internal" };
 }
 
 function handleSSEEvent(event, data, _container, msgDiv, onToken, onRewrite) {
@@ -609,7 +663,28 @@ function handleSSEEvent(event, data, _container, msgDiv, onToken, onRewrite) {
       break;
     }
     case "error":
-      toast(`Error: ${data}`, true);
+      // Terminal. Into state, not a toast: a failed turn has to leave a trace
+      // the user can still read (and copy) a minute later. The card is painted
+      // by renderTurnError() from renderMessages(), which afterStream() runs.
+      {
+        const f = parseFailure(data);
+        S.turnError = {
+          ...f,
+          headline: f.headline || "Generation failed.",
+          convId: S.activeConvId,
+          // The backend knows which pass raised; the phase map only guesses.
+          stage: f.stage || phaseStage(),
+          at: Date.now(),
+        };
+      }
+      break;
+    case "warning":
+      // Non-terminal: a workflow hook failed but the turn continues, so this is
+      // a sticky toast rather than the card (which means "this turn failed").
+      {
+        const w = parseFailure(data);
+        notifyError(w.headline || "A workflow step failed.", { sentence: w.sentence });
+      }
       break;
     case "workflow_attachments_rejected": {
       // Stash for the post-stream renderMessages paint. Do NOT call
@@ -672,6 +747,7 @@ export async function runStreamRequest(
   setStreaming(true);
   setGenerationPhase("pending");
   $("send-btn").disabled = true;
+  S.turnError = null; // this attempt supersedes the last failure
 
   if (cutoffMsgId != null) {
     const idx = S.messages.findIndex((m) => m.id === cutoffMsgId);
@@ -690,7 +766,23 @@ export async function runStreamRequest(
   S.abortController = new AbortController();
   try {
     const resp = await streamPost(path, body, S.abortController.signal);
-    await processSSEStream(resp, ct, msgDiv, S.abortController.signal);
+    // A 500 raised before the generator starts returns a JSON body with no
+    // blank line in it, so sseEvents yields zero frames and the loop exits
+    // clean — the one path that used to fail with no signal whatsoever.
+    if (!resp.ok) {
+      const raw = await resp.text().catch(() => "");
+      const f = parseFailure(raw);
+      S.turnError = {
+        ...f,
+        status: resp.status,
+        convId: S.activeConvId,
+        stage: f.stage || phaseStage(),
+        at: Date.now(),
+      };
+      if (!S.turnError.headline) S.turnError.headline = `Orb returned HTTP ${resp.status}.`;
+    } else {
+      await processSSEStream(resp, ct, msgDiv, S.abortController.signal);
+    }
   } catch (e) {
     if (e.name === "AbortError") {
       S.wasAborted = true;
@@ -699,7 +791,14 @@ export async function runStreamRequest(
       // an unread connection. Abort it (fetch + POST /stop) so it doesn't run
       // headless; its fallback persistence keeps whatever streamed so far.
       console.error("Stream failed client-side:", e);
-      toast(`Error: ${e.message}`, true);
+      S.turnError = {
+        headline: "Lost connection to Orb.",
+        sentence: e.message,
+        kind: "transport",
+        convId: S.activeConvId,
+        stage: phaseStage(),
+        at: Date.now(),
+      };
       stopGeneration();
     }
   }

--- a/frontend/css/forms.css
+++ b/frontend/css/forms.css
@@ -180,37 +180,7 @@ label {
 
 
 
-/* ═══════════════════════════════════════════
-   9. Toast Notifications
-   ═══════════════════════════════════════════ */
-.toast {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
-  padding: 10px 16px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  font-size: 13px;
-  color: var(--text-primary);
-  z-index: 200;
-  animation: toastIn .2s ease, toastOut .3s ease 2.7s forwards;
-}
-
-.toast.error {
-  border-color: var(--red);
-  color: var(--red);
-}
-
-@keyframes toastIn {
-  from { opacity: 0; transform: translateY(10px); }
-  to   { opacity: 1; }
-}
-
-@keyframes toastOut {
-  from { opacity: 1; }
-  to   { opacity: 0; }
-}
+/* Toasts moved to css/notifications.css (loaded immediately after this file). */
 
 /* ═══════════════════════════════════════════
    9.5 Tab Lock Banner

--- a/frontend/css/notifications.css
+++ b/frontend/css/notifications.css
@@ -1,0 +1,216 @@
+/* ═══════════════════════════════════════════
+   Notifications: the toast stack + the failed-turn card
+
+   Split out of forms.css §9 when the `#toast` singleton became a stack. Loaded
+   immediately after forms.css so the cascade order is unchanged for the plain
+   `.toast` rules that moved here verbatim.
+   ═══════════════════════════════════════════ */
+
+.toast-stack {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  max-width: min(420px, calc(100vw - 40px));
+  pointer-events: none; /* the gaps between entries must not eat clicks */
+}
+
+.toast-stack > * { pointer-events: auto; }
+
+.toast {
+  padding: 10px 16px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 13px;
+  color: var(--text-primary);
+  animation: toastIn .2s ease;
+}
+
+/* Only a transient entry self-fades. An error is sticky: it stays until the user
+   dismisses it, so it must never inherit the toastOut delay. Keep 2.7s+0.3s in
+   sync with TRANSIENT_MS in notify.js. */
+.toast-transient {
+  animation: toastIn .2s ease, toastOut .3s ease 2.7s forwards;
+}
+
+.toast-leaving {
+  animation: toastOut .2s ease forwards;
+}
+
+/* `!important` is not decoration here: five themes (litestep, litestep_dark,
+   dark_forest, ocean_depths, frutiger_aero) set `.toast { border/color: … !important }`,
+   which a plain `.toast.error` cannot beat. Higher specificity plus !important
+   wins in all thirteen. `--red` is defined in every theme; `--danger` is defined
+   in none, so it is never used here. */
+.toast.error {
+  border-color: var(--red) !important;
+  border-left: 3px solid var(--red) !important;
+  color: var(--text-primary) !important;
+  max-width: 100%;
+}
+
+.toast-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.toast-icon { color: var(--red); flex-shrink: 0; }
+
+.toast-headline {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.toast-close {
+  flex-shrink: 0;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  font-size: 15px;
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+}
+
+.toast-close:hover { color: var(--text-primary); }
+
+.toast-sentence {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  word-break: break-word;
+  /* Two lines, then ellipsis — Details has the rest. Precedent: css/sidebar.css. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.toast-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.toast-link {
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.toast-link:hover { color: var(--accent); }
+
+@keyframes toastIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; }
+}
+
+@keyframes toastOut {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+/* ═══════════════════════════════════════════
+   The failed-turn card
+
+   Follows the inline-error idiom (css/workflows.css) and the tint precedent in
+   css/chat.css. Sized to match .message so it reads as part of the flow rather
+   than as chrome bolted on beneath it.
+   ═══════════════════════════════════════════ */
+.turn-error {
+  /* `width` must be explicit. #chat-messages is a flex column, and a flex item
+     with auto cross-axis margins is *not* stretched — it falls back to
+     fit-content, which rendered this as a small centered lozenge under a
+     full-width message: exactly the bolted-on look the sizing is meant to avoid.
+     Matches .message's 95% so the card sits in the column, not beside it. */
+  width: 100%;
+  max-width: 95%;
+  margin: 12px auto;
+  padding: 12px 14px;
+  border: 1px solid var(--red);
+  border-left-width: 3px;
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--red) 8%, transparent);
+}
+
+.turn-error-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.turn-error-icon { color: var(--red); flex-shrink: 0; }
+
+.turn-error-headline {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.turn-error-sentence {
+  margin-top: 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+.turn-error-meta {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.turn-error-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+/* Details modal */
+.turn-error-rows {
+  margin-top: 12px;
+  font-size: 12px;
+}
+
+.turn-error-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.turn-error-row > span:first-child { color: var(--text-muted); }
+.turn-error-row > span:last-child { color: var(--text-primary); font-family: var(--font-mono); word-break: break-all; }
+
+.turn-error-raw {
+  max-height: 50vh;
+  overflow: auto;
+  padding: 10px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  user-select: text;
+}
+
+.turn-error-empty {
+  font-size: 12px;
+  color: var(--text-muted);
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -245,7 +245,7 @@ Write a haiku about the sea.&lt;|im_end|&gt;
 <div id="modal-root"></div>
 <div id="modal-sub-root"></div>
 <div id="modal-crop-root"></div>
-<div id="toast" class="toast hidden"></div>
+<div id="toast-stack" class="toast-stack"></div>
 <script type="module" src="/static/app.js"></script>
 </body>
 </html>

--- a/frontend/mobile.css
+++ b/frontend/mobile.css
@@ -190,6 +190,21 @@ body {
     width: 100%;
     z-index: 120;
   }
+
+  /* A two-line provider sentence in a 420px-wide lozenge runs off a phone
+     screen. Pin both edges and let the stack be as wide as the viewport allows. */
+  .toast-stack {
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+    max-width: none;
+    align-items: stretch;
+  }
+
+  /* No .turn-error override: the card is width:100%/max-width:95% like .message,
+     which has no mobile override either, so it already tracks the column here.
+     The old `margin: 12px 8px` existed to widen a card that was shrinking to
+     fit-content — a symptom that is fixed at the source in notifications.css. */
 }
 
 /* ── Tablet modal/layout tightening ── */

--- a/frontend/notify.js
+++ b/frontend/notify.js
@@ -1,0 +1,193 @@
+// Notifications: the toast stack and the sticky error entry.
+//
+// Replaces the `#toast` singleton, which was one <div> and one shared timer for
+// 192 call sites: a second toast overwrote the first's text *and* inherited its
+// already-running timeout, so the second message could flash for 200ms. Each
+// entry here owns its own element and its own timer.
+//
+// The other half of the fix is that an error is no longer transient. A failure
+// the user is expected to act on cannot expire after three seconds, and it has to
+// be selectable so it can be pasted into a bug report — so error entries are
+// sticky, carry a `×`, and offer Copy.
+//
+// Imports nothing on purpose. utils.js re-exports `toast` from here so no call
+// site moves, and a leaf module cannot participate in that cycle.
+
+const MAX_VISIBLE = 4; // beyond this the oldest is evicted; a wall of toasts is no more legible than one
+const TRANSIENT_MS = 3000; // must stay in sync with notifications.css's toastOut delay
+const FADE_MS = 200;
+const COPIED_MS = 1200; // matches the code-block copy button in utils.js
+
+// Copy *text*, reporting whether it actually happened.
+//
+// `navigator.clipboard` is undefined outside a secure context, which for a
+// self-hosted app is the *normal* case the moment it is opened from another
+// device on the LAN over plain http. The old `navigator.clipboard?.writeText(…)`
+// silently evaluated to undefined there while the button still said "Copied" --
+// worst of both, since the whole point of this text is to be pasted into a bug
+// report. execCommand is deprecated but it is what works without TLS.
+export async function copyText(text) {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch (_) {
+    // Permission denied, or a document that isn't focused. Fall through.
+  }
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    // Off-screen rather than hidden: execCommand ignores an unrendered element.
+    ta.setAttribute("readonly", "");
+    ta.style.cssText = "position:fixed;top:-9999px;opacity:0";
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand("copy");
+    ta.remove();
+    return ok;
+  } catch (_) {
+    return false;
+  }
+}
+
+// Copy, then tell the truth on the button itself and put it back.
+//
+// `explain` adds a toast naming the cause, for callers that have somewhere to
+// send the user (the failed-turn card has a Details pane with selectable text).
+// Off by default so an error toast's own Copy button cannot spawn another toast.
+export async function copyToButton(btn, text, { explain = false } = {}) {
+  const ok = await copyText(text);
+  const original = btn.dataset.copyLabel || btn.textContent;
+  btn.dataset.copyLabel = original;
+  btn.textContent = ok ? "Copied" : "Copy failed";
+  if (!ok && explain) {
+    notifyError("Couldn't reach the clipboard.", {
+      sentence: "Copying needs HTTPS or localhost. Open Details and select the text instead.",
+    });
+  }
+  setTimeout(() => {
+    btn.textContent = btn.dataset.copyLabel || original;
+  }, COPIED_MS);
+  return ok;
+}
+
+function stack() {
+  let el = document.getElementById("toast-stack");
+  if (!el) {
+    // index.html ships the container, but a test harness or a partial page may not.
+    el = document.createElement("div");
+    el.id = "toast-stack";
+    el.className = "toast-stack";
+    document.body.appendChild(el);
+  }
+  return el;
+}
+
+function clearTimer(el) {
+  if (el._toastTimer) {
+    clearTimeout(el._toastTimer);
+    el._toastTimer = null;
+  }
+}
+
+function dismiss(el) {
+  if (!el?.isConnected) return;
+  clearTimer(el);
+  el.classList.add("toast-leaving");
+  setTimeout(() => el.remove(), FADE_MS);
+}
+
+function mount(el) {
+  const ct = stack();
+  ct.appendChild(el);
+  // Evict without the fade: an entry being pushed out has already lost its slot,
+  // and animating it would leave more than MAX_VISIBLE on screen while it faded.
+  while (ct.children.length > MAX_VISIBLE && ct.firstElementChild) {
+    clearTimer(ct.firstElementChild);
+    ct.firstElementChild.remove();
+  }
+  return el;
+}
+
+function button(label, className, onClick, { title = "" } = {}) {
+  const b = document.createElement("button");
+  b.type = "button";
+  b.className = className;
+  b.textContent = label;
+  if (title) b.title = title;
+  b.addEventListener("click", onClick);
+  return b;
+}
+
+// The original signature, frozen by the plugin ABI. `isError` now means "sticky
+// and red" rather than "red" (which it never actually was — the class written here
+// was `toast-error` while the CSS styled `.toast.error`, so error toasts rendered
+// identically to success toasts in every theme).
+export function toast(msg, isError = false) {
+  const text = msg == null ? "" : String(msg);
+  if (isError) return notifyError(text);
+
+  const el = document.createElement("div");
+  el.className = "toast toast-transient";
+  el.setAttribute("role", "status");
+  el.setAttribute("aria-live", "polite");
+  el.textContent = text;
+  mount(el);
+  el._toastTimer = setTimeout(() => dismiss(el), TRANSIENT_MS);
+  return el;
+}
+
+// A failure worth reading: a headline Orb can assert, the provider's own sentence
+// under it, and optional Details. Sticky — it goes away when the user says so.
+//
+// Every string is written with textContent. A provider message is untrusted input
+// and must never reach innerHTML.
+export function notifyError(headline, { sentence = "", onDetails = null } = {}) {
+  const head = String(headline ?? "");
+  const detail = String(sentence ?? "");
+
+  const el = document.createElement("div");
+  el.className = "toast error";
+  el.setAttribute("role", "alert");
+  el.setAttribute("aria-live", "assertive");
+
+  const top = document.createElement("div");
+  top.className = "toast-head";
+
+  const icon = document.createElement("span");
+  icon.className = "toast-icon";
+  icon.setAttribute("aria-hidden", "true");
+  icon.textContent = "⚠";
+
+  const title = document.createElement("span");
+  title.className = "toast-headline";
+  title.textContent = head;
+
+  const close = button("×", "toast-close", () => dismiss(el), { title: "Dismiss" });
+  close.setAttribute("aria-label", "Dismiss");
+
+  top.append(icon, title, close);
+  el.appendChild(top);
+
+  if (detail) {
+    const line = document.createElement("div");
+    line.className = "toast-sentence";
+    line.textContent = detail;
+    el.appendChild(line);
+  }
+
+  const actions = document.createElement("div");
+  actions.className = "toast-actions";
+  if (typeof onDetails === "function") {
+    actions.appendChild(button("Details", "toast-link", () => onDetails()));
+  }
+  actions.appendChild(
+    button("Copy", "toast-link", (e) => {
+      copyToButton(e.currentTarget, detail ? `${head}\n${detail}` : head);
+    }),
+  );
+  el.appendChild(actions);
+
+  return mount(el);
+}

--- a/frontend/sse.js
+++ b/frontend/sse.js
@@ -98,9 +98,12 @@ export function unescapeSSE(data) {
 // The streaming sibling of `api._req`: fires a POST and returns the raw Response
 // so the caller can read `resp.body` through `sseEvents`. Bypasses the `api`
 // helper deliberately — `api._req` would consume the body with `.json()`.
-// Non-ok handling is left to the caller: chat streams always return 200 (errors
-// arrive in-band as an `error` event), while document/summarize check
-// `resp.ok` and read the short error body themselves.
+// Non-ok handling is left to the caller, and every caller now does it: chat
+// streams normally return 200 with errors in-band as an `error` event, but a
+// failure raised *before* the generator starts (a dependency 500) answers with a
+// plain JSON body containing no frame separator — zero SSE events, a clean loop
+// exit, and no signal at all unless `resp.ok` is checked. `runStreamRequest`,
+// document and summarize all check it and read the short error body themselves.
 export function streamPost(path, body, signal) {
   return fetch(`/api${path}`, {
     method: "POST",

--- a/frontend/state.js
+++ b/frontend/state.js
@@ -94,6 +94,12 @@ export const S = {
   contextSize: null,
   pendingRefineDiff: null, // {original, ops} set on writer_rewrite, cleared on next stream
   editorDraftBaseline: null, // writer's pre-editor text; diff anchor across draft_update/writer_rewrite, reset on next stream
+  // The last generation failure, or null. Painted as a persistent card at the tail
+  // of the chat by chat_error.js instead of a toast that fades in three seconds.
+  // `convId` is load-bearing: the card renders only when it matches S.activeConvId,
+  // so switching conversations can't leave a stale failure hanging under someone
+  // else's chat. Cleared on the next stream start and on dismiss.
+  turnError: null, // {convId, at, headline, sentence, status, host, model, body, kind, stage}
 
   // ── Reasoning rail & Inspector · owner: chat_inspector.js
   directorState: null,

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -18,6 +18,7 @@
 @import "css/status-bar.css"; /* generation status bar */
 @import "css/modals.css"; /* modal shell, tabs, character + persona + phrase-bank modals */
 @import "css/forms.css"; /* buttons, form fields, toggles, toast, tab-lock banner */
+@import "css/notifications.css"; /* toast stack + failed-turn card (after forms.css: .toast.error must out-specify the theme !important blocks) */
 @import "css/character-browser.css"; /* character library browser modal (grid/list) */
 @import "css/combobox.css"; /* settings hybrid-input combobox */
 @import "css/lorebooks.css"; /* worlds sidebar + lorebook drawer/editor */

--- a/frontend/utils.js
+++ b/frontend/utils.js
@@ -40,14 +40,10 @@ export function boolFlag(value) {
   return value === true || value === 1;
 }
 
-export function toast(msg, isError = false) {
-  const el = $("toast");
-  if (!el) return;
-  el.textContent = msg;
-  el.className = `toast${isError ? " toast-error" : ""}`;
-  el.classList.remove("hidden");
-  setTimeout(() => el.classList.add("hidden"), 3000);
-}
+// The toast stack lives in notify.js; re-exported here so the 192 existing
+// `import { toast } from "./utils.js"` call sites (and the frozen plugin ABI)
+// keep working unchanged.
+export { notifyError, toast } from "./notify.js";
 
 // The chat area's follow controller. Constructed once by chat_messages.js's
 // initAutoscroll() (the element doesn't exist yet at module-eval time); this is

--- a/frontend/workflow_api.js
+++ b/frontend/workflow_api.js
@@ -41,7 +41,7 @@ import { closeModal, setModalCloseGuard, showModal } from "./modal.js";
 import { sseEvents, streamPost } from "./sse.js";
 import { effectiveWorkflowEnabled, S, subscribe } from "./state.js";
 import { broadcastWorkflowMutation } from "./tabLock.js";
-import { convUrl, esc, escAttr, toast } from "./utils.js";
+import { convUrl, esc, escAttr, notifyError, toast } from "./utils.js";
 import {
   registerClickHandler,
   registerTextEffect,
@@ -74,6 +74,7 @@ export {
   esc,
   escAttr,
   messageSegments,
+  notifyError,
   onChannel,
   pauseChannel,
   playAudio,

--- a/scripts/check_frontend_layers.py
+++ b/scripts/check_frontend_layers.py
@@ -43,6 +43,7 @@ LAYERS = {
     "state.js": 1,
     "workflow_registry.js": 1,
     "utils.js": 1,
+    "notify.js": 1,
     # L2 services.
     "tabLock.js": 2,
     "audio_schedule.js": 2,
@@ -65,6 +66,7 @@ LAYERS = {
     # the audit's target, enforced loosely here via the layer rule only).
     "chat.js": 5,
     "chat_core.js": 5,
+    "chat_error.js": 5,
     "chat_stream.js": 5,
     "chat_messages.js": 5,
     "chat_inspector.js": 5,
@@ -125,6 +127,7 @@ FROZEN_ABI = {
     "esc",
     "escAttr",
     "toast",
+    "notifyError",
     "showModal",
     "closeModal",
     "setModalCloseGuard",


### PR DESCRIPTION
Show a clear and persisting message in the chat area in case of upstream errors. Applies too all workflows and core pipeline.